### PR TITLE
feat: add NZBN Register skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ We are borrowing the shape of the best public skills repos, but not copying thei
 | `metservice-nz` | MetService / marine API | No auth | [Adam Holt](https://github.com/adam91holt) |
 | `newworld-nz` | New World NZ public website guest-token APIs | No account login | [Adam Holt](https://github.com/adam91holt) |
 | `nz-news` | NZ RSS feeds | No auth | [Adam Holt](https://github.com/adam91holt) |
+| `nzbn-register` | NZBN Register public business/entity search and exact NZBN lookup | No auth | [Adam Holt](https://github.com/adam91holt) |
 | `paknsave-nz` | PAK'nSAVE NZ public website guest-token APIs | No account login | [Adam Holt](https://github.com/adam91holt) |
 | `trademe-nz` | Trade Me NZ public listing/search endpoints for marketplace, property, motors, jobs, regions, and categories | No login/app credentials | [Adam Holt](https://github.com/adam91holt) |
 | `woolworths-nz` | Woolworths NZ public product search, specials, and SKU detail endpoints | No account login | [Adam Holt](https://github.com/adam91holt) |

--- a/skills/nzbn-register/SKILL.md
+++ b/skills/nzbn-register/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: nzbn-register
+description: Search and lookup public New Zealand Business Number (NZBN) Register business/entity records through the NZBN website's read-only public proxy. Use when the task involves NZ business identity lookup, exact NZBN details, company/entity status, trading names, public addresses, websites, or source-register identifiers. No account login or API subscription key required for supported read-only commands.
+---
+
+# NZBN Register
+
+## Goal
+
+Query live public NZBN Register business/entity data through a small deterministic Python CLI with human-readable and JSON output.
+
+## Use this when
+
+- A user asks to find an NZ business/entity by name
+- A user has a 13-digit NZBN and wants public register details
+- A workflow needs machine-readable NZBN, entity status, entity type, trading names, Companies Office source id, public addresses, websites, or contact fields published on the register
+- A user needs an official NZ business identifier before checking other sources
+
+## Do not use this for
+
+- Authenticated MyNZBN actions, authority management, watchlists, or profile edits
+- Private/suppressed register data
+- Bulk scraping, full-register replication, or enrichment at high volume
+- Mutating NZBN records or contacting businesses automatically
+- Treating live register output as legal advice
+
+## Preferred workflow
+
+1. Run `scripts/cli.py search` with the narrowest business name/query that answers the task
+2. Select the likely `nzbn` from results, then run `lookup <nzbn>` for exact public details
+3. Use `--json` for agent chaining, comparisons, or structured reports
+4. Cite the NZBN and source-register id/date fields when reporting findings
+5. If multiple similar names appear, show candidates and avoid overclaiming identity
+
+## CLI
+
+Run with:
+
+```bash
+python3 skills/nzbn-register/scripts/cli.py <command> [flags]
+```
+
+### Commands
+
+- `search <query> [--limit N] [--page N] [--json]` — search NZBN entities by business/entity name or NZBN text
+- `lookup <nzbn> [--json] [--raw]` — fetch exact public details for a 13-digit NZBN
+
+Examples:
+
+```bash
+python3 skills/nzbn-register/scripts/cli.py search "the warehouse" --limit 5
+python3 skills/nzbn-register/scripts/cli.py search "the warehouse" --limit 5 --json
+python3 skills/nzbn-register/scripts/cli.py lookup 9429000023795 --json
+python3 skills/nzbn-register/scripts/cli.py lookup 9429000023795 --raw --json
+```
+
+## Resources
+
+- CLI entrypoint: `scripts/cli.py`
+- Live smoke test: `scripts/smoke-test.ts`
+- API and stability notes: `references/api-notes.md`
+
+## Notes
+
+- No API key, OAuth token, username, password, cookie, or browser automation is required for the supported read-only commands
+- The official API gateway (`api.business.govt.nz/gateway/nzbn/v5`) requires a subscription key when called directly; this skill uses the public NZBN website proxy used by the register UI
+- Treat records as live public register snapshots; entity details can change
+- Keep queries small and respectful

--- a/skills/nzbn-register/references/api-notes.md
+++ b/skills/nzbn-register/references/api-notes.md
@@ -1,0 +1,57 @@
+# NZBN Register API notes
+
+This skill is an unofficial lightweight wrapper around public NZBN Register website read-only endpoints. It does not use authenticated MyNZBN functionality.
+
+## Source and auth
+
+- Website: `https://www.nzbn.govt.nz`
+- Public register UI route: `https://www.nzbn.govt.nz/mynzbn/search/`
+- Website proxy used by this skill: `https://www.nzbn.govt.nz/api/business/nzbn?u={encoded-uri}`
+- Upstream official gateway surfaced by payload links: `https://api.business.govt.nz/gateway/nzbn/v5`
+- Auth model for this skill: none for the implemented read-only website-proxy requests
+
+No username, password, account cookie, private token, browser session, or API subscription key is required for the implemented commands.
+
+## Endpoint families used
+
+The website React bundle calls a local proxy endpoint and passes the upstream NZBN API URI in the `u` query parameter. The CLI mirrors only these read-only GET calls:
+
+- Search entities:
+  - Proxy call: `GET /api/business/nzbn?u=entities%3Fsearch-term%3D{query}%26page-size%3D{limit}%26page%3D{page}`
+  - Upstream shape: `entities?search-term={query}&page-size={limit}&page={page}`
+- Exact NZBN lookup:
+  - Proxy call: `GET /api/business/nzbn?u=entities%2F{nzbn}`
+  - Upstream shape: `entities/{nzbn}`
+
+The direct official gateway was tested and returned `401` without a subscription key, for example:
+
+```text
+GET https://api.business.govt.nz/gateway/nzbn/v5/entities?search-term=the%20warehouse&page-size=5&page=0
+=> 401 Access denied due to missing subscription key
+```
+
+The website proxy returned live public data for the same entity search and exact lookup without credentials. Some upstream filter parameters shown in older/UI code paths can be rejected by the proxy (`400 One or more values not recognized`), so this skill intentionally keeps the supported search surface to query, page, and page size.
+
+## Response notes
+
+Search responses include:
+
+- `pageSize`, `page`, `totalItems`
+- `items[]` with `entityName`, `nzbn`, entity status/type fields, trading names, previous names, registration date, and source-register id
+
+Lookup responses include public details such as:
+
+- entity status/type, registration and last-updated dates
+- source register and source-register identifier
+- public addresses and websites
+- public email/phone/GST/classification fields when the register exposes them
+
+The CLI simplifies common fields by default and can include the raw exact-lookup payload with `lookup <nzbn> --raw --json`.
+
+## Stability and safety
+
+- The website proxy is public and read-only for these calls, but it is not a formal stable API contract for third-party clients.
+- The official documented API may be preferable for production/high-volume use, but direct gateway calls require an API subscription key.
+- Avoid high-volume scraping or full-register replication. Use narrow queries and small limits.
+- Do not use authenticated MyNZBN endpoints, account actions, watchlists, authority requests, update flows, cookies, or private data.
+- Public register fields can change or be suppressed; treat output as a live snapshot and cite the NZBN/source where relevant.

--- a/skills/nzbn-register/scripts/cli.py
+++ b/skills/nzbn-register/scripts/cli.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""NZBN Register lightweight public lookup CLI.
+
+Self-contained stdlib wrapper around read-only public NZBN Register website
+proxy endpoints. No API key, login, cookies, writes, or private data access.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+BASE_WEB = "https://www.nzbn.govt.nz"
+PROXY = BASE_WEB + "/api/business/nzbn"
+UA = os.environ.get(
+    "NZBN_REGISTER_USER_AGENT",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
+)
+
+
+def die(message: str, code: int = 1) -> None:
+    print(f"nzbn-register: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def nzbn_path(uri: str, timeout: int = 25) -> Any:
+    """GET an NZBN API URI through the public website proxy."""
+    url = PROXY + "?" + urllib.parse.urlencode({"u": uri})
+    headers = {
+        "Accept": "application/json, text/plain, */*",
+        "Referer": BASE_WEB + "/mynzbn/search/",
+        "User-Agent": UA,
+    }
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", "replace")
+            if not raw:
+                return None
+            payload = json.loads(raw)
+            # The proxy commonly returns upstream errors as JSON with HTTP 200.
+            if isinstance(payload, dict):
+                status = str(payload.get("status") or payload.get("statusCode") or "")
+                if status and not status.startswith("2"):
+                    msg = payload.get("errorDescription") or payload.get("message") or payload.get("error") or raw[:300]
+                    die(f"upstream error for {uri}: {status} {msg}")
+            return payload
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8", "replace")
+        die(f"HTTP {e.code} from {url}: {raw[:300]}")
+    except urllib.error.URLError as e:
+        die(f"network error calling {url}: {e.reason}")
+    except json.JSONDecodeError as e:
+        die(f"invalid JSON from {url}: {e}")
+
+
+def nzbn_url(nzbn: Any) -> str | None:
+    s = str(nzbn or "").strip()
+    if not s:
+        return None
+    return f"{BASE_WEB}/mynzbn/nzbndetails/{urllib.parse.quote(s)}/"
+
+
+def compact_address(addr: dict[str, Any]) -> str:
+    parts = [addr.get("careOf"), addr.get("address1"), addr.get("address2"), addr.get("address3"), addr.get("address4"), addr.get("postCode"), addr.get("countryCode")]
+    return ", ".join(str(p) for p in parts if p)
+
+
+def simplify_entity(entity: dict[str, Any], *, detail: bool = False) -> dict[str, Any]:
+    out: dict[str, Any] = {
+        "nzbn": entity.get("nzbn"),
+        "entity_name": entity.get("entityName"),
+        "entity_status": entity.get("entityStatusDescription"),
+        "entity_status_code": entity.get("entityStatusCode"),
+        "entity_type": entity.get("entityTypeDescription"),
+        "entity_type_code": entity.get("entityTypeCode"),
+        "registration_date": entity.get("registrationDate"),
+        "source_register": entity.get("sourceRegister"),
+        "source_register_unique_id": entity.get("sourceRegisterUniqueIdentifier") or entity.get("sourceRegisterUniqueId"),
+        "last_updated_date": entity.get("lastUpdatedDate"),
+        "previous_entity_names": entity.get("previousEntityNames") or [],
+        "trading_names": [x.get("name") for x in entity.get("tradingNames") or [] if isinstance(x, dict) and x.get("name") and x.get("name") != "No trading name"],
+        "url": nzbn_url(entity.get("nzbn")),
+    }
+    if detail:
+        addresses = (entity.get("addresses") or {}).get("addressList") if isinstance(entity.get("addresses"), dict) else entity.get("addresses")
+        if isinstance(addresses, list):
+            out["addresses"] = [
+                {
+                    "type": a.get("addressType"),
+                    "address": compact_address(a),
+                    "start_date": a.get("startDate"),
+                    "end_date": a.get("endDate"),
+                }
+                for a in addresses
+                if isinstance(a, dict)
+            ]
+        out["websites"] = [x.get("url") for x in entity.get("websites") or [] if isinstance(x, dict) and x.get("url")]
+        out["email_addresses"] = [x.get("emailAddress") for x in entity.get("emailAddresses") or [] if isinstance(x, dict) and x.get("emailAddress")]
+        out["phone_numbers"] = [x for x in entity.get("phoneNumbers") or [] if isinstance(x, dict)]
+        out["industry_classifications"] = [x for x in entity.get("industryClassifications") or entity.get("classifications") or [] if isinstance(x, dict)]
+        out["gst_numbers"] = entity.get("gstNumbers") or []
+        out["australian_business_number"] = entity.get("australianBusinessNumber")
+    return out
+
+
+def emit(data: Any, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False))
+        return
+    if isinstance(data, dict) and "entities" in data:
+        print(f"NZBN search: {data.get('total_items')} total, showing {len(data.get('entities') or [])} ({data.get('elapsed_ms')} ms)")
+        print()
+        for item in data.get("entities") or []:
+            print(f"{item.get('nzbn')}  {item.get('entity_name')}")
+            bits = [item.get("entity_status"), item.get("entity_type"), item.get("registration_date")]
+            print("  " + " | ".join(str(x) for x in bits if x))
+            if item.get("trading_names"):
+                print("  trading: " + "; ".join(item["trading_names"]))
+            if item.get("url"):
+                print(f"  {item.get('url')}")
+            print()
+    elif isinstance(data, dict) and "entity" in data:
+        e = data["entity"]
+        print(f"{e.get('nzbn')}  {e.get('entity_name')}")
+        bits = [e.get("entity_status"), e.get("entity_type"), e.get("source_register"), e.get("registration_date")]
+        print("  " + " | ".join(str(x) for x in bits if x))
+        if e.get("previous_entity_names"):
+            print("  previous names: " + "; ".join(e["previous_entity_names"][:8]))
+        if e.get("trading_names"):
+            print("  trading: " + "; ".join(e["trading_names"][:8]))
+        for addr in e.get("addresses") or []:
+            print(f"  {addr.get('type')}: {addr.get('address')}")
+        if e.get("websites"):
+            print("  websites: " + "; ".join(e["websites"]))
+        if e.get("email_addresses"):
+            print("  emails: " + "; ".join(e["email_addresses"]))
+        if e.get("url"):
+            print(f"  {e.get('url')}")
+        print(f"  fetched in {data.get('elapsed_ms')} ms")
+    else:
+        print(data)
+
+
+def cmd_search(args: argparse.Namespace) -> None:
+    if not args.query.strip():
+        die("search query is required")
+    page_size = min(max(1, args.limit), 100)
+    page = max(0, args.page)
+    params = {
+        "search-term": args.query,
+        "page-size": page_size,
+        "page": page,
+    }
+    uri = "entities?" + urllib.parse.urlencode({k: v for k, v in params.items() if v not in (None, "")})
+    started = time.perf_counter()
+    payload = nzbn_path(uri)
+    elapsed_ms = round((time.perf_counter() - started) * 1000)
+    items = payload.get("items") if isinstance(payload, dict) else []
+    data = {
+        "query": args.query,
+        "page": payload.get("page") if isinstance(payload, dict) else page,
+        "page_size": payload.get("pageSize") if isinstance(payload, dict) else page_size,
+        "total_items": payload.get("totalItems") if isinstance(payload, dict) else None,
+        "elapsed_ms": elapsed_ms,
+        "entities": [simplify_entity(x) for x in items or [] if isinstance(x, dict)],
+    }
+    emit(data, args.json)
+
+
+def cmd_lookup(args: argparse.Namespace) -> None:
+    nzbn = re.sub(r"\D", "", args.nzbn)
+    if len(nzbn) != 13:
+        die("NZBN must be 13 digits")
+    started = time.perf_counter()
+    payload = nzbn_path(f"entities/{nzbn}")
+    elapsed_ms = round((time.perf_counter() - started) * 1000)
+    if not isinstance(payload, dict):
+        die("unexpected lookup response")
+    data = {
+        "elapsed_ms": elapsed_ms,
+        "entity": simplify_entity(payload, detail=True),
+        "raw": payload if args.raw else None,
+    }
+    emit(data, args.json)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Search and lookup public NZBN Register entities")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    s = sub.add_parser("search", help="search businesses/entities by name or NZBN text")
+    s.add_argument("query", help="business/entity name or NZBN search text")
+    s.add_argument("--limit", type=int, default=10, help="results per page, 1-100 (default: 10)")
+    s.add_argument("--page", type=int, default=0, help="zero-based page number (default: 0)")
+    s.add_argument("--json", action="store_true", help="emit JSON")
+    s.set_defaults(func=cmd_search)
+
+    l = sub.add_parser("lookup", help="lookup exact 13-digit NZBN")
+    l.add_argument("nzbn", help="13-digit NZBN")
+    l.add_argument("--json", action="store_true", help="emit JSON")
+    l.add_argument("--raw", action="store_true", help="include raw upstream payload in JSON")
+    l.set_defaults(func=cmd_lookup)
+    return p
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/nzbn-register/scripts/smoke-test.ts
+++ b/skills/nzbn-register/scripts/smoke-test.ts
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = resolve(__dirname, 'cli.py');
+
+function run(args: string[]) {
+  const result = spawnSync('python3', [cliPath, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 45_000,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`nzbn-register smoke failed: python3 ${cliPath} ${args.join(' ')}\n${result.stderr || result.stdout}`);
+  }
+  return result.stdout;
+}
+
+run(['--help']);
+const searchRaw = run(['search', 'the warehouse', '--limit', '3', '--json']);
+const search = JSON.parse(searchRaw) as { entities?: Array<Record<string, unknown>>; total_items?: number };
+if (!Array.isArray(search.entities) || search.entities.length < 1) {
+  throw new Error('Expected NZBN search JSON to include entities[]');
+}
+if (typeof search.entities[0].nzbn !== 'string') {
+  throw new Error('Expected first NZBN search result to include nzbn');
+}
+const nzbn = String(search.entities[0].nzbn);
+const lookupRaw = run(['lookup', nzbn, '--json']);
+const lookup = JSON.parse(lookupRaw) as { entity?: Record<string, unknown> };
+if (!lookup.entity?.nzbn || lookup.entity.nzbn !== nzbn) {
+  throw new Error('Expected NZBN lookup JSON to include matching entity.nzbn');
+}
+if (!lookup.entity.entity_name) {
+  throw new Error('Expected NZBN lookup JSON to include entity.entity_name');
+}
+console.log('nzbn-register smoke ok');


### PR DESCRIPTION
## Summary
- Add nzbn-register skill for public NZBN Register business/entity search and exact NZBN lookup
- Include stdlib Python CLI, API notes, and TypeScript smoke test
- Document no-auth website proxy behaviour and direct official gateway subscription-key caveat

## Verification
- npm run validate-skill -- skills/nzbn-register
- npm run typecheck
- python3 -m py_compile skills/nzbn-register/scripts/cli.py
- npx tsx skills/nzbn-register/scripts/smoke-test.ts