### PR TITLE
feat: add fuelclock-nz skill

### DIFF
--- a/skills/fuelclock-nz/SKILL.md
+++ b/skills/fuelclock-nz/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: fuelclock-nz
+description: Fetch New Zealand fuel supply and price data from fuelclock.nz. Use when the task involves NZ pump prices, fuel supply security, days of supply remaining, MSO (Minimum Stock Obligation) status, incoming tanker vessels, geopolitical risk to NZ fuel supply, or NZ fuel news. No authentication required.
+---
+
+# FuelClock NZ
+
+## Goal
+
+Query live NZ fuel supply security data and retail pump prices from fuelclock.nz, which aggregates Gaspy, MBIE, nzoilwatch, and Polymarket into a single public API.
+
+## Use this when
+
+- A user asks about current NZ petrol, diesel, or 95/98 premium prices
+- A user wants to know if NZ has enough fuel (days of supply, MSO status)
+- A user asks about the NZ fuel supply risk level
+- A user wants to know what fuel tankers are en route to New Zealand
+- A user asks about geopolitical risks to NZ's fuel supply (Hormuz Strait, etc.)
+- A user wants a fuel news digest or summary of the current NZ fuel situation
+
+## Do not use this for
+
+- Fuel prices outside New Zealand
+- Electricity, gas, or LPG pricing
+- Vehicle fuel efficiency or consumption calculations
+- Predicting future fuel prices (this skill returns current observed data only)
+
+## Data freshness
+
+| Endpoint | Source | Update frequency |
+|----------|--------|-----------------|
+| Prices | Gaspy | Every 15 minutes |
+| Supply / MSO | MBIE + FuelClock | Near real-time |
+| MBIE stocks | MBIE (government) | Weekly |
+| Vessels | nzoilwatch | Every 4 minutes |
+| Geopolitical risk | Polymarket | Market-driven |
+| News | AI digest | Every 60 minutes |
+
+## Workflow
+
+1. Import `skill.py` or run it directly
+2. Call the relevant function for the task
+3. Format the returned data into a clear response
+4. For a general overview, call `get_summary()` — it combines prices and supply status into a ready-to-read plain-text block
+
+## Functions
+
+### `get_summary() -> str`
+
+Calls `get_fuel_prices()` and `get_supply_status()` and returns a concise plain-text summary. Best default choice for general fuel situation questions.
+
+```python
+from skill import get_summary
+print(get_summary())
+```
+
+Example output:
+
+```
+NZ Fuel Summary (2026-04-10T04:22:56Z)
+
+Retail pump prices (NZD/litre, national average):
+  91 Unleaded: $3.491/L ->  (7d: +0.000, 28d: +53.710)
+  Diesel: $2.104/L v  (7d: -0.010, 28d: +12.300)
+  95 Premium: $3.811/L ->  (7d: +0.000, 28d: +47.200)
+  98 Premium: $4.021/L ->  (7d: +0.000, 28d: +41.100)
+
+Supply security: overall risk = ELEVATED
+  Most constrained fuel depletes in 452.6 hours (18.9 days)
+
+Days of supply remaining:
+  Petrol: 24.7 days (MSO threshold: 28 days) [BELOW MSO]
+    Risk: elevated, depletion in 23.6 days
+  Diesel: 31.2 days (MSO threshold: 25 days)
+    Risk: normal, depletion in 30.1 days
+  Jet: 18.4 days (MSO threshold: 14 days)
+    Risk: normal, depletion in 17.8 days
+```
+
+---
+
+### `get_fuel_prices() -> dict`
+
+Current national average retail pump prices (NZD/litre). Includes 7-day and 28-day change, direction, min/max across stations, and station count.
+
+Fuel types: `91 Unleaded`, `Diesel`, `95 Premium`, `98 Premium`
+
+```python
+from skill import get_fuel_prices
+data = get_fuel_prices()
+for p in data["prices"]:
+    print(f"{p['type']}: ${p['price']:.3f}/L")
+```
+
+---
+
+### `get_supply_status() -> dict`
+
+Days of supply remaining per fuel type, MSO threshold, whether the fuel is currently below MSO, and the overall risk level. Includes a `countdownHours` field for the most constrained fuel type.
+
+Risk levels: `normal`, `elevated`, `critical`
+
+```python
+from skill import get_supply_status
+data = get_supply_status()
+print(f"Overall risk: {data['overallRisk']}")
+for fs in data["fuelStates"]:
+    print(f"{fs['fuelType']}: {fs['currentDays']:.1f} days, belowMSO={fs['belowMSO']}")
+```
+
+---
+
+### `get_mbie_stocks() -> dict`
+
+Official MBIE government petroleum stock figures (not FuelClock-adjusted). Reports in-country days, on-water days, and total days for petrol, diesel, and jet. Updated weekly.
+
+```python
+from skill import get_mbie_stocks
+data = get_mbie_stocks()
+print(f"As at: {data['asAtDate']}")
+print(f"Petrol in-country: {data['inCountryDays']['petrol']} days")
+print(f"Petrol total (incl. on water): {data['totalDays']['petrol']} days")
+```
+
+---
+
+### `get_vessels() -> dict`
+
+Incoming fuel tanker data: vessel name, fuel type, cargo size in millilitres and days of supply equivalent, origin country, ETA, arrival status, and geopolitical risk flag with reason.
+
+```python
+from skill import get_vessels
+data = get_vessels()
+for v in data["vessels"]:
+    eta = v["eta"][:10] if v["eta"] else "unknown"
+    risk = " [FLAGGED]" if v["flagRisk"] else ""
+    print(f"{v['name']} ({v['fuelType']}): {v['cargoDays']:.1f} days, ETA {eta}{risk}")
+```
+
+---
+
+### `get_geopolitical_risk() -> dict`
+
+Polymarket prediction market probabilities for events that affect NZ fuel supply (e.g. Hormuz Strait disruptions). Probabilities are `0.0`-`1.0`. Volume is in USD.
+
+```python
+from skill import get_geopolitical_risk
+data = get_geopolitical_risk()
+for m in data["markets"]:
+    print(f"{m['title']}: {m['probability']*100:.1f}%  (vol ${m['volume']:,.0f})")
+```
+
+---
+
+### `get_news() -> dict`
+
+AI-summarised digest of recent NZ fuel news. Returns a paragraph summary, key topics, recent developments, and notable quotes. Cached for 60 minutes.
+
+```python
+from skill import get_news
+data = get_news()
+print(data["summary"])
+print("Key topics:", ", ".join(data["key_topics"]))
+```
+
+## Running directly
+
+Run the skill as a quick check:
+
+```bash
+python skill.py
+```
+
+This calls `get_summary()` and prints the result to stdout. Useful for verifying the API is reachable and returning current data.
+
+## Notes
+
+- No API key or authentication required
+- All requests use a 10-second timeout
+- `isFallback: true` in price data means the API returned cached data because the live source was unavailable
+- `flagRisk: true` on a vessel means the origin country has an active geopolitical risk flag -- see `flagReason` for detail
+- MBIE stock figures and FuelClock supply figures differ: MBIE is official government data, FuelClock applies its own adjustments to account for consumption rates and pipeline timing

