### PR TITLE
feat(bunnings): add lightweight read-only Bunnings CLI skill

### DIFF
--- a/skills/bunnings/SKILL.md
+++ b/skills/bunnings/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: bunnings
+description: Query Bunnings NZ public product search, pricing, product detail, category browse, store locator, and redemption/specials pages through a lightweight no-login CLI, with optional Bunnings AU support via --country au. Use when the task involves Bunnings New Zealand product lookup, live prices, SKUs, store details, category browsing, promotional/redemption offers, or machine-readable Bunnings product data. Read-only; no cart, checkout, account, or login actions.
+---
+
+# Bunnings
+
+## Goal
+
+Query live Bunnings NZ product, pricing, store, category, and promotion data through a small deterministic CLI with human-readable and JSON output, without browser automation or account login.
+
+## Use this when
+
+- A user asks for Bunnings NZ product prices, product details, or SKUs
+- A user wants to search Bunnings products by keyword
+- A user wants Bunnings store details, phone numbers, opening hours, or map links
+- A user wants current Bunnings redemption/promotional offer products
+- A workflow needs lightweight machine-readable Bunnings product or store data
+- Bunnings AU is acceptable and the user explicitly asks for Australian results
+
+## Do not use this for
+
+- Cart, checkout, project list, account, login, delivery-slot, payment, order, or trade account actions
+- Authenticated/private Bunnings data
+- High-volume scraping or dataset redistribution
+- Historical price tracking or price-change claims unless another dataset provides history
+- Guaranteed local stock claims beyond the live default-store snapshot returned by the site
+
+## Preferred workflow
+
+1. Run `scripts/cli.py` with the narrowest subcommand that answers the task
+2. Use `search` for keyword price/product lookup and `product` when an exact SKU is known
+3. Use `browse` when a product category path is known
+4. Use `stores --region` for location-scoped store lookup
+5. Use `specials` for redemption/promotion products, optionally filtered by query
+6. Use `--json` for agent chaining, comparisons, or structured reports
+7. Mention that prices, stock, and promotions are live Bunnings snapshots from unofficial public page data
+
+## CLI
+
+Run with:
+
+```bash
+python3 skills/bunnings/scripts/cli.py <command> [flags]
+```
+
+Set `--country au` before the subcommand for Bunnings Australia. The default is `nz`.
+
+### Commands
+
+- `search <query> [--limit N] [--json]` - product search with prices
+- `product <sku-or-product-url> [--json]` - fetch product detail, price, default-store stock, and aisle data when present
+- `browse <category-path> [--limit N] [--json]` - browse a known category path such as `tools/power-tools/drills`
+- `stores [--region text] [--limit N] [--json]` - list store details, optionally filtered by region/path/name text
+- `specials [query] [--limit N] [--json]` - list redemption/promotion products
+
+Examples:
+
+```bash
+python3 skills/bunnings/scripts/cli.py search drill --limit 5
+python3 skills/bunnings/scripts/cli.py product 0715241 --json
+python3 skills/bunnings/scripts/cli.py browse tools/power-tools/drills --limit 5
+python3 skills/bunnings/scripts/cli.py stores --region uppernorthisland --limit 5 --json
+python3 skills/bunnings/scripts/cli.py specials dewalt --limit 5
+python3 skills/bunnings/scripts/cli.py --country au search drill --limit 5
+```
+
+## Notes
+
+- No API key, username, password, account cookie, or browser automation is required for the implemented read-only commands
+- The CLI uses public Bunnings page state rather than auth-walled cart/account APIs
+- Product prices and stock are live snapshots and may vary by store, fulfilment method, country, and time
+- Promotion data is based on the public redemption-offers page; Bunnings may not expose a conventional specials feed
+- Endpoint shapes can change without notice because this is not an official public API
+- Keep usage narrow and respectful

