### PR TITLE
Improve nz-news search UX and split fuel watch skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Community-contributed AI skills for useful New Zealand-specific data and workflows.
 
-Point your agent at real NZ infrastructure, public datasets, market data, industry feeds, transport APIs, pricing sources, and other useful local information.
+Point your agent at real NZ infrastructure, public datasets, market data, industry feeds, transport APIs, pricing sources, weather services, and other useful local information.
 
 ## What is this?
 
@@ -23,32 +23,15 @@ It includes:
 
 We are borrowing the shape of the best public skills repos, but not copying their skill content.
 
-## Authentication
-
-Skills that call external APIs may need an API key. Follow these rules:
-
-- **Never hardcode API keys** in skill scripts — environment variables only, no fallback to a raw key
-- Store keys in `~/.env` or the workspace `.env` (e.g. `/home/adam/agents/kev/.env`)
-- Pattern to use in TypeScript:
-  ```typescript
-  const API_KEY = process.env.MY_API_KEY;
-  if (!API_KEY) throw new Error('MY_API_KEY env var not set. Get a key at https://example.com and add it to your .env');
-  ```
-- Each skill that requires a key must document in its `SKILL.md`:
-  - What the env var is called
-  - Where to get the API key (URL)
-  - Whether there's a free tier
-  - Example `.env` entry
-
-Skills that scrape public websites or consume open RSS feeds generally need no key — check each skill's **Setup** section.
-
 ## Available skills
 
 | Skill | Source | Auth | Contributor |
 |-------|--------|------|-------------|