--- a/skills/fuelclock-nz/requirements.txt
+++ b/skills/fuelclock-nz/requirements.txt
@@ -1,0 +1,3 @@
+# Optional: skill.py uses only stdlib (urllib.request) and has no required dependencies.
+# Install requests if you prefer using it instead of urllib in your own integrations.
+requests>=2.28.0

--- a/skills/fuelclock-nz/skill.py
+++ b/skills/fuelclock-nz/skill.py
@@ -1,0 +1,234 @@
+"""
+fuelclock-nz skill
+
+Fetches New Zealand fuel supply and price data from fuelclock.nz's public API.
+No authentication required. All endpoints return JSON.
+
+Data sources behind the API:
+  - Prices: Gaspy (updated every 15 minutes)
+  - Supply/MSO: MBIE + FuelClock adjustments (near real-time)
+  - MBIE stocks: Official government figures (weekly)
+  - Vessels: nzoilwatch (updated every 4 minutes)
+  - Geopolitical risk: Polymarket prediction markets
+  - News: AI-summarised digest (cached 60 minutes)
+"""
+
+import json
+import urllib.request
+from typing import Any
+
+BASE_URL = "https://fuelclock.nz"
+DEFAULT_TIMEOUT = 10
+
+
+def _get(path: str) -> Any:
+    """Make a GET request to the fuelclock.nz API and return parsed JSON."""
+    url = f"{BASE_URL}{path}"
+    req = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(req, timeout=DEFAULT_TIMEOUT) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def get_fuel_prices() -> dict:
+    """
+    Return current national average retail pump prices (NZD/litre) for NZ.
+
+    Data sourced from Gaspy, updated every 15 minutes.
+
+    Returns a dict with:
+      prices: list of price objects, one per fuel type (91 Unleaded, Diesel,
+              95 Premium, 98 Premium). Each has:
+                type, price, change7d, change28d, direction7d, direction28d,
+                changePercent28d, min, max, stationCount
+      source: "Gaspy"
+      fetchedAt: ISO 8601 timestamp
+      isFallback: bool — True if live data was unavailable and cached data returned
+
+    Example:
+      >>> data = get_fuel_prices()
+      >>> for p in data["prices"]:
+      ...     print(f"{p['type']}: ${p['price']:.3f}/L")
+    """
+    return _get("/api/fuel-prices")
+
+
+def get_supply_status() -> dict:
+    """
+    Return NZ fuel supply security status: days of supply remaining, MSO status,
+    and overall risk level for petrol, diesel, and jet fuel.
+
+    MSO (Minimum Stock Obligation) is the government-mandated minimum reserve.
+    belowMSO=True means the fuel type is below its legal minimum threshold.
+
+    Returns a dict with:
+      timestamp: ISO 8601 timestamp
+      fuelStates: list of objects, one per fuel type. Each has:
+                    fuelType, currentDays, msoThreshold, belowMSO,
+                    calendarDaysToDepletion, overallRisk
+      overallRisk: "normal" | "elevated" | "critical" — worst-case across all types
+      countdownHours: float — hours until the most constrained fuel hits zero
+
+    Example:
+      >>> data = get_supply_status()
+      >>> print(f"Overall risk: {data['overallRisk']}")
+      >>> for fs in data["fuelStates"]:
+      ...     print(f"{fs['fuelType']}: {fs['currentDays']:.1f} days, belowMSO={fs['belowMSO']}")
+    """
+    return _get("/api/fuel-data")
+
+
+def get_mbie_stocks() -> dict:
+    """
+    Return official New Zealand government MBIE petroleum stock figures.
+
+    These are the raw MBIE numbers, not FuelClock-adjusted. Updated weekly.
+    Figures are in days of supply (at average consumption rates).
+
+    Returns a dict with:
+      asAtDate: human-readable date string for the data snapshot
+      inCountryDays: {petrol, diesel, jet} — stock physically in NZ
+      onWaterDays: {petrol, diesel, jet} — stock on vessels en route
+      totalDays: {petrol, diesel, jet} — in-country + on-water combined
+      nextUpdate: human-readable string for the next expected update time
+
+    Example:
+      >>> data = get_mbie_stocks()
+      >>> print(f"As at: {data['asAtDate']}")
+      >>> print(f"Petrol total: {data['totalDays']['petrol']} days")
+    """
+    return _get("/api/mbie-stocks")
+
+
+def get_vessels() -> dict:
+    """
+    Return incoming fuel tanker data for New Zealand, updated every 4 minutes.
+
+    Includes vessels that are scheduled, en route, or recently arrived.
+    flagRisk=True means the vessel's origin country has a geopolitical risk flag.
+
+    Returns a dict with:
+      vessels: list of vessel objects. Each has:
+                 name, fuelType, cargoML (cargo in millilitres), cargoDays
+                 (days of supply this cargo represents), origin, status,
+                 eta (ISO 8601), arrived (bool), flagRisk (bool), flagReason
+
+    Example:
+      >>> data = get_vessels()
+      >>> for v in data["vessels"]:
+      ...     eta = v["eta"][:10] if v["eta"] else "unknown"
+      ...     print(f"{v['name']} ({v['fuelType']}): {v['cargoDays']:.1f} days, ETA {eta}")
+    """
+    return _get("/api/vessels")
+
+
+def get_geopolitical_risk() -> dict:
+    """
+    Return Polymarket prediction market probabilities for geopolitical events
+    that could affect New Zealand's fuel supply chain.
+
+    Probabilities are between 0 and 1 (e.g. 0.245 = 24.5% chance).
+    Volume is in USD.
+
+    Returns a dict with:
+      markets: list of market objects. Each has:
+                 title, probability (float 0–1), volume (float, USD)
+
+    Example:
+      >>> data = get_geopolitical_risk()
+      >>> for m in data["markets"]:
+      ...     print(f"{m['title']}: {m['probability']*100:.1f}%")
+    """
+    return _get("/api/polymarket")
+
+
+def get_news() -> dict:
+    """
+    Return an AI-summarised digest of recent NZ fuel news. Cached for 60 minutes.
+
+    Returns a dict with:
+      summary: str — paragraph summary of current fuel situation
+      key_topics: list of str — main themes in current coverage
+      recent_developments: list of str — specific recent events
+      notable_quotes: list of str — notable quotes from sources
+
+    Example:
+      >>> data = get_news()
+      >>> print(data["summary"])
+    """
+    return _get("/api/news")
+
+
+def get_summary() -> str:
+    """
+    Return a concise plain-text summary of NZ fuel prices and supply status.
+
+    Calls get_fuel_prices() and get_supply_status() and formats the results
+    into a short human-readable block suitable for an agent to read and relay.
+
+    Returns a plain-text string. Returns an error message string if either
+    API call fails.
+
+    Example:
+      >>> print(get_summary())
+      NZ Fuel Summary (2026-04-10T04:22:56Z)
+      ...
+    """
+    try:
+        prices_data = get_fuel_prices()
+    except Exception as exc:
+        return f"Error fetching fuel prices: {exc}"
+
+    try:
+        supply_data = get_supply_status()
+    except Exception as exc:
+        return f"Error fetching supply status: {exc}"
+
+    lines = []
+
+    fetched_at = prices_data.get("fetchedAt", "unknown")
+    lines.append(f"NZ Fuel Summary ({fetched_at})")
+    lines.append("")
+
+    lines.append("Retail pump prices (NZD/litre, national average):")
+    for p in prices_data.get("prices", []):
+        direction = p.get("direction7d", "")
+        arrow = {"up": "↑", "down": "↓", "flat": "→"}.get(direction, "")
+        lines.append(
+            f"  {p['type']}: ${p['price']:.3f}/L {arrow}  "
+            f"(7d: {p.get('change7d', 0):+.3f}, "
+            f"28d: {p.get('change28d', 0):+.3f})"
+        )
+
+    lines.append("")
+    overall_risk = supply_data.get("overallRisk", "unknown")
+    countdown_hours = supply_data.get("countdownHours")
+    lines.append(f"Supply security: overall risk = {overall_risk.upper()}")
+    if countdown_hours is not None:
+        lines.append(
+            f"  Most constrained fuel depletes in {countdown_hours:.1f} hours "
+            f"({countdown_hours / 24:.1f} days)"
+        )
+
+    lines.append("")
+    lines.append("Days of supply remaining:")
+    for fs in supply_data.get("fuelStates", []):
+        mso_flag = " [BELOW MSO]" if fs.get("belowMSO") else ""
+        lines.append(
+            f"  {fs['fuelType'].capitalize()}: {fs['currentDays']:.1f} days "
+            f"(MSO threshold: {fs['msoThreshold']} days){mso_flag}"
+        )
+        lines.append(
+            f"    Risk: {fs.get('overallRisk', 'unknown')}, "
+            f"depletion in {fs.get('calendarDaysToDepletion', '?'):.1f} days"
+        )
+
+    is_fallback = prices_data.get("isFallback", False)
+    if is_fallback:
+        lines.append("")
+        lines.append("Note: price data is from cache (live data unavailable).")
+
+    return "\n".join(lines)
+
+
+if __name__ == "__main__":
+    print(get_summary())