--- a/skills/bunnings/references/api-notes.md
+++ b/skills/bunnings/references/api-notes.md
@@ -1,0 +1,43 @@
+# Bunnings API notes
+
+This skill is an unofficial lightweight wrapper around public Bunnings NZ/AU page data used by `bunnings.co.nz` and `bunnings.com.au`.
+
+## Source and auth
+
+- NZ website: `https://www.bunnings.co.nz`
+- AU website: `https://www.bunnings.com.au`
+- Auth model for supported commands: none
+
+No username, password, account cookie, private token, or browser session is required for the implemented read-only operations. The CLI sends a browser-like `User-Agent`, `Accept`, `Accept-Language`, and `Referer`.
+
+## Endpoint families used
+
+- `GET /search/products?q={query}` for product search. Product results are embedded in `__NEXT_DATA__` as a hydrated Coveo search result.
+- `GET /products/{category-path}` for category browse. Category children and product results are embedded in `__NEXT_DATA__`.
+- `GET /{product-slug}_p{sku}` for product detail. The hydrated data includes `retail-product`, `product-retail-price`, `product-fulfilment`, and `product-aisle-item-location` query records when available.
+- `GET /stores` for public store-region and store-detail links.
+- `GET /stores/{region}/{store-slug}` for store detail, address, phone, opening hours, services, map URL, and coordinates.
+- `GET /campaign/redemption-offers` for redemption/promotion products. Products are embedded in page state under related-product blocks.
+
+The Next.js data route form, such as `/_next/data/{buildId}/search/products.json?q=drill&rest=products`, also returned public JSON during discovery. The CLI intentionally parses the HTML page state instead so it does not need to maintain a changing `buildId`.
+
+## Browser-sniffed endpoints not used by the CLI
+
+Browser traffic also showed these JSON/XHR calls:
+
+- `GET /_apis/v1/stores/country/NZ?fields=FULL`
+- `GET /_apis/v2/products/{sku}/priceInfo`
+- `POST /_apis/v2/products/{sku}/fulfillment`
+- `GET /_apis/v1/item-api/locations?locationCode={storeCode}&productCode={sku}`
+
+Those calls returned `200` in the live browser session but plain stdlib requests returned `401` without the browser's guest/session authorization flow. They are documented for future discovery, but this lightweight CLI does not mint guest tokens and does not call them.
+
+## Stability and safety
+
+- Treat prices, stock, store hours, and promotions as live snapshots.
+- Product price and stock are default-store snapshots unless the page data changes the selected store context.
+- Search and category pages usually hydrate the first 36 product results; keep `--limit` within that practical first-page boundary.
+- Bunnings may alter its Next.js state shape, Coveo fields, or promotion page layout without notice.
+- Cloudflare/Bunnings allowed the public page reads with a browser-like user agent during testing; if stdlib requests begin failing, re-check the browser traffic and update the notes before changing the CLI.
+- Do not use this skill for cart mutation, checkout, order placement, project list mutation, account actions, or authenticated trade/customer data.
+- Do not commit credentials, cookies, raw authenticated captures, or screenshots with private data.