-| `fuelclock-nz` | fuelclock.nz | None | [Adam Holt](https://github.com/adam91holt) |
-| `metservice-nz` | MetOcean API | `METOCEAN_API_KEY` | [Adam Holt](https://github.com/adam91holt) |
-| `nz-news` | NZ RSS feeds | None | [Adam Holt](https://github.com/adam91holt) |
+| `at-transport` | dev-portal.at.govt.nz | API key required | [Adam Holt](https://github.com/adam91holt) |
+| `fuelclock-nz` | fuelclock.nz | No auth | [Adam Holt](https://github.com/adam91holt) |
+| `fuelclock-nz-watch` | fuelclock.nz watch endpoints | No auth | [Adam Holt](https://github.com/adam91holt) |
+| `metservice-nz` | MetService / marine API | No auth | [Adam Holt](https://github.com/adam91holt) |
+| `nz-news` | NZ RSS feeds | No auth | [Adam Holt](https://github.com/adam91holt) |
 
 ## Skill sets
 
@@ -103,6 +86,12 @@ npm run typecheck
 
 - Skills should target useful NZ-specific data or workflows
 - Public and open data is great, but not the only valid source
+- If auth is required, document it clearly in `SKILL.md`, including:
+  - How to obtain access
+  - Required environment variables
+  - Whether there's a free tier
+  - Example `.env` entry
+- Skills that scrape public websites or consume open RSS feeds should note rate limits, caching expectations, and source stability concerns
 - `description` must say what the skill does and when to use it
 - Keep `SKILL.md` lean and operational
 - Move deep detail into `references/`

--- a/skills/fuelclock-nz-watch/SKILL.md
+++ b/skills/fuelclock-nz-watch/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: fuelclock-nz-watch
+description: Monitor NZ fuel watch signals using recent fuel headlines and fuel-shipping market signals. Use when the task involves recent NZ fuel news, geopolitical shipping market signals relevant to NZ fuel supply, or a quick watchlist summary. No authentication required.
+---
+
+# FuelClock NZ Watch
+
+## Goal
+
+Track NZ fuel watch signals that sit outside the core price and supply workflow, specifically recent fuel headlines and shipping-related market signals.
+
+## Use this when
+
+- A user asks for recent NZ fuel headlines
+- A user asks about geopolitical shipping market signals relevant to NZ fuel supply
+- A user wants a quick fuel watchlist summary instead of raw price or stock data
+
+## Do not use this for
+
+- NZ pump prices, use `fuelclock-nz`
+- NZ fuel stock levels or MSO status, use `fuelclock-nz`
+- Inbound tanker details, use `fuelclock-nz`
+- Non-NZ fuel news or broad macro market research
+
+## Preferred workflow
+
+1. Run `scripts/cli.ts` with the narrowest subcommand that answers the task
+2. Use `summary` for a compact watchlist brief
+3. Use `risk` when the question is about market signals
+4. Use `news` when the question is about recent fuel headlines
+5. Use `--json` when another tool or agent needs machine-readable output
+
+## CLI
+
+Run with:
+
+```bash
+npx tsx skills/fuelclock-nz-watch/scripts/cli.ts <command> [flags]
+```
+
+### `summary [--json]`
+
+Best default for a quick watchlist briefing. Combines top tracked markets with the latest recent fuel headlines.
+
+JSON shape:
+
+- `risk.fetchedAt`
+- `risk.totalMarkets`
+- `risk.markets[]`
+- `news.fetchedAt`
+- `news.totalArticles`
+- `news.articles[]`
+
+Examples:
+
+```bash
+npx tsx skills/fuelclock-nz-watch/scripts/cli.ts summary
+npx tsx skills/fuelclock-nz-watch/scripts/cli.ts summary --json
+```
+
+### `risk [--limit N] [--json]`
+
+Shows tracked geopolitical markets relevant to fuel shipping. Output is sorted by market volume. The `probability` field is the market yes-price, not a direct NZ fuel risk score.
+
+JSON shape:
+
+- `fetchedAt`
+- `sort`
+- `filters.limit`
+- `totalMarkets`
+- `returnedCount`
+- `markets[]` with `title`, `shortTitle`, `probability`, `volume`, `liquidity`, `lastUpdated`, `isFallback`, `subMarkets[]`
+
+Examples:
+
+```bash
+npx tsx skills/fuelclock-nz-watch/scripts/cli.ts risk
+npx tsx skills/fuelclock-nz-watch/scripts/cli.ts risk --limit 5
+npx tsx skills/fuelclock-nz-watch/scripts/cli.ts risk --limit 3 --json
+```
+
+### `news [--limit N] [--json]`
+
+Shows recent NZ fuel headlines, newest first.
+
+JSON shape:
+
+- `fetchedAt`
+- `filters.limit`
+- `totalArticles`
+- `returnedCount`
+- `articles[]` with `title`, `source`, `date`, `url`
+
+Examples:
+
+```bash
+npx tsx skills/fuelclock-nz-watch/scripts/cli.ts news
+npx tsx skills/fuelclock-nz-watch/scripts/cli.ts news --limit 3
+npx tsx skills/fuelclock-nz-watch/scripts/cli.ts news --limit 5 --json
+```
+
+## Resources
+
+- CLI entrypoint: `scripts/cli.ts`
+- Typed fetch client: `scripts/client.ts`
+- Live smoke test: `scripts/smoke-test.ts`
+
+## Notes
+
+- No API key required
+- Uses the built-in `fetch` available in modern Node runtimes
+- Default output is human-readable and filtered for quick answers
+- `--json` output is intended for chaining into other tools or agent steps
+- The watch skill is intentionally separate from `fuelclock-nz`, which stays focused on prices, supply, and vessels

--- a/skills/fuelclock-nz-watch/scripts/cli.ts
+++ b/skills/fuelclock-nz-watch/scripts/cli.ts
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+import { Command } from 'commander';
+import { pathToFileURL } from 'node:url';
+import {
+  getGeopoliticalRisk,
+  getNews,
+  type GeopoliticalRiskMarket,
+  type NewsArticle,
+} from './client.js';
+
+type JsonFlag = { json?: boolean };
+
+type RiskView = {
+  title: string;
+  shortTitle?: string;
+  probability: number;
+  volume: number;
+  liquidity?: number;
+  lastUpdated?: string;
+  isFallback?: boolean;
+  subMarkets: Array<{ label: string; probability: number }>;
+};
+
+type NewsView = {
+  title: string;
+  source: string;
+  date: string;
+  url: string;
+};
+
+const program = new Command();
+const nzDateTimeFormatter = new Intl.DateTimeFormat('en-NZ', {
+  timeZone: 'Pacific/Auckland',
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: '2-digit',
+  hour12: true,
+  timeZoneName: 'short',
+});
+
+function addExamples(command: Command, examples: string[]): Command {
+  return command.addHelpText(
+    'after',
+    `\nExamples:\n${examples.map((example) => `  ${example}`).join('\n')}`,
+  );
+}
+
+function printOutput(data: unknown, json: boolean | undefined, render: () => string) {
+  if (json) {
+    console.log(JSON.stringify(data, null, 2));
+    return;
+  }
+
+  console.log(render());
+}
+
+function formatDateTime(value: string | null | undefined): string {
+  if (!value) return 'unknown';
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return nzDateTimeFormatter.format(date);
+}
+
+function formatPercent(value: number): string {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function parsePositiveInt(raw: string): number {
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`Expected a positive integer, received: ${raw}`);
+  }
+
+  return value;
+}
+
+function selectRiskRows(markets: GeopoliticalRiskMarket[], limit?: number): RiskView[] {
+  const sorted = [...markets]
+    .sort((left, right) => right.volume - left.volume || right.probability - left.probability)
+    .slice(0, limit ?? markets.length);
+
+  return sorted.map((market) => ({
+    title: market.title,
+    shortTitle: market.shortTitle,
+    probability: market.probability,
+    volume: market.volume,
+    liquidity: market.liquidity,
+    lastUpdated: market.lastUpdated,
+    isFallback: market.isFallback,
+    subMarkets: market.subMarkets ?? [],
+  }));
+}
+
+function selectNewsRows(articles: NewsArticle[], limit?: number): NewsView[] {
+  return [...articles]
+    .sort((left, right) => Date.parse(right.date) - Date.parse(left.date))
+    .slice(0, limit ?? articles.length)
+    .map((article) => ({
+      title: article.title,
+      source: article.source,
+      date: article.date,
+      url: article.url,
+    }));
+}
+
+function renderRisk(rows: RiskView[], fetchedAt: string | null): string {
+  const lines = ['Tracked geopolitical fuel-shipping markets'];
+  lines.push(`Latest market update: ${formatDateTime(fetchedAt)}`);
+  lines.push('Sorted by trading volume. The probability shown is the market yes-price, not a direct NZ fuel risk score.');
+  lines.push('');
+
+  if (rows.length === 0) {
+    lines.push('No markets returned.');
+    return lines.join('\n');
+  }
+
+  for (const row of rows) {
+    lines.push(
+      `- ${row.shortTitle ?? row.title}: ${formatPercent(row.probability)} yes, $${row.volume.toLocaleString(undefined, { maximumFractionDigits: 0 })} volume${typeof row.liquidity === 'number' ? `, $${row.liquidity.toLocaleString(undefined, { maximumFractionDigits: 0 })} liquidity` : ''}, updated ${formatDateTime(row.lastUpdated)}`,
+    );
+    if (row.subMarkets.length > 0) {
+      lines.push(
+        `  Sub-markets: ${row.subMarkets.map((market) => `${market.label} ${formatPercent(market.probability)}`).join(', ')}`,
+      );
+    }
+  }
+
+  return lines.join('\n');
+}
+
+function renderNews(rows: NewsView[], fetchedAt: string): string {
+  const lines = [`Recent NZ fuel headlines, updated ${formatDateTime(fetchedAt)}`];
+  lines.push('');
+
+  if (rows.length === 0) {
+    lines.push('No articles returned.');
+    return lines.join('\n');
+  }
+
+  rows.forEach((row, index) => {
+    lines.push(`${index + 1}. ${row.title}`);
+    lines.push(`   ${row.source}, ${formatDateTime(row.date)}`);
+    lines.push(`   ${row.url}`);
+  });
+
+  return lines.join('\n');
+}
+
+program
+  .name('fuelclock-nz-watch')
+  .description('Monitor NZ fuel watch signals, including shipping-related markets and recent fuel headlines.')
+  .showHelpAfterError('(add --help for usage)');
+
+addExamples(program, [
+  'npx tsx skills/fuelclock-nz-watch/scripts/cli.ts summary',
+  'npx tsx skills/fuelclock-nz-watch/scripts/cli.ts risk --limit 5',
+  'npx tsx skills/fuelclock-nz-watch/scripts/cli.ts news --limit 3 --json',
+]);
+
+addExamples(
+  program
+    .command('summary')
+    .description('Show a compact fuel watch briefing across top markets and recent headlines.')
+    .option('--json', 'emit machine-readable JSON')
+    .action(async (options: JsonFlag) => {
+      const [riskData, newsData] = await Promise.all([getGeopoliticalRisk(), getNews()]);
+      const markets = selectRiskRows(riskData.markets, 3);
+      const articles = selectNewsRows(newsData.articles, 3);
+
+      const summary = {
+        risk: {
+          fetchedAt: riskData.fetchedAt,
+          totalMarkets: riskData.markets.length,
+          markets,
+        },
+        news: {
+          fetchedAt: newsData.fetchedAt,
+          totalArticles: newsData.articles.length,
+          articles,
+        },
+      };
+
+      printOutput(summary, options.json, () => {
+        const lines = ['NZ fuel watch summary'];
+        lines.push(`Market update: ${formatDateTime(riskData.fetchedAt)}`);
+        lines.push(`Headline update: ${formatDateTime(newsData.fetchedAt)}`);
+        lines.push('');
+        if (markets[0]) {
+          lines.push(
+            `Top market: ${markets[0].shortTitle ?? markets[0].title} at ${formatPercent(markets[0].probability)} yes on $${markets[0].volume.toLocaleString(undefined, { maximumFractionDigits: 0 })} volume`,
+          );
+        }
+        if (articles[0]) {
+          lines.push(`Latest headline: ${articles[0].title} (${articles[0].source})`);
+        }
+        if (!markets[0] && !articles[0]) {
+          lines.push('No watch items returned.');
+        }
+        return lines.join('\n');
+      });
+    }),
+  [
+    'npx tsx skills/fuelclock-nz-watch/scripts/cli.ts summary',
+    'npx tsx skills/fuelclock-nz-watch/scripts/cli.ts summary --json',
+  ],
+);
+
+addExamples(
+  program
+    .command('risk')
+    .description('Show tracked geopolitical markets relevant to fuel shipping, sorted by market volume.')
+    .option('--limit <n>', 'limit the number of markets returned', parsePositiveInt)
+    .option('--json', 'emit machine-readable JSON')
+    .action(async (options: JsonFlag & { limit?: number }) => {
+      const data = await getGeopoliticalRisk();
+      const markets = selectRiskRows(data.markets, options.limit);
+      const output = {
+        fetchedAt: data.fetchedAt,
+        sort: 'volume-desc',
+        filters: {
+          limit: options.limit ?? null,
+        },
+        totalMarkets: data.markets.length,
+        returnedCount: markets.length,
+        markets,
+      };
+
+      printOutput(output, options.json, () => renderRisk(markets, data.fetchedAt));
+    }),
+  [
+    'npx tsx skills/fuelclock-nz-watch/scripts/cli.ts risk',
+    'npx tsx skills/fuelclock-nz-watch/scripts/cli.ts risk --limit 5',
+    'npx tsx skills/fuelclock-nz-watch/scripts/cli.ts risk --limit 3 --json',
+  ],
+);
+
+addExamples(
+  program
+    .command('news')
+    .description('Show recent NZ fuel headlines, newest first.')
+    .option('--limit <n>', 'limit the number of articles returned', parsePositiveInt)
+    .option('--json', 'emit machine-readable JSON')
+    .action(async (options: JsonFlag & { limit?: number }) => {
+      const data = await getNews();
+      const articles = selectNewsRows(data.articles, options.limit);
+      const output = {
+        fetchedAt: data.fetchedAt,
+        filters: {
+          limit: options.limit ?? null,
+        },
+        totalArticles: data.articles.length,
+        returnedCount: articles.length,
+        articles,
+      };
+
+      printOutput(output, options.json, () => renderNews(articles, data.fetchedAt));
+    }),
+  [
+    'npx tsx skills/fuelclock-nz-watch/scripts/cli.ts news',
+    'npx tsx skills/fuelclock-nz-watch/scripts/cli.ts news --limit 3',
+    'npx tsx skills/fuelclock-nz-watch/scripts/cli.ts news --limit 5 --json',
+  ],
+);
+
+async function main() {
+  await program.parseAsync(process.argv);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/skills/fuelclock-nz-watch/scripts/client.ts
+++ b/skills/fuelclock-nz-watch/scripts/client.ts
@@ -1,0 +1,84 @@
+import { pathToFileURL } from 'node:url';
+
+const BASE_URL = 'https://fuelclock.nz';
+const DEFAULT_TIMEOUT_MS = 10_000;
+
+export interface GeopoliticalRiskMarket {
+  id: string;
+  slug: string;
+  title: string;
+  shortTitle?: string;
+  probability: number;
+  volume: number;
+  liquidity?: number;
+  description?: string;
+  endDate?: string;
+  outcomes?: string[];
+  lastUpdated?: string;
+  isFallback?: boolean;
+  subMarkets?: Array<{ label: string; probability: number }>;
+}
+
+export interface GeopoliticalRiskResponse {
+  markets: GeopoliticalRiskMarket[];
+  fetchedAt: string | null;
+}
+
+export interface NewsArticle {
+  title: string;
+  url: string;
+  source: string;
+  date: string;
+}
+
+export interface NewsResponse {
+  articles: NewsArticle[];
+  fetchedAt: string;
+}
+
+async function getJson<T>(path: string): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(`${BASE_URL}${path}`, {
+      headers: { Accept: 'application/json' },
+      signal: controller.signal,
+    });
+
+    if (!response.ok) {
+      throw new Error(`Request failed: ${response.status} ${response.statusText}`);
+    }
+
+    return (await response.json()) as T;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function getGeopoliticalRisk(): Promise<GeopoliticalRiskResponse> {
+  const markets = await getJson<GeopoliticalRiskMarket[]>('/api/polymarket');
+  const fetchedAt = markets.reduce<string | null>((latest, market) => {
+    if (!market.lastUpdated) return latest;
+    if (!latest) return market.lastUpdated;
+    return market.lastUpdated > latest ? market.lastUpdated : latest;
+  }, null);
+
+  return { markets, fetchedAt };
+}
+
+export async function getNews(): Promise<NewsResponse> {
+  return getJson<NewsResponse>('/api/news');
+}
+
+async function main() {
+  const [risk, news] = await Promise.all([getGeopoliticalRisk(), getNews()]);
+  console.log(`FuelClock NZ watch client is reachable. Markets: ${risk.markets.length}, articles: ${news.articles.length}`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  });
+}

--- a/skills/fuelclock-nz-watch/scripts/smoke-test.ts
+++ b/skills/fuelclock-nz-watch/scripts/smoke-test.ts
@@ -1,0 +1,53 @@
+import { execFileSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  getGeopoliticalRisk,
+  getNews,
+} from './client.js';
+
+function assert(condition: unknown, message: string): asserts condition {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(scriptDir, '../../..');
+const cliPath = 'skills/fuelclock-nz-watch/scripts/cli.ts';
+
+function runCliJson(args: string[]) {
+  const stdout = execFileSync('npx', ['tsx', cliPath, ...args, '--json'], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  return JSON.parse(stdout) as Record<string, unknown>;
+}
+
+async function main() {
+  const risk = await getGeopoliticalRisk();
+  assert(Array.isArray(risk.markets), 'risk.markets must be an array');
+
+  const news = await getNews();
+  assert(Array.isArray(news.articles), 'news.articles must be an array');
+
+  const summaryJson = runCliJson(['summary']);
+  assert(typeof summaryJson === 'object', 'summary JSON must parse');
+  assert('risk' in summaryJson, 'summary JSON must include risk');
+  assert('news' in summaryJson, 'summary JSON must include news');
+
+  const riskJson = runCliJson(['risk', '--limit', '2']);
+  assert(riskJson.returnedCount === 2, 'risk --limit 2 should return two rows');
+
+  const newsJson = runCliJson(['news', '--limit', '2']);
+  assert(newsJson.returnedCount === 2, 'news --limit 2 should return two rows');
+
+  console.log('FuelClock NZ Watch smoke test passed.');
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/skills/fuelclock-nz/SKILL.md
+++ b/skills/fuelclock-nz/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fuelclock-nz
-description: Query New Zealand fuel price and supply data from fuelclock.nz. Use when the task involves NZ petrol or diesel prices, fuel supply security, days of supply remaining, MSO status, incoming fuel tankers, geopolitical fuel-shipping risk, or recent NZ fuel headlines. No authentication required.
+description: Query New Zealand fuel price and supply data from fuelclock.nz. Use when the task involves NZ petrol or diesel prices, fuel supply security, days of supply remaining, MSO status, or incoming fuel tankers. No authentication required.
 ---
 
 # FuelClock NZ
@@ -14,8 +14,7 @@ Query live New Zealand fuel price and supply data from fuelclock.nz through a CL
 - A user asks about current NZ petrol, diesel, or premium fuel prices
 - A user wants to know whether NZ fuel supply is tight or below MSO thresholds
 - A user asks what tankers are en route to New Zealand
-- A user asks about geopolitical shipping risk relevant to NZ fuel supply
-- A user wants recent NZ fuel headlines or a quick fuel situation summary
+- A user wants a quick fuel situation summary focused on prices, supply, and vessels
 
 ## Do not use this for
 
@@ -23,13 +22,15 @@ Query live New Zealand fuel price and supply data from fuelclock.nz through a CL
 - Electricity, gas, or LPG pricing
 - Vehicle fuel efficiency calculations
 - Forecasting future fuel prices beyond the live observed data
+- Recent fuel headlines or geopolitical watch signals, use `fuelclock-nz-watch` for that
 
 ## Preferred workflow
 
 1. Run `scripts/cli.ts` with the narrowest subcommand that answers the task
-2. Use default human output for direct answers
-3. Use `--json` when another tool or agent needs machine-readable output
-4. Fall back to importing `scripts/client.ts` only when you need the raw typed fetch functions
+2. Use `summary` for a quick situational briefing
+3. Use default human output for direct answers
+4. Use `--json` when another tool or agent needs machine-readable output
+5. Fall back to importing `scripts/client.ts` only when you need the raw typed fetch functions
 
 ## CLI
 
@@ -41,14 +42,13 @@ npx tsx skills/fuelclock-nz/scripts/cli.ts <command> [flags]
 
 ### `summary [--json]`
 
-Best default for general questions. Combines prices, supply, inbound vessels, top tracked markets, and recent headlines.
+Best default for general questions. Combines prices, supply, and inbound vessels.
 
 JSON shape:
+
 - `prices`: fetched price snapshot plus filtered price rows
 - `supply`: overall risk, countdown, lowest fuel, below-MSO list, and fuel rows
-- `vessels`: inbound vessel count, flagged count, and top vessels
-- `risk`: fetched time, total market count, and top markets
-- `news`: fetched time, total article count, and latest articles
+- `vessels`: fetched time, inbound vessel count, flagged count, and top vessels
 
 Examples:
 
@@ -62,6 +62,7 @@ npx tsx skills/fuelclock-nz/scripts/cli.ts summary --json
 Shows national average NZ pump prices from FuelClock's Gaspy-backed endpoint.
 
 JSON shape:
+
 - `fetchedAt`
 - `source`
 - `isFallback`
@@ -82,6 +83,7 @@ npx tsx skills/fuelclock-nz/scripts/cli.ts prices --fuel 95 --json
 Shows NZ fuel supply state, including days remaining, MSO gap, and depletion timing.
 
 JSON shape:
+
 - `timestamp`
 - `anchorDate`
 - `mbieAsAtDate`
@@ -106,6 +108,7 @@ npx tsx skills/fuelclock-nz/scripts/cli.ts supply --fuel diesel --json
 Shows inbound vessel data, sorted by ETA.
 
 JSON shape:
+
 - `fetchedAt`
 - `source`
 - `govOnWaterByFuel`
@@ -124,49 +127,6 @@ npx tsx skills/fuelclock-nz/scripts/cli.ts vessels --flagged-only --limit 3
 npx tsx skills/fuelclock-nz/scripts/cli.ts vessels --fuel diesel --json
 ```
 
-### `risk [--limit N] [--json]`
-
-Shows tracked geopolitical markets relevant to fuel shipping. Output is sorted by market volume. The `probability` field is the market yes-price, not a direct NZ fuel risk score.
-
-JSON shape:
-- `fetchedAt`
-- `sort`
-- `filters.limit`
-- `totalMarkets`
-- `returnedCount`
-- `markets[]` with `title`, `shortTitle`, `probability`, `volume`, `liquidity`, `lastUpdated`, `isFallback`, `subMarkets[]`
-
-Examples:
-
-```bash
-npx tsx skills/fuelclock-nz/scripts/cli.ts risk
-npx tsx skills/fuelclock-nz/scripts/cli.ts risk --limit 5
-npx tsx skills/fuelclock-nz/scripts/cli.ts risk --limit 3 --json
-```
-
-### `news [--limit N] [--json]`
-
-Shows recent NZ fuel headlines, newest first.
-
-JSON shape:
-- `fetchedAt`
-- `filters.limit`
-- `totalArticles`
-- `returnedCount`
-- `articles[]` with `title`, `source`, `date`, `url`
-
-Examples:
-
-```bash
-npx tsx skills/fuelclock-nz/scripts/cli.ts news
-npx tsx skills/fuelclock-nz/scripts/cli.ts news --limit 3
-npx tsx skills/fuelclock-nz/scripts/cli.ts news --limit 5 --json
-```
-
-## Setup
-
-No API key required — just Node.js and `npx tsx`.
-
 ## Resources
 
 - CLI entrypoint: `scripts/cli.ts`
@@ -180,3 +140,4 @@ No API key required — just Node.js and `npx tsx`.
 - Default output is human-readable and filtered for quick answers
 - `--json` output is intended for chaining into other tools or agent steps
 - FuelClock supply data and MBIE stock data are related but not identical, FuelClock applies its own live supply model on top of source data
+- For NZ fuel headlines and geopolitical watch signals, use `fuelclock-nz-watch`

--- a/skills/fuelclock-nz/scripts/cli.ts
+++ b/skills/fuelclock-nz/scripts/cli.ts
@@ -3,14 +3,10 @@ import { Command, Option } from 'commander';
 import { pathToFileURL } from 'node:url';
 import {
   getFuelPrices,
-  getGeopoliticalRisk,
-  getNews,
   getSupplyStatus,
   getVessels,
   type FuelPriceRow,
   type FuelState,
-  type GeopoliticalRiskMarket,
-  type NewsArticle,
   type Vessel,
 } from './client.js';
 
@@ -65,24 +61,6 @@ type VesselView = {
   hormuzTransit: boolean;
 };
 
-type RiskView = {
-  title: string;
-  shortTitle?: string;
-  probability: number;
-  volume: number;
-  liquidity?: number;
-  lastUpdated?: string;
-  isFallback?: boolean;
-  subMarkets: Array<{ label: string; probability: number }>;
-};
-
-type NewsView = {
-  title: string;
-  source: string;
-  date: string;
-  url: string;
-};
-
 const program = new Command();
 const priceFuelOrder: PriceFuelOption[] = ['91', '95', '98', 'diesel'];
 const supplyFuelOrder: SupplyFuelOption[] = ['petrol', 'diesel', 'jet'];
@@ -128,16 +106,8 @@ function formatCents(value: number): string {
   return `${value >= 0 ? '+' : ''}${value.toFixed(2)} c/L`;
 }
 
-function formatPercent(value: number): string {
-  return `${(value * 100).toFixed(1)}%`;
-}
-
 function formatDays(value: number): string {
   return `${value.toFixed(1)}d`;
-}
-
-function formatMl(value: number): string {
-  return `${(value / 1_000_000).toFixed(1)} ML`;
 }
 
 function formatDirection(direction: string): string {
@@ -252,35 +222,6 @@ function selectVesselRows(
   return limited.map(toVesselView);
 }
 
-function selectRiskRows(markets: GeopoliticalRiskMarket[], limit?: number): RiskView[] {
-  const sorted = [...markets]
-    .sort((left, right) => right.volume - left.volume || right.probability - left.probability)
-    .slice(0, limit ?? markets.length);
-
-  return sorted.map((market) => ({
-    title: market.title,
-    shortTitle: market.shortTitle,
-    probability: market.probability,
-    volume: market.volume,
-    liquidity: market.liquidity,
-    lastUpdated: market.lastUpdated,
-    isFallback: market.isFallback,
-    subMarkets: market.subMarkets ?? [],
-  }));
-}
-
-function selectNewsRows(articles: NewsArticle[], limit?: number): NewsView[] {
-  return [...articles]
-    .sort((left, right) => Date.parse(right.date) - Date.parse(left.date))
-    .slice(0, limit ?? articles.length)
-    .map((article) => ({
-      title: article.title,
-      source: article.source,
-      date: article.date,
-      url: article.url,
-    }));
-}
-
 function renderPrices(rows: PriceView[], fetchedAt: string, source: string, isFallback: boolean): string {
   const lines = [`NZ pump prices, ${source}, updated ${formatDateTime(fetchedAt)}`];
 
@@ -292,7 +233,7 @@ function renderPrices(rows: PriceView[], fetchedAt: string, source: string, isFa
 
   if (isFallback) {
     lines.push('');
-    lines.push('Note: FuelClock reports this price snapshot came from fallback/cache data.');
+    lines.push('Note: FuelClock reports this price snapshot came from fallback or cache data.');
   }
 
   return lines.join('\n');
@@ -365,52 +306,9 @@ function renderVessels(
   return lines.join('\n');
 }
 
-function renderRisk(rows: RiskView[], fetchedAt: string | null): string {
-  const lines = ['Tracked geopolitical fuel-shipping markets'];
-  lines.push(`Latest market update: ${formatDateTime(fetchedAt)}`);
-  lines.push('Sorted by trading volume. The probability shown is the market yes-price, not a direct NZ fuel risk score.');
-  lines.push('');
-
-  if (rows.length === 0) {
-    lines.push('No markets returned.');
-    return lines.join('\n');
-  }
-
-  for (const row of rows) {
-    lines.push(
-      `- ${row.shortTitle ?? row.title}: ${formatPercent(row.probability)} yes, $${row.volume.toLocaleString(undefined, { maximumFractionDigits: 0 })} volume${typeof row.liquidity === 'number' ? `, $${row.liquidity.toLocaleString(undefined, { maximumFractionDigits: 0 })} liquidity` : ''}, updated ${formatDateTime(row.lastUpdated)}`,
-    );
-    if (row.subMarkets.length > 0) {
-      lines.push(
-        `  Sub-markets: ${row.subMarkets.map((market) => `${market.label} ${formatPercent(market.probability)}`).join(', ')}`,
-      );
-    }
-  }
-
-  return lines.join('\n');
-}
-
-function renderNews(rows: NewsView[], fetchedAt: string): string {
-  const lines = [`Recent NZ fuel headlines, updated ${formatDateTime(fetchedAt)}`];
-  lines.push('');
-
-  if (rows.length === 0) {
-    lines.push('No articles returned.');
-    return lines.join('\n');
-  }
-
-  rows.forEach((row, index) => {
-    lines.push(`${index + 1}. ${row.title}`);
-    lines.push(`   ${row.source}, ${formatDateTime(row.date)}`);
-    lines.push(`   ${row.url}`);
-  });
-
-  return lines.join('\n');
-}
-
 program
   .name('fuelclock-nz')
-  .description('Query live New Zealand fuel prices, supply status, vessels, shipping-related market signals, and headlines from fuelclock.nz.')
+  .description('Query live New Zealand fuel prices, supply status, and inbound vessels from fuelclock.nz.')
   .showHelpAfterError('(add --help for usage)');
 
 addExamples(program, [
@@ -418,29 +316,19 @@ addExamples(program, [
   'npx tsx skills/fuelclock-nz/scripts/cli.ts prices --fuel diesel --json',
   'npx tsx skills/fuelclock-nz/scripts/cli.ts supply --below-mso',
   'npx tsx skills/fuelclock-nz/scripts/cli.ts vessels --flagged-only --limit 3',
-  'npx tsx skills/fuelclock-nz/scripts/cli.ts risk --limit 5',
-  'npx tsx skills/fuelclock-nz/scripts/cli.ts news --limit 3 --json',
 ]);
 
 addExamples(
   program
     .command('summary')
-    .description('Show a compact NZ fuel briefing across pump prices, supply, inbound vessels, top tracked markets, and recent headlines.')
+    .description('Show a compact NZ fuel briefing across pump prices, supply, and inbound vessels.')
     .option('--json', 'emit machine-readable JSON')
     .action(async (options: JsonFlag) => {
-      const [pricesData, supplyData, vesselsData, riskData, newsData] = await Promise.all([
-        getFuelPrices(),
-        getSupplyStatus(),
-        getVessels(),
-        getGeopoliticalRisk(),
-        getNews(),
-      ]);
+      const [pricesData, supplyData, vesselsData] = await Promise.all([getFuelPrices(), getSupplyStatus(), getVessels()]);
 
       const prices = selectPriceRows(pricesData.prices);
       const fuels = selectFuelStates(supplyData.fuelStates);
       const vessels = selectVesselRows(vesselsData.vessels, { limit: 3 });
-      const riskMarkets = selectRiskRows(riskData.markets, 3);
-      const articles = selectNewsRows(newsData.articles, 3);
       const lowestFuel = supplyData.lowestFuel ? toSupplyView(supplyData.lowestFuel) : undefined;
       const belowMSO = fuels.filter((fuel) => fuel.belowMSO).map((fuel) => fuel.label);
 
@@ -466,16 +354,6 @@ addExamples(
           flaggedCount: vesselsData.vessels.filter((vessel) => vessel.flagRisk).length,
           vessels,
         },
-        risk: {
-          fetchedAt: riskData.fetchedAt,
-          totalMarkets: riskData.markets.length,
-          markets: riskMarkets,
-        },
-        news: {
-          fetchedAt: newsData.fetchedAt,
-          totalArticles: newsData.articles.length,
-          articles,
-        },
       };
 
       printOutput(summary, options.json, () => {
@@ -491,14 +369,6 @@ addExamples(
         lines.push(
           `Vessels: ${vesselsData.vessels.length} inbound, ${summary.vessels.flaggedCount} flagged, next ETA ${vessels[0]?.eta ? formatDateTime(vessels[0].eta) : 'unknown'}`,
         );
-        if (riskMarkets[0]) {
-          lines.push(
-            `Markets: ${riskMarkets[0].shortTitle ?? riskMarkets[0].title} at ${formatPercent(riskMarkets[0].probability)} yes on $${riskMarkets[0].volume.toLocaleString(undefined, { maximumFractionDigits: 0 })} volume`,
-          );
-        }
-        if (articles[0]) {
-          lines.push(`News: ${articles[0].title} (${articles[0].source})`);
-        }
         return lines.join('\n');
       });
     }),
@@ -618,63 +488,6 @@ addExamples(
     'npx tsx skills/fuelclock-nz/scripts/cli.ts vessels',
     'npx tsx skills/fuelclock-nz/scripts/cli.ts vessels --flagged-only --limit 3',
     'npx tsx skills/fuelclock-nz/scripts/cli.ts vessels --fuel diesel --json',
-  ],
-);
-
-addExamples(
-  program
-    .command('risk')
-    .description('Show tracked geopolitical markets relevant to fuel shipping, sorted by market volume.')
-    .option('--limit <n>', 'limit the number of markets returned', parsePositiveInt)
-    .option('--json', 'emit machine-readable JSON')
-    .action(async (options: JsonFlag & { limit?: number }) => {
-      const data = await getGeopoliticalRisk();
-      const markets = selectRiskRows(data.markets, options.limit);
-      const output = {
-        fetchedAt: data.fetchedAt,
-        sort: 'volume-desc',
-        filters: {
-          limit: options.limit ?? null,
-        },
-        totalMarkets: data.markets.length,
-        returnedCount: markets.length,
-        markets,
-      };
-
-      printOutput(output, options.json, () => renderRisk(markets, data.fetchedAt));
-    }),
-  [
-    'npx tsx skills/fuelclock-nz/scripts/cli.ts risk',
-    'npx tsx skills/fuelclock-nz/scripts/cli.ts risk --limit 5',
-    'npx tsx skills/fuelclock-nz/scripts/cli.ts risk --limit 3 --json',
-  ],
-);
-
-addExamples(
-  program
-    .command('news')
-    .description('Show recent NZ fuel headlines, newest first.')
-    .option('--limit <n>', 'limit the number of articles returned', parsePositiveInt)
-    .option('--json', 'emit machine-readable JSON')
-    .action(async (options: JsonFlag & { limit?: number }) => {
-      const data = await getNews();
-      const articles = selectNewsRows(data.articles, options.limit);
-      const output = {
-        fetchedAt: data.fetchedAt,
-        filters: {
-          limit: options.limit ?? null,
-        },
-        totalArticles: data.articles.length,
-        returnedCount: articles.length,
-        articles,
-      };
-
-      printOutput(output, options.json, () => renderNews(articles, data.fetchedAt));
-    }),
-  [
-    'npx tsx skills/fuelclock-nz/scripts/cli.ts news',
-    'npx tsx skills/fuelclock-nz/scripts/cli.ts news --limit 3',
-    'npx tsx skills/fuelclock-nz/scripts/cli.ts news --limit 5 --json',
   ],
 );
 

--- a/skills/fuelclock-nz/scripts/client.ts
+++ b/skills/fuelclock-nz/scripts/client.ts
@@ -108,39 +108,6 @@ export interface VesselsResponse {
   fetchedAt: string;
 }
 
-export interface GeopoliticalRiskMarket {
-  id: string;
-  slug: string;
-  title: string;
-  shortTitle?: string;
-  probability: number;
-  volume: number;
-  liquidity?: number;
-  description?: string;
-  endDate?: string;
-  outcomes?: string[];
-  lastUpdated?: string;
-  isFallback?: boolean;
-  subMarkets?: Array<{ label: string; probability: number }>;
-}
-
-export interface GeopoliticalRiskResponse {
-  markets: GeopoliticalRiskMarket[];
-  fetchedAt: string | null;
-}
-
-export interface NewsArticle {
-  title: string;
-  url: string;
-  source: string;
-  date: string;
-}
-
-export interface NewsResponse {
-  articles: NewsArticle[];
-  fetchedAt: string;
-}
-
 async function getJson<T>(path: string): Promise<T> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), DEFAULT_TIMEOUT_MS);
@@ -177,72 +144,9 @@ export async function getVessels(): Promise<VesselsResponse> {
   return getJson<VesselsResponse>('/api/vessels');
 }
 
-export async function getGeopoliticalRisk(): Promise<GeopoliticalRiskResponse> {
-  const markets = await getJson<GeopoliticalRiskMarket[]>('/api/polymarket');
-  const fetchedAt = markets.reduce<string | null>((latest, market) => {
-    if (!market.lastUpdated) return latest;
-    if (!latest) return market.lastUpdated;
-    return market.lastUpdated > latest ? market.lastUpdated : latest;
-  }, null);
-
-  return { markets, fetchedAt };
-}
-
-export async function getNews(): Promise<NewsResponse> {
-  return getJson<NewsResponse>('/api/news');
-}
-
-function formatDeltaCents(value: number): string {
-  return `${value >= 0 ? '+' : ''}${value.toFixed(2)} c/L`;
-}
-
-function formatFuelStatus(fuel: FuelState): string {
-  const status = fuel.belowMSO ? 'below MSO' : 'meets MSO';
-  return `${status}, depletion in ${fuel.calendarDaysToDepletion.toFixed(1)} days`;
-}
-
-export async function getSummary(): Promise<string> {
-  const [pricesData, supplyData] = await Promise.all([getFuelPrices(), getSupplyStatus()]);
-
-  const lines: string[] = [];
-  lines.push(`NZ Fuel Summary (${pricesData.fetchedAt ?? supplyData.timestamp ?? 'unknown'})`);
-  lines.push('');
-  lines.push('Retail pump prices (NZD/litre, national average):');
-
-  for (const price of pricesData.prices) {
-    const arrow = { up: '↑', down: '↓', flat: '→' }[price.direction7d] ?? '';
-    lines.push(
-      `  ${price.type}: $${price.price.toFixed(3)}/L ${arrow} (7d: ${formatDeltaCents(price.change7d)}, 28d: ${formatDeltaCents(price.change28d)})`,
-    );
-  }
-
-  lines.push('');
-  lines.push(`Supply security: overall risk = ${supplyData.overallRisk.toUpperCase()}`);
-  if (typeof supplyData.countdownHours === 'number') {
-    lines.push(
-      `  Most constrained fuel depletes in ${supplyData.countdownHours.toFixed(1)} hours (${(supplyData.countdownHours / 24).toFixed(1)} days)`,
-    );
-  }
-
-  lines.push('');
-  lines.push('Days of supply remaining:');
-  for (const fuel of supplyData.fuelStates) {
-    lines.push(
-      `  ${fuel.label}: ${fuel.currentDays.toFixed(1)} days (MSO threshold: ${fuel.msoThreshold} days)${fuel.belowMSO ? ' [BELOW MSO]' : ''}`,
-    );
-    lines.push(`    Status: ${formatFuelStatus(fuel)}`);
-  }
-
-  if (pricesData.isFallback) {
-    lines.push('');
-    lines.push('Note: price data is currently being served from cache.');
-  }
-
-  return lines.join('\n');
-}
-
 async function main() {
-  console.log(await getSummary());
+  const [prices, supply] = await Promise.all([getFuelPrices(), getSupplyStatus()]);
+  console.log(`FuelClock NZ client is reachable. Prices: ${prices.prices.length}, fuels: ${supply.fuelStates.length}`);
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {

--- a/skills/fuelclock-nz/scripts/smoke-test.ts
+++ b/skills/fuelclock-nz/scripts/smoke-test.ts
@@ -6,9 +6,6 @@ import {
   getSupplyStatus,
   getMbieStocks,
   getVessels,
-  getGeopoliticalRisk,
-  getNews,
-  getSummary,
 } from './client.js';
 
 function assert(condition: unknown, message: string): asserts condition {
@@ -45,19 +42,11 @@ async function main() {
   const vessels = await getVessels();
   assert(Array.isArray(vessels.vessels), 'vessels.vessels must be an array');
 
-  const risk = await getGeopoliticalRisk();
-  assert(Array.isArray(risk.markets), 'risk.markets must be an array');
-
-  const news = await getNews();
-  assert(Array.isArray(news.articles), 'news.articles must be an array');
-
-  const summary = await getSummary();
-  assert(summary.includes('NZ Fuel Summary'), 'summary must include the title');
-
   const summaryJson = runCliJson(['summary']);
   assert(typeof summaryJson === 'object', 'summary JSON must parse');
   assert('prices' in summaryJson, 'summary JSON must include prices');
   assert('supply' in summaryJson, 'summary JSON must include supply');
+  assert('vessels' in summaryJson, 'summary JSON must include vessels');
 
   const pricesJson = runCliJson(['prices', '--fuel', 'diesel']);
   assert(pricesJson.count === 1, 'prices --fuel diesel should return one row');
@@ -67,12 +56,6 @@ async function main() {
 
   const vesselsJson = runCliJson(['vessels', '--flagged-only', '--limit', '2']);
   assert(typeof vesselsJson.returnedCount === 'number', 'vessels JSON must include returnedCount');
-
-  const riskJson = runCliJson(['risk', '--limit', '2']);
-  assert(riskJson.returnedCount === 2, 'risk --limit 2 should return two rows');
-
-  const newsJson = runCliJson(['news', '--limit', '2']);
-  assert(newsJson.returnedCount === 2, 'news --limit 2 should return two rows');
 
   console.log('FuelClock NZ smoke test passed.');
 }

--- a/skills/nz-news/SKILL.md
+++ b/skills/nz-news/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: nz-news
-description: Aggregate RSS feeds from New Zealand news websites (NZ Herald, Stuff, RNZ, Newsroom, The Spinoff, Interest.co.nz). Use when the task involves NZ news, current events in New Zealand, what's happening in NZ, or NZ headlines. No authentication required.
+description: Aggregate RSS feeds from major New Zealand news websites. Use when the task involves NZ news, current events in New Zealand, what's happening in NZ, NZ headlines, or searching NZ stories by topic, timeframe, or source. No authentication required.
 ---
 
 # NZ News
 
 ## Goal
 
-Aggregate live RSS feeds from major New Zealand news websites into a single CLI tool for quick headline scanning, source browsing, and topic searching.
+Aggregate live RSS feeds from major New Zealand news websites into a single CLI tool for quick headline scanning, source browsing, and obvious topic searching.
 
 ## Use this when
 
 - A user asks about current NZ news or what's happening in New Zealand
 - A user wants today's headlines from NZ media
 - A user asks about news from a specific NZ outlet (Stuff, RNZ, NZ Herald, etc.)
-- A user wants to find NZ news about a specific topic or keyword
-- A user needs a quick news briefing for New Zealand
+- A user wants to search NZ news by topic, keyword, timeframe, or source
+- A user needs a quick New Zealand news briefing
 
 ## Do not use this for
 
@@ -28,9 +28,10 @@ Aggregate live RSS feeds from major New Zealand news websites into a single CLI 
 ## Preferred workflow
 
 1. Run `scripts/cli.ts` with the narrowest subcommand that answers the task
-2. Use default human output for direct answers
-3. Use `--json` when another tool or agent needs machine-readable output
-4. For topic-specific questions, use `topic <keyword>` to filter
+2. Start with `search` for any topic lookup, either positionally or with flags
+3. Use `--source`, `--since-hours`, `--since-date`, `--contains-all`, `--exact`, and `--exclude` when the request needs tighter matching
+4. Use default human output for direct answers
+5. Use `--json` when another tool or agent needs machine-readable output
 
 ## CLI
 
@@ -38,6 +39,27 @@ Run with:
 
 ```bash
 npx tsx skills/nz-news/scripts/cli.ts <command> [flags]
+```
+
+### Search first
+
+The easiest path for topic lookups is now `search`.
+
+Examples:
+
+```bash
+npx tsx skills/nz-news/scripts/cli.ts search cyclone
+npx tsx skills/nz-news/scripts/cli.ts search --keyword cyclone --since-hours 24
+npx tsx skills/nz-news/scripts/cli.ts search --keyword "housing market" --contains-all --source rnz,newsroom
+npx tsx skills/nz-news/scripts/cli.ts search --keyword coalition --exact --since-date 2026-04-01
+npx tsx skills/nz-news/scripts/cli.ts topic cyclone --exclude sport --limit 5
+```
+
+`topic` is kept as an alias for `search`, so both of these work:
+
+```bash
+npx tsx skills/nz-news/scripts/cli.ts topic cyclone
+npx tsx skills/nz-news/scripts/cli.ts search --keyword cyclone
 ```
 
 ### `headlines [--limit N] [--json]`
@@ -54,7 +76,7 @@ npx tsx skills/nz-news/scripts/cli.ts headlines --json
 
 ### `source <name> [--limit N] [--json]`
 
-News from a specific source. Accepts source ID (rnz, stuff, herald, spinoff, newsroom, interest) or name. Default limit: 10.
+News from a specific source. Accepts source ID (for example `rnz`, `stuff`, `herald`) or a source name. Default limit: 10.
 
 Examples:
 
@@ -64,16 +86,47 @@ npx tsx skills/nz-news/scripts/cli.ts source stuff --limit 5
 npx tsx skills/nz-news/scripts/cli.ts source herald --json
 ```
 
-### `topic <keyword> [--limit N] [--json]`
+### `search [keyword...] [flags]`
 
-Filter headlines by keyword across all primary sources. Searches titles and summaries. Default limit: 10.
+Search headlines and summaries across NZ sources. You can provide the search term positionally or with `--keyword`.
+
+Useful flags:
+
+- `--keyword <text>` for flag-based search input
+- `--source rnz,herald` to limit the search to specific feeds
+- `--since-hours <hours>` to keep only recent stories
+- `--since-date <YYYY-MM-DD or ISO timestamp>` for a fixed start date
+- `--contains-all` to require every term in a multi-word query
+- `--exact` to match an exact phrase
+- `--exclude sport,opinion` to remove unwanted terms
+- `--limit N`
+- `--json`
+
+JSON shape:
+
+- `fetchedAt`
+- `keyword`
+- `matchMode`
+- `sourcesQueried`
+- `sourcesOk`
+- `filters.sourceIds`
+- `filters.sinceHours`
+- `filters.sinceDate`
+- `filters.exclude`
+- `filters.limit`
+- `totalMatching`
+- `returnedCount`
+- `items[]` with `title`, `url`, `published`, `source`, `sourceId`, `summary`
+- `errors[]`
 
 Examples:
 
 ```bash
-npx tsx skills/nz-news/scripts/cli.ts topic cyclone
-npx tsx skills/nz-news/scripts/cli.ts topic "housing market"
-npx tsx skills/nz-news/scripts/cli.ts topic rugby --limit 5 --json
+npx tsx skills/nz-news/scripts/cli.ts search cyclone
+npx tsx skills/nz-news/scripts/cli.ts search --keyword cyclone --since-hours 24
+npx tsx skills/nz-news/scripts/cli.ts search --keyword "housing market" --contains-all --source rnz,newsroom
+npx tsx skills/nz-news/scripts/cli.ts search --keyword coalition --exact --since-date 2026-04-01
+npx tsx skills/nz-news/scripts/cli.ts topic cyclone --exclude sport --limit 5 --json
 ```
 
 ### `sources [--json]`
@@ -113,9 +166,9 @@ npx tsx skills/nz-news/scripts/cli.ts summary --json
 | rnz-national | RNZ National | RSS | Category |
 | rnz-world | RNZ World | RSS | Category |
 | rnz-sport | RNZ Sport | RSS | Category |
-| rnz-te-ao-maori | RNZ Te Ao Maori | RSS | Category |
+| rnz-te-ao-maori | RNZ Te Ao Māori | RSS | Category |
 
-Primary sources are queried by default. Category feeds (RNZ sub-feeds) are available via `source <id>` but excluded from `headlines`/`topic`/`summary` to avoid duplicates.
+Primary sources are queried by default. Category feeds (RNZ sub-feeds) are available via `source <id>` and `search --source <id>`, but excluded from `headlines` and `summary` to avoid duplicate stories.
 
 ## Setup
 
@@ -131,7 +184,7 @@ No API key required — just Node.js and `npx tsx`.
 
 - No API key required
 - Uses the built-in `fetch` available in modern Node runtimes
-- No external XML parsing dependencies — uses regex-based RSS/Atom parsing
-- Default output is human-readable; `--json` output is for chaining into other tools or agent steps
+- No external XML parsing dependencies, uses regex-based RSS and Atom parsing
+- Default output is human-readable, `--json` output is for chaining into other tools or agent steps
 - Headlines are deduplicated by normalised title across sources
 - RNZ category feeds may overlap with the main RNZ feed

--- a/skills/nz-news/scripts/cli.ts
+++ b/skills/nz-news/scripts/cli.ts
@@ -8,12 +8,32 @@ import {
   fetchFeeds,
   deduplicateItems,
   sortByDate,
-  filterByKeyword,
+  type FeedDefinition,
   type FeedResult,
   type NewsItem,
 } from './feeds.js';
 
 type CommonFlags = { json?: boolean; limit?: number };
+type SearchFlags = CommonFlags & {
+  keyword?: string;
+  sinceHours?: number;
+  sinceDate?: string;
+  containsAll?: boolean;
+  exact?: boolean;
+  exclude?: string[];
+  source?: string[];
+};
+
+type SearchFilters = {
+  keyword: string;
+  limit: number;
+  sinceHours?: number;
+  sinceDate?: string;
+  containsAll?: boolean;
+  exact?: boolean;
+  exclude: string[];
+  sourceIds: string[];
+};
 
 const nzDateTimeFormatter = new Intl.DateTimeFormat('en-NZ', {
   timeZone: 'Pacific/Auckland',
@@ -24,6 +44,13 @@ const nzDateTimeFormatter = new Intl.DateTimeFormat('en-NZ', {
   minute: '2-digit',
   hour12: true,
 });
+
+function addExamples(command: Command, examples: string[]): Command {
+  return command.addHelpText(
+    'after',
+    `\nExamples:\n${examples.map((example) => `  ${example}`).join('\n')}`,
+  );
+}
 
 function formatDate(date: Date): string {
   if (date.getTime() === 0) return 'unknown';
@@ -38,6 +65,35 @@ function parsePositiveInt(raw: string): number {
   return value;
 }
 
+function parsePositiveNumber(raw: string): number {
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`Expected a positive number, received: ${raw}`);
+  }
+  return value;
+}
+
+function parseSinceDate(raw: string): string {
+  const parsed = new Date(raw);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Expected an ISO date or date-time, received: ${raw}`);
+  }
+  return parsed.toISOString();
+}
+
+function parseCsvList(raw: string): string[] {
+  const values = raw
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  if (values.length === 0) {
+    throw new Error('Expected a comma-separated list with at least one value.');
+  }
+
+  return values;
+}
+
 function printOutput(data: unknown, json: boolean | undefined, render: () => string) {
   if (json) {
     console.log(JSON.stringify(data, null, 2));
@@ -47,15 +103,15 @@ function printOutput(data: unknown, json: boolean | undefined, render: () => str
 }
 
 function collectItems(results: FeedResult[]): NewsItem[] {
-  const all = results.flatMap((r) => r.items);
+  const all = results.flatMap((result) => result.items);
   return sortByDate(deduplicateItems(all));
 }
 
 function renderItems(items: NewsItem[], limit: number): string {
   const lines: string[] = [];
   const shown = items.slice(0, limit);
-  shown.forEach((item, i) => {
-    lines.push(`${i + 1}. ${item.title}`);
+  shown.forEach((item, index) => {
+    lines.push(`${index + 1}. ${item.title}`);
     lines.push(`   ${item.source} · ${formatDate(item.published)}`);
     lines.push(`   ${item.url}`);
   });
@@ -63,9 +119,9 @@ function renderItems(items: NewsItem[], limit: number): string {
 }
 
 function feedErrors(results: FeedResult[]): string {
-  const failed = results.filter((r) => !r.ok);
+  const failed = results.filter((result) => !result.ok);
   if (failed.length === 0) return '';
-  return '\nFailed feeds: ' + failed.map((r) => `${r.feed.name} (${r.error})`).join(', ');
+  return '\nFailed feeds: ' + failed.map((result) => `${result.feed.name} (${result.error})`).join(', ');
 }
 
 function itemsToJson(items: NewsItem[]) {
@@ -79,6 +135,142 @@ function itemsToJson(items: NewsItem[]) {
   }));
 }
 
+function normaliseSearchText(text: string): string {
+  return text
+    .replace(/<[^>]+>/g, ' ')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function searchableText(item: NewsItem): string {
+  return normaliseSearchText(`${item.title} ${item.summary ?? ''}`);
+}
+
+function matchesKeyword(item: NewsItem, filters: SearchFilters): boolean {
+  const haystack = searchableText(item);
+  const keyword = normaliseSearchText(filters.keyword);
+
+  if (!keyword) return true;
+
+  if (filters.exact) {
+    const exactPattern = new RegExp(`(^| )${escapeRegExp(keyword).replace(/ /g, ' +')}( |$)`, 'i');
+    return exactPattern.test(haystack);
+  }
+
+  if (filters.containsAll) {
+    const terms = keyword.split(' ').filter(Boolean);
+    return terms.every((term) => haystack.includes(term));
+  }
+
+  return haystack.includes(keyword);
+}
+
+function withinSinceWindow(item: NewsItem, filters: SearchFilters): boolean {
+  if (item.published.getTime() === 0) return false;
+
+  if (typeof filters.sinceHours === 'number') {
+    const cutoff = Date.now() - filters.sinceHours * 60 * 60 * 1000;
+    return item.published.getTime() >= cutoff;
+  }
+
+  if (filters.sinceDate) {
+    return item.published.getTime() >= Date.parse(filters.sinceDate);
+  }
+
+  return true;
+}
+
+function passesExcludeFilter(item: NewsItem, filters: SearchFilters): boolean {
+  if (filters.exclude.length === 0) return true;
+  const haystack = searchableText(item);
+  return !filters.exclude.some((term) => haystack.includes(normaliseSearchText(term)));
+}
+
+function applySearchFilters(items: NewsItem[], filters: SearchFilters): NewsItem[] {
+  return items.filter(
+    (item) => withinSinceWindow(item, filters) && passesExcludeFilter(item, filters) && matchesKeyword(item, filters),
+  );
+}
+
+function resolveFeed(name: string): FeedDefinition | undefined {
+  const lower = name.toLowerCase();
+  const exact = FEEDS.find((feed) => feed.id === lower || feed.name.toLowerCase() === lower);
+  if (exact) return exact;
+
+  const partialMatches = FEEDS.filter(
+    (feed) => feed.id.startsWith(lower) || feed.name.toLowerCase().includes(lower),
+  );
+
+  return partialMatches.length === 1 ? partialMatches[0] : undefined;
+}
+
+function resolveSources(rawSources?: string[]): FeedDefinition[] {
+  if (!rawSources || rawSources.length === 0) {
+    return FEEDS.filter((feed) => PRIMARY_FEED_IDS.includes(feed.id));
+  }
+
+  const resolved = rawSources.map((rawSource) => {
+    const feed = resolveFeed(rawSource);
+    if (!feed) {
+      throw new Error(`Unknown source: "${rawSource}". Run "nz-news sources" to see available sources.`);
+    }
+    return feed;
+  });
+
+  return resolved.filter((feed, index) => resolved.findIndex((candidate) => candidate.id === feed.id) === index);
+}
+
+function getKeyword(keywordParts: string[], keywordFlag?: string): string {
+  const positional = keywordParts.join(' ').trim();
+  const flag = keywordFlag?.trim() ?? '';
+
+  if (positional && flag) {
+    throw new Error('Use either a positional search term or --keyword, not both.');
+  }
+
+  const keyword = positional || flag;
+  if (!keyword) {
+    throw new Error('A search keyword is required. Try "nz-news search cyclone" or "nz-news search --keyword cyclone".');
+  }
+
+  return keyword;
+}
+
+function getMatchMode(filters: SearchFilters): 'substring' | 'contains-all' | 'exact' {
+  if (filters.exact) return 'exact';
+  if (filters.containsAll) return 'contains-all';
+  return 'substring';
+}
+
+function formatSearchFilters(filters: SearchFilters, feeds: FeedDefinition[]): string[] {
+  const lines: string[] = [];
+  if (feeds.length > 0 && feeds.length !== PRIMARY_FEED_IDS.length) {
+    lines.push(`Sources: ${feeds.map((feed) => feed.id).join(', ')}`);
+  }
+  if (typeof filters.sinceHours === 'number') {
+    lines.push(`Since: last ${filters.sinceHours} hour${filters.sinceHours === 1 ? '' : 's'}`);
+  }
+  if (filters.sinceDate) {
+    lines.push(`Since date: ${filters.sinceDate}`);
+  }
+  if (filters.containsAll) {
+    lines.push('Match mode: all search terms must appear');
+  }
+  if (filters.exact) {
+    lines.push('Match mode: exact phrase');
+  }
+  if (filters.exclude.length > 0) {
+    lines.push(`Exclude: ${filters.exclude.join(', ')}`);
+  }
+  return lines;
+}
+
 const program = new Command();
 
 program
@@ -86,183 +278,264 @@ program
   .description('Aggregate RSS feeds from New Zealand news websites.')
   .showHelpAfterError('(add --help for usage)');
 
-program
-  .command('headlines')
-  .description('Top headlines across all primary sources, deduplicated and sorted by date.')
-  .option('--limit <n>', 'number of items to show', parsePositiveInt, 10)
-  .option('--json', 'emit machine-readable JSON')
-  .action(async (options: CommonFlags) => {
-    const limit = options.limit ?? 10;
-    const results = await fetchFeeds();
-    const items = collectItems(results);
-    const shown = items.slice(0, limit);
+addExamples(program, [
+  'npx tsx skills/nz-news/scripts/cli.ts headlines',
+  'npx tsx skills/nz-news/scripts/cli.ts search cyclone',
+  'npx tsx skills/nz-news/scripts/cli.ts search --keyword cyclone --since-hours 24',
+  'npx tsx skills/nz-news/scripts/cli.ts search --keyword "housing market" --contains-all --source rnz,newsroom',
+  'npx tsx skills/nz-news/scripts/cli.ts topic cyclone --exclude sport --limit 5',
+  'npx tsx skills/nz-news/scripts/cli.ts sources',
+]);
 
-    const output = {
-      fetchedAt: new Date().toISOString(),
-      sourcesQueried: results.length,
-      sourcesOk: results.filter((r) => r.ok).length,
-      totalItems: items.length,
-      returnedCount: shown.length,
-      items: itemsToJson(shown),
-      errors: results.filter((r) => !r.ok).map((r) => ({ source: r.feed.name, error: r.error })),
-    };
+addExamples(
+  program
+    .command('headlines')
+    .description('Top headlines across all primary sources, deduplicated and sorted by date.')
+    .option('--limit <n>', 'number of items to show', parsePositiveInt, 10)
+    .option('--json', 'emit machine-readable JSON')
+    .action(async (options: CommonFlags) => {
+      const limit = options.limit ?? 10;
+      const results = await fetchFeeds();
+      const items = collectItems(results);
+      const shown = items.slice(0, limit);
 
-    printOutput(output, options.json, () => {
-      const lines = [`NZ Headlines — ${shown.length} of ${items.length} stories from ${output.sourcesOk} sources`];
-      lines.push('');
-      lines.push(renderItems(items, limit));
-      lines.push(feedErrors(results));
-      return lines.join('\n');
-    });
-  });
+      const output = {
+        fetchedAt: new Date().toISOString(),
+        sourcesQueried: results.length,
+        sourcesOk: results.filter((result) => result.ok).length,
+        totalItems: items.length,
+        returnedCount: shown.length,
+        items: itemsToJson(shown),
+        errors: results.filter((result) => !result.ok).map((result) => ({ source: result.feed.name, error: result.error })),
+      };
 
-program
-  .command('source <name>')
-  .description('News from a specific source. Use "sources" command to list available names.')
-  .option('--limit <n>', 'number of items to show', parsePositiveInt, 10)
-  .option('--json', 'emit machine-readable JSON')
-  .action(async (name: string, options: CommonFlags) => {
-    const lower = name.toLowerCase();
-    const feed = FEEDS.find(
-      (f) => f.id === lower || f.name.toLowerCase() === lower || f.id.startsWith(lower),
-    );
-    if (!feed) {
-      console.error(`Unknown source: "${name}". Run "nz-news sources" to see available sources.`);
-      process.exit(1);
-    }
-    const limit = options.limit ?? 10;
-    const result = await fetchFeed(feed);
-    if (!result.ok) {
-      console.error(`Failed to fetch ${feed.name}: ${result.error}`);
-      process.exit(1);
-    }
-    const items = sortByDate(result.items).slice(0, limit);
-
-    const output = {
-      fetchedAt: new Date().toISOString(),
-      source: feed.name,
-      sourceId: feed.id,
-      totalItems: result.items.length,
-      returnedCount: items.length,
-      items: itemsToJson(items),
-    };
-
-    printOutput(output, options.json, () => {
-      const lines = [`${feed.name} — ${items.length} of ${result.items.length} stories`];
-      lines.push('');
-      lines.push(renderItems(items, limit));
-      return lines.join('\n');
-    });
-  });
-
-program
-  .command('topic <keyword>')
-  .description('Filter headlines by keyword across all primary sources.')
-  .option('--limit <n>', 'number of items to show', parsePositiveInt, 10)
-  .option('--json', 'emit machine-readable JSON')
-  .action(async (keyword: string, options: CommonFlags) => {
-    const limit = options.limit ?? 10;
-    const results = await fetchFeeds();
-    const all = collectItems(results);
-    const filtered = filterByKeyword(all, keyword);
-    const shown = filtered.slice(0, limit);
-
-    const output = {
-      fetchedAt: new Date().toISOString(),
-      keyword,
-      sourcesQueried: results.length,
-      sourcesOk: results.filter((r) => r.ok).length,
-      totalMatching: filtered.length,
-      returnedCount: shown.length,
-      items: itemsToJson(shown),
-      errors: results.filter((r) => !r.ok).map((r) => ({ source: r.feed.name, error: r.error })),
-    };
-
-    printOutput(output, options.json, () => {
-      const lines = [`NZ News: "${keyword}" — ${filtered.length} matching stories`];
-      lines.push('');
-      if (shown.length === 0) {
-        lines.push('No stories matched that keyword.');
-      } else {
-        lines.push(renderItems(filtered, limit));
-      }
-      lines.push(feedErrors(results));
-      return lines.join('\n');
-    });
-  });
-
-program
-  .command('sources')
-  .description('List all available news sources with live status check.')
-  .option('--json', 'emit machine-readable JSON')
-  .action(async (options: { json?: boolean }) => {
-    const results = await Promise.all(FEEDS.map(fetchFeed));
-
-    const sourceList = results.map((r) => ({
-      id: r.feed.id,
-      name: r.feed.name,
-      url: r.feed.url,
-      format: r.feed.format,
-      category: r.feed.category ?? null,
-      primary: PRIMARY_FEED_IDS.includes(r.feed.id),
-      status: r.ok ? 'ok' : 'error',
-      itemCount: r.items.length,
-      error: r.error ?? null,
-      durationMs: r.durationMs,
-    }));
-
-    const output = {
-      fetchedAt: new Date().toISOString(),
-      totalSources: sourceList.length,
-      working: sourceList.filter((s) => s.status === 'ok').length,
-      failed: sourceList.filter((s) => s.status === 'error').length,
-      sources: sourceList,
-    };
-
-    printOutput(output, options.json, () => {
-      const lines = [`NZ News Sources — ${output.working}/${output.totalSources} working`];
-      lines.push('');
-      for (const s of sourceList) {
-        const status = s.status === 'ok' ? `✓ ${s.itemCount} items` : `✗ ${s.error}`;
-        const primary = s.primary ? '' : ' (category feed)';
-        lines.push(`  ${s.id.padEnd(18)} ${s.name.padEnd(20)} ${status}${primary}`);
-      }
-      return lines.join('\n');
-    });
-  });
-
-program
-  .command('summary')
-  .description('Brief summary: story count, source count, and top 5 headlines.')
-  .option('--json', 'emit machine-readable JSON')
-  .action(async (options: { json?: boolean }) => {
-    const results = await fetchFeeds();
-    const items = collectItems(results);
-    const top5 = items.slice(0, 5);
-    const okSources = results.filter((r) => r.ok);
-
-    const output = {
-      fetchedAt: new Date().toISOString(),
-      sourcesQueried: results.length,
-      sourcesOk: okSources.length,
-      totalStories: items.length,
-      top5: itemsToJson(top5),
-      errors: results.filter((r) => !r.ok).map((r) => ({ source: r.feed.name, error: r.error })),
-    };
-
-    printOutput(output, options.json, () => {
-      const lines = [
-        `NZ News Summary — ${items.length} stories from ${okSources.length} sources`,
-        '',
-        'Top 5 headlines:',
-      ];
-      top5.forEach((item, i) => {
-        lines.push(`  ${i + 1}. ${item.title} (${item.source})`);
+      printOutput(output, options.json, () => {
+        const lines = [`NZ Headlines — ${shown.length} of ${items.length} stories from ${output.sourcesOk} sources`];
+        lines.push('');
+        lines.push(renderItems(items, limit));
+        lines.push(feedErrors(results));
+        return lines.join('\n');
       });
-      lines.push(feedErrors(results));
-      return lines.join('\n');
-    });
-  });
+    }),
+  [
+    'npx tsx skills/nz-news/scripts/cli.ts headlines',
+    'npx tsx skills/nz-news/scripts/cli.ts headlines --limit 20',
+    'npx tsx skills/nz-news/scripts/cli.ts headlines --json',
+  ],
+);
+
+addExamples(
+  program
+    .command('source <name>')
+    .description('News from a specific source. Use "sources" to list available names and IDs.')
+    .option('--limit <n>', 'number of items to show', parsePositiveInt, 10)
+    .option('--json', 'emit machine-readable JSON')
+    .action(async (name: string, options: CommonFlags) => {
+      const feed = resolveFeed(name);
+      if (!feed) {
+        console.error(`Unknown source: "${name}". Run "nz-news sources" to see available sources.`);
+        process.exit(1);
+      }
+      const limit = options.limit ?? 10;
+      const result = await fetchFeed(feed);
+      if (!result.ok) {
+        console.error(`Failed to fetch ${feed.name}: ${result.error}`);
+        process.exit(1);
+      }
+      const items = sortByDate(result.items).slice(0, limit);
+
+      const output = {
+        fetchedAt: new Date().toISOString(),
+        source: feed.name,
+        sourceId: feed.id,
+        totalItems: result.items.length,
+        returnedCount: items.length,
+        items: itemsToJson(items),
+      };
+
+      printOutput(output, options.json, () => {
+        const lines = [`${feed.name} — ${items.length} of ${result.items.length} stories`];
+        lines.push('');
+        lines.push(renderItems(items, limit));
+        return lines.join('\n');
+      });
+    }),
+  [
+    'npx tsx skills/nz-news/scripts/cli.ts source rnz',
+    'npx tsx skills/nz-news/scripts/cli.ts source stuff --limit 5',
+    'npx tsx skills/nz-news/scripts/cli.ts source herald --json',
+  ],
+);
+
+addExamples(
+  program
+    .command('search [keyword...]')
+    .alias('topic')
+    .description('Search headlines and summaries across NZ sources. Accepts either a positional keyword or --keyword.')
+    .option('--keyword <text>', 'search phrase, when you prefer flags over a positional argument')
+    .option('--source <ids>', 'comma-separated source IDs or names, for example rnz,herald', parseCsvList)
+    .option('--since-hours <hours>', 'only include stories from the last N hours', parsePositiveNumber)
+    .option('--since-date <date>', 'only include stories on or after this ISO date or date-time', parseSinceDate)
+    .option('--contains-all', 'for multi-word searches, require every search term to appear')
+    .option('--exact', 'match the exact phrase instead of a loose substring search')
+    .option('--exclude <terms>', 'comma-separated terms to exclude from title or summary matches', parseCsvList)
+    .option('--limit <n>', 'number of items to show', parsePositiveInt, 10)
+    .option('--json', 'emit machine-readable JSON')
+    .action(async (keywordParts: string[], options: SearchFlags) => {
+      if (options.containsAll && options.exact) {
+        throw new Error('Use either --contains-all or --exact, not both.');
+      }
+      if (typeof options.sinceHours === 'number' && options.sinceDate) {
+        throw new Error('Use either --since-hours or --since-date, not both.');
+      }
+
+      const keyword = getKeyword(keywordParts, options.keyword);
+      const feeds = resolveSources(options.source);
+      const limit = options.limit ?? 10;
+      const filters: SearchFilters = {
+        keyword,
+        limit,
+        sinceHours: options.sinceHours,
+        sinceDate: options.sinceDate,
+        containsAll: Boolean(options.containsAll),
+        exact: Boolean(options.exact),
+        exclude: options.exclude ?? [],
+        sourceIds: feeds.map((feed) => feed.id),
+      };
+
+      const results = await fetchFeeds(filters.sourceIds);
+      const all = collectItems(results);
+      const filtered = applySearchFilters(all, filters);
+      const shown = filtered.slice(0, limit);
+
+      const output = {
+        fetchedAt: new Date().toISOString(),
+        keyword,
+        matchMode: getMatchMode(filters),
+        sourcesQueried: results.length,
+        sourcesOk: results.filter((result) => result.ok).length,
+        filters: {
+          sourceIds: filters.sourceIds,
+          sinceHours: filters.sinceHours ?? null,
+          sinceDate: filters.sinceDate ?? null,
+          exclude: filters.exclude,
+          limit,
+        },
+        totalMatching: filtered.length,
+        returnedCount: shown.length,
+        items: itemsToJson(shown),
+        errors: results.filter((result) => !result.ok).map((result) => ({ source: result.feed.name, error: result.error })),
+      };
+
+      printOutput(output, options.json, () => {
+        const lines = [`NZ News search: "${keyword}" — ${filtered.length} matching stories`];
+        const filterLines = formatSearchFilters(filters, feeds);
+        if (filterLines.length > 0) {
+          lines.push(...filterLines);
+        }
+        lines.push('');
+        if (shown.length === 0) {
+          lines.push('No stories matched those filters.');
+        } else {
+          lines.push(renderItems(filtered, limit));
+        }
+        lines.push(feedErrors(results));
+        return lines.join('\n');
+      });
+    }),
+  [
+    'npx tsx skills/nz-news/scripts/cli.ts search cyclone',
+    'npx tsx skills/nz-news/scripts/cli.ts search --keyword cyclone --since-hours 24',
+    'npx tsx skills/nz-news/scripts/cli.ts search --keyword "housing market" --contains-all --source rnz,newsroom',
+    'npx tsx skills/nz-news/scripts/cli.ts search --keyword coalition --exact --since-date 2026-04-01',
+    'npx tsx skills/nz-news/scripts/cli.ts topic cyclone --exclude sport --limit 5 --json',
+  ],
+);
+
+addExamples(
+  program
+    .command('sources')
+    .description('List all available news sources with a live status check.')
+    .option('--json', 'emit machine-readable JSON')
+    .action(async (options: { json?: boolean }) => {
+      const results = await Promise.all(FEEDS.map(fetchFeed));
+
+      const sourceList = results.map((result) => ({
+        id: result.feed.id,
+        name: result.feed.name,
+        url: result.feed.url,
+        format: result.feed.format,
+        category: result.feed.category ?? null,
+        primary: PRIMARY_FEED_IDS.includes(result.feed.id),
+        status: result.ok ? 'ok' : 'error',
+        itemCount: result.items.length,
+        error: result.error ?? null,
+        durationMs: result.durationMs,
+      }));
+
+      const output = {
+        fetchedAt: new Date().toISOString(),
+        totalSources: sourceList.length,
+        working: sourceList.filter((source) => source.status === 'ok').length,
+        failed: sourceList.filter((source) => source.status === 'error').length,
+        sources: sourceList,
+      };
+
+      printOutput(output, options.json, () => {
+        const lines = [`NZ News Sources — ${output.working}/${output.totalSources} working`];
+        lines.push('');
+        for (const source of sourceList) {
+          const status = source.status === 'ok' ? `✓ ${source.itemCount} items` : `✗ ${source.error}`;
+          const primary = source.primary ? '' : ' (category feed)';
+          lines.push(`  ${source.id.padEnd(18)} ${source.name.padEnd(20)} ${status}${primary}`);
+        }
+        return lines.join('\n');
+      });
+    }),
+  [
+    'npx tsx skills/nz-news/scripts/cli.ts sources',
+    'npx tsx skills/nz-news/scripts/cli.ts sources --json',
+  ],
+);
+
+addExamples(
+  program
+    .command('summary')
+    .description('Brief summary: story count, source count, and top 5 headlines.')
+    .option('--json', 'emit machine-readable JSON')
+    .action(async (options: { json?: boolean }) => {
+      const results = await fetchFeeds();
+      const items = collectItems(results);
+      const top5 = items.slice(0, 5);
+      const okSources = results.filter((result) => result.ok);
+
+      const output = {
+        fetchedAt: new Date().toISOString(),
+        sourcesQueried: results.length,
+        sourcesOk: okSources.length,
+        totalStories: items.length,
+        top5: itemsToJson(top5),
+        errors: results.filter((result) => !result.ok).map((result) => ({ source: result.feed.name, error: result.error })),
+      };
+
+      printOutput(output, options.json, () => {
+        const lines = [
+          `NZ News Summary — ${items.length} stories from ${okSources.length} sources`,
+          '',
+          'Top 5 headlines:',
+        ];
+        top5.forEach((item, index) => {
+          lines.push(`  ${index + 1}. ${item.title} (${item.source})`);
+        });
+        lines.push(feedErrors(results));
+        return lines.join('\n');
+      });
+    }),
+  [
+    'npx tsx skills/nz-news/scripts/cli.ts summary',
+    'npx tsx skills/nz-news/scripts/cli.ts summary --json',
+  ],
+);
 
 async function main() {
   await program.parseAsync(process.argv);

--- a/skills/nz-news/scripts/smoke-test.ts
+++ b/skills/nz-news/scripts/smoke-test.ts
@@ -9,6 +9,7 @@ import {
   deduplicateItems,
   sortByDate,
   filterByKeyword,
+  type NewsItem,
 } from './feeds.js';
 
 function assert(condition: unknown, message: string): asserts condition {
@@ -30,11 +31,39 @@ function runCliJson(args: string[]) {
   return JSON.parse(stdout) as Record<string, unknown>;
 }
 
+function getSearchCase(items: NewsItem[]) {
+  const candidate = items.find((item) => {
+    if (!PRIMARY_FEED_IDS.includes(item.sourceId)) return false;
+    if (item.published.getTime() === 0) return false;
+    const words = item.title
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .split(' ')
+      .filter((word) => word.length >= 4);
+    return words.length >= 2;
+  });
+
+  assert(candidate, 'Expected at least one usable live item for search tests');
+
+  const words = candidate.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .split(' ')
+    .filter((word) => word.length >= 4);
+
+  return {
+    item: candidate,
+    singleWord: words[0],
+    phrase: `${words[0]} ${words[1]}`,
+    sinceDate: candidate.published.toISOString().slice(0, 10),
+  };
+}
+
 async function main() {
   console.log('Testing feed library...');
 
-  // Test individual feed fetch (RNZ is reliable)
-  const rnzFeed = FEEDS.find((f) => f.id === 'rnz')!;
+  const rnzFeed = FEEDS.find((feed) => feed.id === 'rnz');
+  assert(rnzFeed, 'Expected RNZ feed definition to exist');
   const rnzResult = await fetchFeed(rnzFeed);
   assert(rnzResult.ok, `RNZ feed should succeed, got: ${rnzResult.error}`);
   assert(rnzResult.items.length > 0, 'RNZ feed should return items');
@@ -42,59 +71,80 @@ async function main() {
   assert(rnzResult.items[0].url.startsWith('http'), 'RNZ items should have URLs');
   console.log(`  ✓ RNZ feed: ${rnzResult.items.length} items`);
 
-  // Test primary feeds
   const primaryResults = await fetchFeeds();
-  const okCount = primaryResults.filter((r) => r.ok).length;
+  const okCount = primaryResults.filter((result) => result.ok).length;
   assert(okCount >= 3, `At least 3 primary feeds should work, got ${okCount}`);
   console.log(`  ✓ Primary feeds: ${okCount}/${primaryResults.length} ok`);
 
-  // Test deduplication
-  const allItems = primaryResults.flatMap((r) => r.items);
+  const allItems = primaryResults.flatMap((result) => result.items);
   const deduped = deduplicateItems(allItems);
   assert(deduped.length <= allItems.length, 'Deduplicated count should be <= total');
   assert(deduped.length > 0, 'Should have items after dedup');
   console.log(`  ✓ Dedup: ${allItems.length} → ${deduped.length} items`);
 
-  // Test sort
   const sorted = sortByDate(deduped);
   assert(sorted[0].published >= sorted[sorted.length - 1].published, 'Should be sorted newest first');
   console.log('  ✓ Sort: newest first');
 
-  // Test keyword filter
   const filtered = filterByKeyword(allItems, 'new zealand');
   console.log(`  ✓ Keyword filter "new zealand": ${filtered.length} matches`);
 
+  const searchCase = getSearchCase(sorted);
+  console.log(`  ✓ Search case picked: "${searchCase.phrase}" from ${searchCase.item.sourceId}`);
+
   console.log('\nTesting CLI commands...');
 
-  // Test headlines
   const headlinesJson = runCliJson(['headlines', '--limit', '5']);
   assert(typeof headlinesJson.sourcesOk === 'number', 'headlines JSON must include sourcesOk');
   assert(Array.isArray(headlinesJson.items), 'headlines JSON must include items array');
   assert((headlinesJson.items as unknown[]).length <= 5, 'headlines should respect --limit');
   console.log(`  ✓ headlines --limit 5: ${(headlinesJson.items as unknown[]).length} items`);
 
-  // Test source
   const sourceJson = runCliJson(['source', 'rnz', '--limit', '3']);
   assert(sourceJson.sourceId === 'rnz', 'source should return rnz');
   assert(Array.isArray(sourceJson.items), 'source JSON must include items array');
   console.log(`  ✓ source rnz --limit 3: ${(sourceJson.items as unknown[]).length} items`);
 
-  // Test sources
   const sourcesJson = runCliJson(['sources']);
   assert(typeof sourcesJson.working === 'number', 'sources JSON must include working count');
   assert(Array.isArray(sourcesJson.sources), 'sources JSON must include sources array');
   console.log(`  ✓ sources: ${sourcesJson.working}/${sourcesJson.totalSources} working`);
 
-  // Test summary
   const summaryJson = runCliJson(['summary']);
   assert(typeof summaryJson.totalStories === 'number', 'summary JSON must include totalStories');
   assert(Array.isArray(summaryJson.top5), 'summary JSON must include top5 array');
   console.log(`  ✓ summary: ${summaryJson.totalStories} stories, ${(summaryJson.top5 as unknown[]).length} top headlines`);
 
-  // Test topic
-  const topicJson = runCliJson(['topic', 'zealand']);
+  const topicJson = runCliJson(['topic', searchCase.singleWord, '--source', searchCase.item.sourceId]);
   assert(typeof topicJson.totalMatching === 'number', 'topic JSON must include totalMatching');
-  console.log(`  ✓ topic "zealand": ${topicJson.totalMatching} matches`);
+  assert((topicJson.totalMatching as number) >= 1, 'topic alias should find at least one match');
+  console.log(`  ✓ topic alias: ${topicJson.totalMatching} matches for ${searchCase.singleWord}`);
+
+  const searchJson = runCliJson([
+    'search',
+    '--keyword',
+    searchCase.phrase,
+    '--contains-all',
+    '--source',
+    searchCase.item.sourceId,
+    '--since-date',
+    searchCase.sinceDate,
+  ]);
+  assert(typeof searchJson.totalMatching === 'number', 'search JSON must include totalMatching');
+  assert((searchJson.totalMatching as number) >= 1, 'search should find at least one match');
+  assert((searchJson.matchMode as string) === 'contains-all', 'search should report contains-all mode');
+  console.log(`  ✓ search filters: ${searchJson.totalMatching} matches for "${searchCase.phrase}"`);
+
+  const exactJson = runCliJson([
+    'search',
+    '--keyword',
+    searchCase.phrase,
+    '--exact',
+    '--source',
+    searchCase.item.sourceId,
+  ]);
+  assert((exactJson.matchMode as string) === 'exact', 'exact search should report exact mode');
+  console.log(`  ✓ exact search: ${exactJson.totalMatching} matches for "${searchCase.phrase}"`);
 
   console.log('\nNZ News smoke test passed.');
 }


### PR DESCRIPTION
## Summary
- make nz-news search more discoverable with a clear search command alias, richer filters, and clearer help/docs
- keep fuelclock-nz focused on prices, supply, and vessels
- move fuel headlines and geopolitical watch signals into a new fuelclock-nz-watch companion skill

## Validation
- npm run typecheck
- npm run validate-skill -- skills
- npx tsx skills/nz-news/scripts/smoke-test.ts
- npx tsx skills/fuelclock-nz/scripts/smoke-test.ts
- npx tsx skills/fuelclock-nz-watch/scripts/smoke-test.ts
- live CLI checks for nz-news, fuelclock-nz, and fuelclock-nz-watch