### PR DESCRIPTION
## Summary

- Adds `skills/fuelclock-nz/` — the first skill in this repo
- Wraps all 6 public endpoints on fuelclock.nz (no auth required): fuel prices, supply status, MBIE stocks, incoming vessels, geopolitical risk, and news
- `skill.py` uses stdlib only (`urllib.request`), so there are zero required dependencies
- `get_summary()` combines prices + supply status into a plain-text block ready for an agent to relay
- `requirements.txt` lists `requests>=2.28.0` as an optional convenience dependency
- Passes `npm run validate-skill -- skills/fuelclock-nz` cleanly
- Tested against the live API (`python skill.py` runs without error)

## Data sources

| Function | Source | Freshness |
|----------|--------|-----------|
| `get_fuel_prices` | Gaspy via fuelclock.nz | Every 15 min |
| `get_supply_status` | MBIE + FuelClock | Near real-time |
| `get_mbie_stocks` | MBIE (government) | Weekly |
| `get_vessels` | nzoilwatch | Every 4 min |
| `get_geopolitical_risk` | Polymarket | Market-driven |
| `get_news` | AI digest | Every 60 min |

## Test plan

- [ ] Run `npm run validate-skill -- skills/fuelclock-nz` — should pass
- [ ] Run `python skills/fuelclock-nz/skill.py` — should print a live NZ fuel summary
- [ ] Confirm all 6 functions return dicts with the expected top-level keys

Generated with [Claude Code](https://claude.com/claude-code)