### PR TITLE
fix(woolworths-nz): apply query filter to specials command

### DIFF
--- a/skills/woolworths-nz/scripts/cli.py
+++ b/skills/woolworths-nz/scripts/cli.py
@@ -191,7 +191,18 @@ def cmd_search(args: argparse.Namespace) -> None:
 
 
 def cmd_specials(args: argparse.Namespace) -> None:
-    data = products_query("specials", search=args.query, limit=args.limit, page=args.page, in_stock_only=args.in_stock_only)
+    if args.query:
+        # The upstream specials endpoint ignores the search parameter, so when the
+        # user supplies a query we use the search target and filter to specials
+        # client-side. Fetch up to the API max so the filter has enough to work with.
+        fetch_size = max(args.limit * 4, 24)
+        data = products_query("search", search=args.query, limit=fetch_size, page=args.page, in_stock_only=args.in_stock_only)
+        specials_only = [p for p in data["products"] if p.get("is_special")]
+        data["products"] = specials_only[:args.limit]
+        data["count"] = len(data["products"])
+        data["target"] = "specials"
+    else:
+        data = products_query("specials", limit=args.limit, page=args.page, in_stock_only=args.in_stock_only)
     emit(data, args.json)
 
 


### PR DESCRIPTION
## Summary
- `specials <query>` was ignoring its query argument because the upstream Woolworths NZ API silently drops the `search` parameter when `target=specials`.
- Reproduced: `python3 scripts/cli.py specials cheese` returned Clean Collective energy drinks and Nivea body lotion, not cheese.
- Fix: when a query is supplied, route through `target=search` and filter the response to `is_special=true` client-side. We fetch a slightly larger page (`max(limit*4, 24)`) so the filter has enough to work with. No-query behaviour is unchanged.

## Test plan
- [x] `specials cheese --limit 5` returns 5 cheese specials (Mainland tasty grated \$8.50 was \$10, colby \$7 was \$8, etc)
- [x] `specials` with no query still returns the general specials list
- [x] `search milk --limit 5` unaffected
- [x] `product 705692` unaffected