--- a/skills/bunnings/scripts/cli.py
+++ b/skills/bunnings/scripts/cli.py
@@ -1,0 +1,692 @@
+#!/usr/bin/env python3
+"""Bunnings lightweight public read-only CLI.
+
+Self-contained stdlib wrapper around public Bunnings NZ/AU page data.
+No login, cart mutation, browser automation, or third-party dependencies.
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+COUNTRIES = {
+    "nz": {
+        "label": "Bunnings NZ",
+        "base": "https://www.bunnings.co.nz",
+        "currency": "NZD",
+    },
+    "au": {
+        "label": "Bunnings AU",
+        "base": "https://www.bunnings.com.au",
+        "currency": "AUD",
+    },
+}
+
+UA = os.environ.get(
+    "BUNNINGS_USER_AGENT",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
+)
+
+
+def die(message: str, code: int = 1) -> None:
+    print(f"bunnings: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def country_cfg(country: str) -> dict[str, str]:
+    return COUNTRIES.get(country) or COUNTRIES["nz"]
+
+
+def build_url(cfg: dict[str, str], path_or_url: str) -> str:
+    if path_or_url.startswith("http://") or path_or_url.startswith("https://"):
+        return path_or_url
+    path = path_or_url if path_or_url.startswith("/") else "/" + path_or_url
+    return cfg["base"] + path
+
+
+def request_text(cfg: dict[str, str], path_or_url: str, timeout: int = 30) -> str:
+    url = build_url(cfg, path_or_url)
+    headers = {
+        "Accept": "text/html,application/xhtml+xml,application/json;q=0.9,*/*;q=0.8",
+        "Accept-Language": "en-NZ,en-AU;q=0.9,en;q=0.8",
+        "Referer": cfg["base"] + "/",
+        "User-Agent": UA,
+    }
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return resp.read().decode("utf-8", "replace")
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8", "replace")
+        detail = re.sub(r"\s+", " ", raw[:300]).strip()
+        die(f"HTTP {e.code} from {url}: {detail}")
+    except urllib.error.URLError as e:
+        die(f"network error calling {url}: {e.reason}")
+
+
+def next_data_from_text(text: str, url: str) -> dict[str, Any]:
+    stripped = text.lstrip()
+    if stripped.startswith("{"):
+        try:
+            return json.loads(stripped)
+        except json.JSONDecodeError as e:
+            die(f"invalid JSON from {url}: {e}")
+    match = re.search(r'<script id="__NEXT_DATA__"[^>]*>(.*?)</script>', text)
+    if not match:
+        if "<title>Page Not Found" in text or "/404" in text[:5000]:
+            die(f"page not found: {url}")
+        die(f"could not find Next.js data in {url}")
+    try:
+        return json.loads(html.unescape(match.group(1)))
+    except json.JSONDecodeError as e:
+        die(f"invalid Next.js data in {url}: {e}")
+
+
+def fetch_next_data(cfg: dict[str, str], path_or_url: str) -> dict[str, Any]:
+    url = build_url(cfg, path_or_url)
+    return next_data_from_text(request_text(cfg, url), url)
+
+
+def page_props(data: dict[str, Any]) -> dict[str, Any]:
+    return ((data.get("props") or {}).get("pageProps") or {})
+
+
+def query_states(data: dict[str, Any]) -> list[dict[str, Any]]:
+    queries = ((page_props(data).get("dehydratedState") or {}).get("queries") or [])
+    return [q for q in queries if isinstance(q, dict)]
+
+
+def query_data(data: dict[str, Any], key_name: str) -> Any:
+    for q in query_states(data):
+        key = q.get("queryKey") or []
+        if isinstance(key, list) and key and key[0] == key_name:
+            return ((q.get("state") or {}).get("data"))
+    return None
+
+
+def search_payload(data: dict[str, Any]) -> dict[str, Any]:
+    for q in query_states(data):
+        payload = ((q.get("state") or {}).get("data"))
+        if isinstance(payload, dict) and isinstance(payload.get("results"), list):
+            return payload
+    return {}
+
+
+def walk(value: Any) -> list[Any]:
+    out = [value]
+    if isinstance(value, dict):
+        for child in value.values():
+            out.extend(walk(child))
+    elif isinstance(value, list):
+        for child in value:
+            out.extend(walk(child))
+    return out
+
+
+def money(value: Any, currency: str | None = None) -> str:
+    if value is None:
+        return "-"
+    try:
+        prefix = "$"
+        return f"{prefix}{float(value):.2f}" + (f" {currency}" if currency else "")
+    except Exception:
+        return str(value)
+
+
+def slugify_query(value: str) -> str:
+    return urllib.parse.quote(value.strip())
+
+
+def product_url(cfg: dict[str, str], route: str | None) -> str | None:
+    if not route:
+        return None
+    return build_url(cfg, route)
+
+
+def category_label(raw: dict[str, Any]) -> str:
+    parts = []
+    categories = raw.get("supercategories") or []
+    if isinstance(categories, list):
+        for value in categories:
+            if isinstance(value, str) and "--" in value:
+                parts.append(value.split("--", 1)[0])
+    return " / ".join(parts)
+
+
+def parse_raw_product(raw: dict[str, Any], cfg: dict[str, str]) -> dict[str, Any]:
+    route = raw.get("productroutingurl") or raw.get("productRoutingUrl")
+    offers = raw.get("productoffers")
+    ranges = raw.get("productranges")
+    if isinstance(offers, str):
+        offers = [offers]
+    if isinstance(ranges, str):
+        ranges = [ranges]
+    return {
+        "sku": str(raw.get("code") or raw.get("itemnumber") or raw.get("itemNumber") or ""),
+        "name": raw.get("name") or raw.get("title") or "",
+        "brand": raw.get("brandname") or "",
+        "price": raw.get("price"),
+        "currency": raw.get("currency") or cfg.get("currency"),
+        "unit": raw.get("unitofprice"),
+        "rating": raw.get("rating"),
+        "rating_count": raw.get("ratingcount"),
+        "category": category_label(raw),
+        "product_ranges": ranges or [],
+        "product_offers": offers or [],
+        "promotional_campaign": raw.get("promotionalcampaign"),
+        "is_new_arrival": str(raw.get("newarrival", "")).lower() == "true",
+        "is_best_seller": str(raw.get("bestseller", "")).lower() == "true",
+        "image": raw.get("imageurl") or raw.get("thumbnailimageurl"),
+        "source_url": product_url(cfg, route),
+    }
+
+
+def products_from_search_payload(payload: dict[str, Any], cfg: dict[str, str], limit: int) -> list[dict[str, Any]]:
+    products = []
+    for item in payload.get("results") or []:
+        raw = item.get("raw") if isinstance(item, dict) else None
+        if isinstance(raw, dict) and (raw.get("code") or raw.get("itemnumber")):
+            products.append(parse_raw_product(raw, cfg))
+    return products[: max(1, limit)]
+
+
+def search_products(cfg: dict[str, str], query: str, limit: int = 10) -> dict[str, Any]:
+    started = time.perf_counter()
+    path = "/search/products?" + urllib.parse.urlencode({"q": query})
+    data = fetch_next_data(cfg, path)
+    payload = search_payload(data)
+    products = products_from_search_payload(payload, cfg, min(max(limit, 1), 36))
+    return {
+        "country": cfg["label"],
+        "query": query,
+        "count": len(products),
+        "total_count": payload.get("totalCount"),
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+        "products": products,
+    }
+
+
+def normalize_product_path(value: str) -> str:
+    if value.startswith("http://") or value.startswith("https://"):
+        path = urllib.parse.urlparse(value).path
+    else:
+        path = value
+    if not path.startswith("/"):
+        path = "/" + path
+    return path
+
+
+def sku_from_value(value: str) -> str | None:
+    match = re.search(r"_p([A-Za-z0-9]+)", value)
+    if match:
+        return match.group(1)
+    if re.fullmatch(r"[A-Za-z0-9-]+", value):
+        return value
+    return None
+
+
+def find_product_route(cfg: dict[str, str], sku_or_route: str) -> tuple[str, str]:
+    if "_p" in sku_or_route or "/" in sku_or_route:
+        path = normalize_product_path(sku_or_route)
+        sku = sku_from_value(path) or sku_or_route
+        return sku, path
+    sku = sku_or_route
+    data = search_products(cfg, sku, limit=10)
+    exact = None
+    for product in data["products"]:
+        if product.get("sku") == sku:
+            exact = product
+            break
+    exact = exact or (data["products"][0] if data["products"] else None)
+    if not exact or not exact.get("source_url"):
+        die(f"could not resolve product route for SKU {sku}")
+    return str(exact.get("sku") or sku), normalize_product_path(str(exact["source_url"]))
+
+
+def primary_image(product: dict[str, Any]) -> str | None:
+    images = product.get("images") or []
+    if isinstance(images, list):
+        for item in images:
+            if isinstance(item, dict) and item.get("imageType") == "PRIMARY":
+                return item.get("url") or item.get("thumbnailUrl")
+        for item in images:
+            if isinstance(item, dict) and (item.get("url") or item.get("thumbnailUrl")):
+                return item.get("url") or item.get("thumbnailUrl")
+    return None
+
+
+def feature_values(product: dict[str, Any]) -> dict[str, str]:
+    out = {}
+    for group in product.get("classifications") or []:
+        if not isinstance(group, dict):
+            continue
+        for feature in group.get("features") or []:
+            if not isinstance(feature, dict):
+                continue
+            vals = feature.get("featureValues") or []
+            value = vals[0].get("value") if vals and isinstance(vals[0], dict) else None
+            name = feature.get("name")
+            if name and value is not None:
+                out[str(name)] = str(value)
+    return out
+
+
+def category_from_detail(product: dict[str, Any]) -> str:
+    categories = product.get("allCategories") or []
+    names = [c.get("displayName") for c in categories if isinstance(c, dict) and c.get("displayName")]
+    return " / ".join(str(x) for x in names)
+
+
+def parse_product_detail(data: dict[str, Any], cfg: dict[str, str], sku: str, path: str) -> dict[str, Any]:
+    product = query_data(data, "retail-product") or {}
+    price = query_data(data, "product-retail-price") or {}
+    fulfilment = query_data(data, "product-fulfilment") or {}
+    aisle_data = query_data(data, "product-aisle-item-location") or []
+    if not isinstance(product, dict) or not product.get("code"):
+        die(f"could not find product detail data for {sku}")
+    brand = product.get("brand") or {}
+    feature = product.get("feature") or {}
+    in_store = fulfilment.get("inStorePickUpData") if isinstance(fulfilment, dict) else {}
+    click_collect = fulfilment.get("clickNCollectData") if isinstance(fulfilment, dict) else {}
+    delivery = fulfilment.get("deliveryData") if isinstance(fulfilment, dict) else {}
+    aisle_locations = []
+    if isinstance(aisle_data, list):
+        for group in aisle_data:
+            if not isinstance(group, dict):
+                continue
+            for loc in group.get("inStoreLocations") or []:
+                if isinstance(loc, dict):
+                    aisle_locations.append(
+                        {
+                            "aisle": loc.get("aisle"),
+                            "bay": loc.get("bay"),
+                            "sequence": loc.get("sequence"),
+                        }
+                    )
+    return {
+        "sku": str(product.get("code") or sku),
+        "item_number": product.get("itemNumber"),
+        "name": product.get("name"),
+        "brand": brand.get("name") if isinstance(brand, dict) else None,
+        "price": price.get("value") if isinstance(price, dict) else None,
+        "price_display": price.get("formattedValue") if isinstance(price, dict) else None,
+        "currency": price.get("currencyIso") if isinstance(price, dict) else cfg.get("currency"),
+        "rating": product.get("averageRating"),
+        "rating_count": product.get("numberOfReviews"),
+        "category": category_from_detail(product),
+        "key_selling_points": feature.get("pointers") if isinstance(feature, dict) else [],
+        "description": feature.get("description") if isinstance(feature, dict) else None,
+        "features": feature_values(product),
+        "product_ranges": [
+            "Click & Collect" if click_collect and click_collect.get("isClicknCollectAvailable") else None,
+            "In-Store" if in_store and in_store.get("inStorePickUpAvailable") else None,
+            "Delivery" if delivery and delivery.get("isDeliveryAvailable") else None,
+        ],
+        "stock": {
+            "store": in_store.get("storeName") if isinstance(in_store, dict) else None,
+            "in_store_text": in_store.get("inStoreStockTxt") if isinstance(in_store, dict) else None,
+            "in_store_stock": in_store.get("stock") if isinstance(in_store, dict) else None,
+            "click_collect_text": click_collect.get("clickNCollectStockTxt") if isinstance(click_collect, dict) else None,
+            "click_collect_stock": click_collect.get("stock") if isinstance(click_collect, dict) else None,
+        },
+        "aisle_locations": aisle_locations,
+        "image": primary_image(product),
+        "source_url": build_url(cfg, path),
+    }
+
+
+def product_detail(cfg: dict[str, str], sku_or_route: str) -> dict[str, Any]:
+    started = time.perf_counter()
+    sku, path = find_product_route(cfg, sku_or_route)
+    data = fetch_next_data(cfg, path)
+    product = parse_product_detail(data, cfg, sku, path)
+    return {
+        "country": cfg["label"],
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+        "product": product,
+    }
+
+
+def browse_category(cfg: dict[str, str], category: str, limit: int = 10) -> dict[str, Any]:
+    started = time.perf_counter()
+    path = normalize_product_path(category)
+    if not path.startswith("/products/"):
+        path = "/products/" + path.lstrip("/")
+    data = fetch_next_data(cfg, path)
+    payload = search_payload(data)
+    category_data = query_data(data, "retail-category") or {}
+    children = []
+    if isinstance(category_data, dict):
+        for child in category_data.get("levels") or []:
+            if isinstance(child, dict):
+                children.append(
+                    {
+                        "code": child.get("code"),
+                        "name": child.get("displayName"),
+                        "path": child.get("internalPath"),
+                        "level": child.get("level"),
+                    }
+                )
+    products = products_from_search_payload(payload, cfg, min(max(limit, 1), 36))
+    return {
+        "country": cfg["label"],
+        "category": path,
+        "count": len(products),
+        "total_count": payload.get("totalCount"),
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+        "child_categories": children,
+        "products": products,
+    }
+
+
+def store_links(cfg: dict[str, str]) -> list[str]:
+    text = request_text(cfg, "/stores")
+    paths = []
+    for match in re.finditer(r'["\'](/stores/[A-Za-z0-9/-]+)["\']', text):
+        path = match.group(1).rstrip("/")
+        parts = [p for p in path.split("/") if p]
+        if len(parts) == 3 and parts[1] not in {"checkActiveStore", "products", "defaultStore"}:
+            paths.append(path)
+    seen = set()
+    out = []
+    for path in paths:
+        if path not in seen:
+            seen.add(path)
+            out.append(path)
+    return out
+
+
+def parse_hours(store: dict[str, Any]) -> list[dict[str, Any]]:
+    hours = ((store.get("openingHours") or {}).get("weekDayOpeningList") or [])
+    out = []
+    for item in hours:
+        if not isinstance(item, dict):
+            continue
+        out.append(
+            {
+                "day": item.get("weekDay"),
+                "closed": bool(item.get("closed")),
+                "open": ((item.get("openingTime") or {}).get("formattedHour")),
+                "close": ((item.get("closingTime") or {}).get("formattedHour")),
+            }
+        )
+    return out
+
+
+def parse_store_detail(data: dict[str, Any], cfg: dict[str, str], path: str) -> dict[str, Any] | None:
+    state = page_props(data).get("initialState") or {}
+    store = ((state.get("store") or {}).get("data") or {})
+    if not isinstance(store, dict) or not store.get("name"):
+        return None
+    address = store.get("address") or {}
+    geo = store.get("geoPoint") or {}
+    return {
+        "code": store.get("name"),
+        "name": store.get("displayName") or store.get("description"),
+        "region": store.get("urlRegion") or path.split("/")[2],
+        "store_region": store.get("storeRegion"),
+        "pricing_region": store.get("pricingRegion"),
+        "address": address.get("formattedAddress"),
+        "line1": address.get("line1"),
+        "suburb": address.get("line2") or address.get("suburb"),
+        "town": address.get("town"),
+        "state": address.get("state"),
+        "postal_code": address.get("postalCode"),
+        "phone": address.get("phone"),
+        "email": address.get("email"),
+        "latitude": geo.get("latitude"),
+        "longitude": geo.get("longitude"),
+        "has_click_and_collect": bool(store.get("hasClickAndCollect")),
+        "has_delivery": bool(store.get("hasDelivery")),
+        "services": store.get("storeServices") or [],
+        "hours": parse_hours(store),
+        "map_url": store.get("mapUrl"),
+        "source_url": build_url(cfg, path),
+    }
+
+
+def store_matches(store: dict[str, Any], region: str | None) -> bool:
+    if not region:
+        return True
+    needle = region.lower().replace(" ", "")
+    hay = " ".join(str(v or "") for v in store.values() if not isinstance(v, (list, dict))).lower().replace(" ", "")
+    return needle in hay
+
+
+def stores(cfg: dict[str, str], region: str | None = None, limit: int = 20) -> dict[str, Any]:
+    started = time.perf_counter()
+    links = store_links(cfg)
+    path_needle = (region or "").lower().replace(" ", "").replace("-", "")
+    if path_needle:
+        path_matches = [p for p in links if path_needle in p.lower().replace("-", "")]
+        if path_matches:
+            links = path_matches
+    rows = []
+    for path in links:
+        if len(rows) >= max(1, limit):
+            break
+        data = fetch_next_data(cfg, path)
+        store = parse_store_detail(data, cfg, path)
+        if store and store_matches(store, region):
+            rows.append(store)
+    return {
+        "country": cfg["label"],
+        "region": region,
+        "count": len(rows),
+        "available_store_links": len(links),
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+        "stores": rows,
+    }
+
+
+def promotional_products(cfg: dict[str, str], query: str | None = None, limit: int = 10) -> dict[str, Any]:
+    started = time.perf_counter()
+    data = fetch_next_data(cfg, "/campaign/redemption-offers")
+    products = []
+    seen = set()
+    for item in walk(page_props(data).get("initialState") or {}):
+        if not isinstance(item, dict):
+            continue
+        raw = item.get("raw") if isinstance(item.get("raw"), dict) else item
+        if not isinstance(raw, dict):
+            continue
+        offers = raw.get("productoffers") or []
+        if isinstance(offers, str):
+            offers = [offers]
+        is_promo = "Redemption Offer" in offers or bool(raw.get("promotionalcampaign"))
+        code = str(raw.get("code") or raw.get("itemnumber") or "")
+        if not is_promo or not code or code in seen:
+            continue
+        product = parse_raw_product(raw, cfg)
+        text = " ".join(str(product.get(k) or "") for k in ("sku", "name", "brand", "category")).lower()
+        if query and query.lower() not in text:
+            continue
+        seen.add(code)
+        products.append(product)
+        if len(products) >= max(1, limit):
+            break
+    return {
+        "country": cfg["label"],
+        "query": query,
+        "count": len(products),
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+        "products": products,
+        "source_url": build_url(cfg, "/campaign/redemption-offers"),
+    }
+
+
+def price_label(product: dict[str, Any]) -> str:
+    display = product.get("price_display")
+    if display:
+        return str(display)
+    return money(product.get("price"), product.get("currency"))
+
+
+def print_products(data: dict[str, Any], label: str) -> None:
+    query = data.get("query") or data.get("category") or label
+    total = data.get("total_count")
+    total_text = f" of {total}" if total is not None else ""
+    print(f"{data.get('country')}: {query}: {data.get('count', 0)}{total_text} products ({data.get('elapsed_ms')} ms)")
+    children = data.get("child_categories") or []
+    if children:
+        print("Child categories: " + ", ".join(str(c.get("name")) for c in children[:8] if c.get("name")))
+    print()
+    for p in data.get("products") or []:
+        bits = [price_label(p)]
+        ranges = [x for x in p.get("product_ranges") or [] if x]
+        offers = [x for x in p.get("product_offers") or [] if x]
+        if ranges:
+            bits.append(", ".join(str(x) for x in ranges))
+        if offers:
+            bits.append(", ".join(str(x) for x in offers))
+        rating = p.get("rating")
+        if rating:
+            bits.append(f"rating {rating}")
+        print(f"{p.get('sku'):>8}  {' '.join(x for x in [p.get('brand'), p.get('name')] if x)}")
+        print("          " + " | ".join(str(x) for x in bits if x))
+        if p.get("category"):
+            print(f"          category: {p.get('category')}")
+        if p.get("source_url"):
+            print(f"          {p.get('source_url')}")
+        print()
+
+
+def print_product_detail(data: dict[str, Any]) -> None:
+    p = data["product"]
+    print(f"{data.get('country')}: {p.get('sku')}  {' '.join(x for x in [p.get('brand'), p.get('name')] if x)}")
+    print(f"Price: {price_label(p)}")
+    ranges = [x for x in p.get("product_ranges") or [] if x]
+    if ranges:
+        print("Fulfilment: " + ", ".join(str(x) for x in ranges))
+    stock = p.get("stock") or {}
+    stock_bits = []
+    if stock.get("store"):
+        stock_bits.append(str(stock["store"]))
+    if stock.get("in_store_text"):
+        stock_bits.append(str(stock["in_store_text"]))
+    if stock.get("in_store_stock") is not None:
+        stock_bits.append(f"{stock.get('in_store_stock')} in store")
+    if stock_bits:
+        print("Stock: " + " | ".join(stock_bits))
+    locations = p.get("aisle_locations") or []
+    if locations:
+        loc = locations[0]
+        print(f"Location: aisle {loc.get('aisle')}, bay {loc.get('bay')}")
+    if p.get("category"):
+        print(f"Category: {p.get('category')}")
+    if p.get("rating"):
+        print(f"Rating: {p.get('rating')} ({p.get('rating_count') or 0} reviews)")
+    if p.get("source_url"):
+        print(p["source_url"])
+
+
+def compact_hours(hours: list[dict[str, Any]]) -> str:
+    out = []
+    for item in hours[:7]:
+        if item.get("closed"):
+            out.append(f"{item.get('day')}: closed")
+        elif item.get("open") and item.get("close"):
+            out.append(f"{item.get('day')}: {item.get('open')}-{item.get('close')}")
+    return "; ".join(out)
+
+
+def print_stores(data: dict[str, Any]) -> None:
+    region = f" {data.get('region')}" if data.get("region") else ""
+    print(f"{data.get('country')} stores{region}: {data.get('count')} stores ({data.get('elapsed_ms')} ms)")
+    print()
+    for s in data.get("stores") or []:
+        print(f"{s.get('code'):>5}  {s.get('name')}")
+        bits = [s.get("address"), s.get("phone"), s.get("email")]
+        print("       " + " | ".join(str(x) for x in bits if x))
+        hours = compact_hours(s.get("hours") or [])
+        if hours:
+            print(f"       {hours}")
+        if s.get("source_url"):
+            print(f"       {s.get('source_url')}")
+        print()
+
+
+def emit(data: dict[str, Any], as_json: bool, kind: str) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2, ensure_ascii=False))
+    elif kind == "product":
+        print_product_detail(data)
+    elif kind == "stores":
+        print_stores(data)
+    else:
+        print_products(data, kind)
+
+
+def cmd_search(args: argparse.Namespace) -> None:
+    emit(search_products(country_cfg(args.country), args.query, args.limit), args.json, "search")
+
+
+def cmd_product(args: argparse.Namespace) -> None:
+    emit(product_detail(country_cfg(args.country), args.sku), args.json, "product")
+
+
+def cmd_browse(args: argparse.Namespace) -> None:
+    emit(browse_category(country_cfg(args.country), args.category, args.limit), args.json, "browse")
+
+
+def cmd_stores(args: argparse.Namespace) -> None:
+    emit(stores(country_cfg(args.country), args.region, args.limit), args.json, "stores")
+
+
+def cmd_specials(args: argparse.Namespace) -> None:
+    emit(promotional_products(country_cfg(args.country), args.query, args.limit), args.json, "specials")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description="Lightweight Bunnings NZ/AU public read-only product and store lookup CLI.")
+    ap.add_argument("--country", choices=sorted(COUNTRIES), default=os.environ.get("BUNNINGS_COUNTRY", "nz").lower(), help="site country, default nz")
+    sub = ap.add_subparsers(dest="command", required=True)
+
+    sp = sub.add_parser("search", help="search products")
+    sp.add_argument("query")
+    sp.add_argument("--limit", type=int, default=10)
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_search)
+
+    sp = sub.add_parser("product", help="fetch product details by SKU or product URL")
+    sp.add_argument("sku")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_product)
+
+    sp = sub.add_parser("browse", help="browse a product category path")
+    sp.add_argument("category", help="category path, e.g. tools/power-tools/drills")
+    sp.add_argument("--limit", type=int, default=10)
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_browse)
+
+    sp = sub.add_parser("stores", help="list stores")
+    sp.add_argument("--region", help="region/path/name filter, e.g. uppernorthisland, lowernorthisland, nsw")
+    sp.add_argument("--limit", type=int, default=20)
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_stores)
+
+    sp = sub.add_parser("specials", help="list redemption/promotion products, optionally filtered by query")
+    sp.add_argument("query", nargs="?")
+    sp.add_argument("--limit", type=int, default=10)
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_specials)
+    return ap
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Added `skills/bunnings/` with a lightweight Python stdlib read-only CLI.
- Supports Bunnings NZ product search, product detail/pricing/default-store stock, category browse, store locator, and redemption/promotion products.
- Includes optional Bunnings AU support via `--country au`.
- Documents discovered public page-state endpoints and the auth boundary for browser-only `_apis` calls.

## Verified live test output

Ran from `/tmp/.skills-bunnings/skills/bunnings` on 2026-05-23 UTC.

### `python3 scripts/cli.py --help`

```text
usage: cli.py [-h] [--country {au,nz}]
              {search,product,browse,stores,specials} ...

Lightweight Bunnings NZ/AU public read-only product and store lookup CLI.
```

### `python3 scripts/cli.py search drill --limit 5`

```text
Bunnings NZ: drill: 5 of 403 products (1460 ms)

 0715241  Ryobi One+ Ryobi 18V ONE+ Drill Driver Starter Kit R18DD22
          $99.98 NZD | Click & Collect, Delivery | rating 4.81
          category: Tools / Power Tools / Drills / Drill Drivers
          https://www.bunnings.co.nz/ryobi-18v-one-drill-driver-starter-kit-r18dd22_p0715241
```

### `python3 scripts/cli.py product 0715241`

```text
Bunnings NZ: 0715241  Ryobi One+ Ryobi 18V ONE+ Drill Driver Starter Kit R18DD22
Price: $99.98
Fulfilment: Click & Collect, In-Store, Delivery
Stock: Lyall Bay | inStock | 108 in store
Location: aisle 12, bay 2
Category: Tools / Power Tools / Drills / Drill Drivers
Rating: 4.8 (107 reviews)
https://www.bunnings.co.nz/ryobi-18v-one-drill-driver-starter-kit-r18dd22_p0715241
```

### `python3 scripts/cli.py browse tools/power-tools/drills --limit 5`

```text
Bunnings NZ: /products/tools/power-tools/drills: 5 of 403 products (1401 ms)
Child categories: Cordless Drill Skins, Cordless Power Tool & Drill Kits, Cordless Screwdrivers, Drill Drivers, Hammer Drills, Impact Drill Drivers, Rotary Hammer Drills

 0715241  Ryobi One+ Ryobi 18V ONE+ Drill Driver Starter Kit R18DD22
          $99.98 NZD | Click & Collect, Delivery | rating 4.81
          category: Tools / Power Tools / Drills / Drill Drivers
```

### `python3 scripts/cli.py stores --region uppernorthisland --limit 3`

```text
Bunnings NZ stores uppernorthisland: 3 stores (2746 ms)

 9453  Botany
       Burswood, 320 Ti Rakau Drive, 2013, Auckland | 09 265 5200 | Botany@bunnings.co.nz
       https://www.bunnings.co.nz/stores/uppernorthisland/botany
```

### `python3 scripts/cli.py specials dewalt --limit 3`

```text
Bunnings NZ: dewalt: 3 products (1528 ms)

 0274900  DEWALT DeWALT 254mm 2000W Heavy Duty Portable Table Saw DWE7491-XE
          $1274.20 NZD | Click & Collect, Delivery | Redemption Offer | rating 4.49
          category: Tools / Power Tools / Power Saws / Benchtop Tools / Table Saws
          https://www.bunnings.co.nz/dewalt-254mm-2000w-heavy-duty-portable-table-saw-dwe7491-xe_p0274900
```

### JSON and AU smoke checks

```text
python3 scripts/cli.py search drill --limit 2 --json
=> JSON output returned 2 products, total_count 403.

python3 scripts/cli.py --country au search drill --limit 2
=> Bunnings AU returned 2 of 427 products.
```
