### PR TITLE
fix: restore typecheck and custom validate-skill paths

### DIFF
--- a/scripts/new-skill.ts
+++ b/scripts/new-skill.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { Command } from 'commander';
 import { cpSync, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, statSync, writeFileSync, chmodSync } from 'node:fs';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -47,6 +47,11 @@ function walk(dir: string): string[] {
   return results;
 }
 
+function displayPath(path: string): string {
+  const rel = relative(repoRoot, path);
+  return rel === '' || (!rel.startsWith('..') && rel !== '.') ? (rel || '.') : path;
+}
+
 function scaffoldSkill(options: { name: string; variant: Variant; path: string; force: boolean }) {
   const name = normalizeName(options.name);
   if (!name) throw new Error('Skill name must include at least one letter or digit.');
@@ -77,7 +82,7 @@ function scaffoldSkill(options: { name: string; variant: Variant; path: string; 
   }
 
   console.log(`[OK] Created ${options.variant} skill scaffold at ${targetDir}`);
-  console.log('[NEXT] Fill in the description, remove placeholders, and run validate-skill before review.');
+  console.log(`[NEXT] Fill in the description, remove placeholders, then run: npm run validate-skill -- ${displayPath(targetDir)}`);
 }
 
 const program = new Command();

--- a/scripts/validate-skill.ts
+++ b/scripts/validate-skill.ts
@@ -25,6 +25,17 @@ type ValidationResult = {
   warnings: string[];
 };
 
+function displayPath(path: string): string {
+  const rel = relative(repoRoot, path);
+  return rel === '' || (!rel.startsWith('..') && rel !== '.') ? (rel || '.') : path;
+}
+
+function listSkillDirs(dir: string): string[] {
+  return readdirSync(dir)
+    .map((entry) => join(dir, entry))
+    .filter((entry) => statSync(entry).isDirectory() && existsSync(join(entry, 'SKILL.md')));
+}
+
 function walk(dir: string): string[] {
   const out: string[] = [];
   for (const entry of readdirSync(dir)) {
@@ -55,11 +66,15 @@ function resolveSkillDirs(targetPath: string): string[] {
     ? absolute
     : join(absolute, 'skills');
 
-  if (!existsSync(skillsDir)) throw new Error(`No skill directory found at: ${absolute}`);
+  if (existsSync(skillsDir)) {
+    const skillDirs = listSkillDirs(skillsDir);
+    if (skillDirs.length > 0) return skillDirs;
+  }
 
-  return readdirSync(skillsDir)
-    .map((entry) => join(skillsDir, entry))
-    .filter((entry) => statSync(entry).isDirectory() && existsSync(join(entry, 'SKILL.md')));
+  const directSkillDirs = listSkillDirs(absolute);
+  if (directSkillDirs.length > 0) return directSkillDirs;
+
+  throw new Error(`No skill directory found at: ${absolute}`);
 }
 
 function validateFrontmatter(frontmatter: Record<string, unknown>, result: ValidationResult) {
@@ -103,7 +118,7 @@ function validateLinks(skillDir: string, filePath: string, content: string, resu
 
 function validateSkill(skillDir: string): ValidationResult {
   const result: ValidationResult = {
-    skill: relative(repoRoot, skillDir),
+    skill: displayPath(skillDir),
     errors: [],
     warnings: [],
   };

--- a/skills/at-transport/scripts/client.ts
+++ b/skills/at-transport/scripts/client.ts
@@ -148,7 +148,7 @@ export async function getStops(): Promise<Stop[]> {
 
 export async function getStop(stopId: string): Promise<Stop> {
   const data = await getJson<{ data: { attributes: Stop } }>(`/gtfs/v3/stops/${stopId}`);
-  return data.attributes;
+  return data.data.attributes;
 }
 
 export async function getRoutesMap(): Promise<Map<string, Route>> {
@@ -160,7 +160,7 @@ export async function getRoutesMap(): Promise<Map<string, Route>> {
 
 export async function getRoute(routeId: string): Promise<Route> {
   const data = await getJson<{ data: { attributes: Route } }>(`/gtfs/v3/routes/${routeId}`);
-  return data.attributes;
+  return data.data.attributes;
 }
 
 export async function searchStops(query: string): Promise<Stop[]> {

--- a/skills/metservice-nz/scripts/client.ts
+++ b/skills/metservice-nz/scripts/client.ts
@@ -4,6 +4,10 @@ const API_BASE = 'https://forecast-v2.metoceanapi.com/point/time';
 const API_KEY = process.env.METOCEAN_API_KEY;
 if (!API_KEY) throw new Error('METOCEAN_API_KEY env var not set. Sign up at https://forecast-v2.metoceanapi.com and add it to your .env');
 const DEFAULT_TIMEOUT_MS = 15_000;
+const DEFAULT_HEADERS: Record<string, string> = {
+  'x-api-key': API_KEY,
+  'Content-Type': 'application/json',
+};
 
 export interface Location {
   name: string;
@@ -51,10 +55,7 @@ export async function queryPointTime(request: PointTimeRequest): Promise<PointTi
   try {
     const response = await fetch(API_BASE, {
       method: 'POST',
-      headers: {
-        'x-api-key': API_KEY,
-        'Content-Type': 'application/json',
-      },
+      headers: DEFAULT_HEADERS,
       body: JSON.stringify(request),
       signal: controller.signal,
     });
@@ -477,16 +478,19 @@ export async function fetchCycloneData(location: Location, hours: number = 48): 
     rainMmH: rainArr[i] !== null && rainArr[i] !== undefined ? Math.max(0, rainArr[i]!) : null,
   }));
 
-  const current = hoursList[0] ?? {
-    pressureHpa: null, windSpeedKmh: null, gustSpeedKmh: null,
-    windDirDeg: null, waveHeightM: null, swellHeightM: null,
-    wavePeriodS: null, rainMmH: null,
-  };
+  const current = hoursList[0];
 
   return {
     location,
-    time: times[0] ?? from,
-    ...current,
+    time: current?.time ?? times[0] ?? from,
+    pressureHpa: current?.pressureHpa ?? null,
+    windSpeedKmh: current?.windSpeedKmh ?? null,
+    gustSpeedKmh: current?.gustSpeedKmh ?? null,
+    windDirDeg: current?.windDirDeg ?? null,
+    waveHeightM: current?.waveHeightM ?? null,
+    swellHeightM: current?.swellHeightM ?? null,
+    wavePeriodS: current?.wavePeriodS ?? null,
+    rainMmH: current?.rainMmH ?? null,
     hours: hoursList,
   };
 }


### PR DESCRIPTION
## Summary
- fix the root TypeScript errors in the AT and Metservice clients
- let `validate-skill` validate custom parent directories created via `new-skill --path ...`
- improve scaffold follow-up output so it prints the exact validation command to run

## Testing
- `npm run typecheck`
- `npm run validate-skill -- skills`
- `npm run new-skill -- demo-path-skill --variant minimal --path /tmp/skills-scaffold-LjCKrU`
- `npm run validate-skill -- /tmp/skills-scaffold-LjCKrU` (expected placeholder error from fresh scaffold)
- `npm run validate-skill -- /tmp/skills-scaffold-LjCKrU/demo-path-skill` (expected placeholder error from fresh scaffold)
- `npx tsx skills/at-transport/scripts/smoke-test.ts`
- `npx tsx skills/fuelclock-nz/scripts/smoke-test.ts`
- `npx tsx skills/nz-news/scripts/smoke-test.ts`
- `source /tmp/rex-metservice.env && npx tsx skills/metservice-nz/scripts/smoke-test.ts`

The scaffold validation still fails intentionally until placeholder content is replaced. The fix here is the path resolution and ergonomics, not weakening placeholder enforcement.
