### PR TITLE
feat: add Eventfinda NZ skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ We are borrowing the shape of the best public skills repos, but not copying thei
 |-------|--------|------|-------------|
 | `at-transport` | dev-portal.at.govt.nz | API key required | [Adam Holt](https://github.com/adam91holt) |
 | `auckland-bin-schedule` | Auckland Council rubbish/recycling/food scraps collection days | No auth | [Adam Holt](https://github.com/adam91holt) |
+| `eventfinda-nz` | Eventfinda NZ public event listing pages and event JSON-LD | No account login | [Adam Holt](https://github.com/adam91holt) |
 | `fuelclock-nz` | fuelclock.nz (prices, supply, vessels, risk markets, headlines) | No auth | [Adam Holt](https://github.com/adam91holt) |
 | `metservice-nz` | MetService / marine API | No auth | [Adam Holt](https://github.com/adam91holt) |
 | `newworld-nz` | New World NZ public website guest-token APIs | No account login | [Adam Holt](https://github.com/adam91holt) |

--- a/skills/eventfinda-nz/SKILL.md
+++ b/skills/eventfinda-nz/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: eventfinda-nz
+description: Search and inspect public Eventfinda New Zealand event listings from the no-login website pages. Use when the task involves finding NZ events by location, category, or keyword, getting Eventfinda event URLs, venues, dates, public session times, ticket badges, images, or JSON-LD detail from public event pages.
+---
+
+# Eventfinda NZ
+
+## Goal
+
+Query live public Eventfinda New Zealand event listings through a small deterministic CLI with human-readable and JSON output.
+
+## Use this when
+
+- A user asks what events are on in Auckland, Wellington, Christchurch, or New Zealand generally
+- A workflow needs Eventfinda event titles, URLs, venues, dates, categories, badges, or images
+- A user has an Eventfinda event URL/path and wants structured details, sessions, venue address, geo coordinates, or offer/pricing metadata published in the page JSON-LD
+- An agent needs a no-login NZ event discovery source before checking venue-specific sources
+
+## Do not use this for
+
+- Buying tickets, reserving seats, logging into Eventfinda, or changing account data
+- High-volume scraping, full-site mirroring, or alerting that hammers Eventfinda pages
+- Private organiser, attendee, sales, or ticket inventory data
+- Treating scraped public website structure as a permanent API contract
+- The official Eventfinda developer API unless you explicitly have credentials and add a separate authenticated wrapper
+
+## Preferred workflow
+
+1. Run `scripts/cli.py upcoming --location <slug>` for broad discovery
+2. Use `search <query>` for keyword searches such as artists, festivals, venues, or genres
+3. Pass the chosen event URL to `event <url>` for structured JSON-LD details and sessions
+4. Use `--json` for agent chaining, comparisons, or structured summaries
+5. Cite Eventfinda event URLs and include the date/venue when reporting findings
+6. If a listing has repeated sessions, summarize the first few and mention the total session count
+
+## CLI
+
+Run with:
+
+```bash
+python3 skills/eventfinda-nz/scripts/cli.py <command> [flags]
+```
+
+### Commands
+
+- `upcoming [--location slug] [--category slug] [--page N] [--limit N] [--json]` — list public Eventfinda event cards from a location/category page
+- `search <query> [--page N] [--limit N] [--json]` — search Eventfinda public pages by keyword
+- `event <url-or-path> [--json] [--raw]` — inspect a public Eventfinda event detail page using embedded JSON-LD
+
+Examples:
+
+```bash
+python3 skills/eventfinda-nz/scripts/cli.py upcoming --location auckland --limit 5
+python3 skills/eventfinda-nz/scripts/cli.py upcoming --location wellington --category concerts-gig-guide --limit 5 --json
+python3 skills/eventfinda-nz/scripts/cli.py search "jazz" --limit 5 --json
+python3 skills/eventfinda-nz/scripts/cli.py event /2026/classic-comedy-all-stars-festival-edition/auckland --json
+python3 skills/eventfinda-nz/scripts/cli.py event https://www.eventfinda.co.nz/2026/classic-comedy-all-stars-festival-edition/auckland --raw --json
+```
+
+## Location and category slugs
+
+The CLI uses Eventfinda website URL slugs. Common locations include:
+
+- `new-zealand`
+- `auckland`
+- `wellington`
+- `christchurch`
+- `hamilton`
+- `dunedin`
+- `tauranga`
+
+Category slugs are the same path segments Eventfinda uses, for example:
+
+- `concerts-gig-guide`
+- `festivals-lifestyle`
+- `performing-arts`
+- `sports-outdoors`
+- `exhibitions`
+- `comedy`
+
+If a category/location combination produces no cards, try the broader `upcoming --location <slug>` page or `search <query>`.
+
+## Resources
+
+- CLI entrypoint: `scripts/cli.py`
+- Live smoke test: `scripts/smoke-test.ts`
+- API and website notes: `references/api-notes.md`
+
+## Notes
+
+- No username, password, API key, account cookie, or browser automation is required for the implemented public website commands
+- The official `api.eventfinda.co.nz/v2` developer API returned `401 Incorrect authentication details supplied` without Basic-auth credentials during verification; this skill intentionally uses public website pages instead
+- Listing pages are parsed from public HTML event cards; detail pages are parsed from embedded Schema.org JSON-LD
+- Eventfinda page markup can change; run the smoke test before relying on this skill in automation
+- Keep requests narrow and respectful

--- a/skills/eventfinda-nz/references/api-notes.md
+++ b/skills/eventfinda-nz/references/api-notes.md
@@ -1,0 +1,66 @@
+# Eventfinda NZ API and website notes
+
+This skill is an unofficial lightweight wrapper around public Eventfinda New Zealand website pages. It does not use account login, cookies, ticket purchasing flows, or private organiser/customer data.
+
+## Source and auth
+
+- Public website: `https://www.eventfinda.co.nz`
+- Public listing examples:
+  - `https://www.eventfinda.co.nz/whatson/events/new-zealand`
+  - `https://www.eventfinda.co.nz/whatson/events/auckland`
+  - `https://www.eventfinda.co.nz/search?q=music`
+- Event detail pages include Schema.org JSON-LD in `<script type="application/ld+json">` blocks
+- Official developer API host tested: `https://api.eventfinda.co.nz/v2`
+- Auth model for this skill: none for the implemented public website requests
+
+No username, password, account cookie, browser session, or API key is required for the implemented commands.
+
+## Official developer API caveat
+
+The Eventfinda developer API exists separately from the public website pages and is Basic-auth gated. During verification, this unauthenticated request:
+
+```text
+GET https://api.eventfinda.co.nz/v2/events.json?rows=1
+=> 401 Incorrect authentication details supplied.
+```
+
+Because the `.skills` repo favours immediately usable public/read-only skills where possible, this skill does not require Eventfinda API credentials. If authenticated developer API access becomes available later, add it as an explicit credential-backed mode rather than silently changing the no-auth commands.
+
+## Endpoint/page families used
+
+### Listings
+
+The CLI reads Eventfinda HTML listing cards from public pages:
+
+- Upcoming events by location: `/whatson/events/{location}`
+- Upcoming events by category/location: `/{category}/events/{location}`
+- Keyword search: `/search?q={query}`
+
+Cards currently expose enough public data for discovery:
+
+- internal Eventfinda event id from the `_efC(...)` tracking call when present
+- title and canonical event URL/path
+- venue/location text
+- start timestamp from the microformat `value-title` attribute
+- human date text
+- category
+- card image URL
+- public badges such as sold-out/ticket status badges
+
+### Event detail pages
+
+Detail pages currently include Schema.org JSON-LD objects for:
+
+- `Place` venue/address/geo data
+- `Offer` ticket/price metadata visible in the page
+- one or more `*Event` objects, typically one per session/date
+
+The CLI resolves the first event's place/offers and aggregates unique sessions into `event.sessions[]`.
+
+## Stability and safety
+
+- This is public website parsing, not a formal stable third-party API contract.
+- Markup can change. Run `scripts/smoke-test.ts` or a live `upcoming` + `event` poke before production use.
+- Avoid high-volume scraping, full-site replication, or rapid polling.
+- Do not automate ticket purchases, checkout, account actions, or private organiser/customer workflows.
+- Treat results as live public snapshots; venues, dates, prices, and availability can change.

--- a/skills/eventfinda-nz/scripts/cli.py
+++ b/skills/eventfinda-nz/scripts/cli.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""Eventfinda NZ public website lookup CLI.
+
+Self-contained stdlib wrapper around public Eventfinda NZ pages. It does not
+use account login, cookies, or the Basic-auth Eventfinda developer API.
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+BASE = "https://www.eventfinda.co.nz"
+UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146 Safari/537.36"
+EVENT_TYPES = {"Event", "BusinessEvent", "ChildrensEvent", "ComedyEvent", "CourseInstance", "DanceEvent", "DeliveryEvent", "EducationEvent", "ExhibitionEvent", "Festival", "FoodEvent", "LiteraryEvent", "MusicEvent", "PublicationEvent", "SaleEvent", "ScreeningEvent", "SocialEvent", "SportsEvent", "TheaterEvent", "VisualArtsEvent"}
+
+
+def die(message: str, code: int = 1) -> None:
+    print(f"eventfinda-nz: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def get(url_or_path: str, timeout: int = 30) -> tuple[str, str, int]:
+    if url_or_path.startswith("http://") or url_or_path.startswith("https://"):
+        url = url_or_path
+    else:
+        url = BASE + (url_or_path if url_or_path.startswith("/") else "/" + url_or_path)
+    req = urllib.request.Request(url, headers={"User-Agent": UA, "Accept": "text/html,application/xhtml+xml"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", "replace")
+            return body, resp.geturl(), resp.status
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8", "replace")
+        die(f"HTTP {e.code} from {url}: {strip_tags(raw)[:240]}")
+    except urllib.error.URLError as e:
+        die(f"network error calling {url}: {e.reason}")
+
+
+def strip_tags(value: str) -> str:
+    value = re.sub(r"<script\b.*?</script>", " ", value, flags=re.I | re.S)
+    value = re.sub(r"<style\b.*?</style>", " ", value, flags=re.I | re.S)
+    value = re.sub(r"<br\s*/?>", " | ", value, flags=re.I)
+    value = re.sub(r"<[^>]+>", " ", value)
+    value = html.unescape(value).replace("\xa0", " ")
+    return re.sub(r"\s+", " ", value).strip(" |\t\r\n")
+
+
+def absolutize(url: str | None) -> str | None:
+    if not url:
+        return None
+    return urllib.parse.urljoin(BASE, html.unescape(url))
+
+
+def attr(tag: str, name: str) -> str | None:
+    m = re.search(rf"\b{name}=['\"]([^'\"]+)['\"]", tag, flags=re.I)
+    return html.unescape(m.group(1)) if m else None
+
+
+def event_cards(page_html: str, limit: int) -> list[dict[str, Any]]:
+    starts = [m.start() for m in re.finditer(r'<div\s+class="card\s+h-event\b', page_html, flags=re.I)]
+    cards: list[dict[str, Any]] = []
+    for idx, start in enumerate(starts):
+        end = starts[idx + 1] if idx + 1 < len(starts) else min(len(page_html), start + 9000)
+        block = page_html[start:end]
+        title_m = re.search(r'<h2[^>]*class="[^"]*p-summary[^"]*"[^>]*>\s*<a\s+([^>]+)>(.*?)</a>', block, flags=re.I | re.S)
+        if not title_m:
+            continue
+        href = attr(title_m.group(1), "href")
+        title = strip_tags(title_m.group(2))
+        if not href or not title:
+            continue
+        id_m = re.search(r'_efC\(\s*\d+\s*,\s*(\d+)\s*\)', block)
+        loc_m = re.search(r'<p[^>]*class="[^"]*meta-location[^"]*"[^>]*>(.*?)</p>', block, flags=re.I | re.S)
+        date_title_m = re.search(r'<span\s+class="value-title"\s+title="([^"]+)"', block, flags=re.I)
+        date_display_m = re.search(r'<span\s+class="value-title"\s+title="[^"]+"\s*>\s*(.*?)\s*</span>', block, flags=re.I | re.S)
+        category_m = re.search(r'<span\s+class="category"[^>]*>(.*?)</span>', block, flags=re.I | re.S)
+        img_m = re.search(r'<img\s+([^>]+)>', block, flags=re.I | re.S)
+        badge_texts = [strip_tags(x) for x in re.findall(r'<span[^>]*class="[^"]*badge[^"]*"[^>]*>(.*?)</span>', block, flags=re.I | re.S)]
+        item = {
+            "id": id_m.group(1) if id_m else None,
+            "title": title,
+            "url": absolutize(href),
+            "path": href,
+            "location": strip_tags(loc_m.group(1)) if loc_m else None,
+            "start": html.unescape(date_title_m.group(1)) if date_title_m else None,
+            "date_text": strip_tags(date_display_m.group(1)) if date_display_m else None,
+            "category": strip_tags(category_m.group(1)) if category_m else None,
+            "image": absolutize(attr(img_m.group(1), "src") or attr(img_m.group(1), "data-src")) if img_m else None,
+            "badges": [b for b in badge_texts if b],
+        }
+        cards.append(item)
+        if len(cards) >= limit:
+            break
+    return cards
+
+
+def list_path(location: str | None, category: str | None, page: int) -> str:
+    loc = (location or "new-zealand").strip("/")
+    if loc in ("", "nz", "all"):
+        loc = "new-zealand"
+    if category:
+        # Eventfinda category pages use /{category}/events/{location}, e.g.
+        # /concerts-gig-guide/events/auckland rather than /whatson/{category}/...
+        bits = [urllib.parse.quote(category.strip("/")), "events", urllib.parse.quote(loc)]
+    else:
+        bits = ["whatson", "events", urllib.parse.quote(loc)]
+    path = "/" + "/".join(bits)
+    if page > 1:
+        path += "?page=" + str(page)
+    return path
+
+
+def cmd_upcoming(args: argparse.Namespace) -> None:
+    started = time.perf_counter()
+    body, final_url, status = get(list_path(args.location, args.category, args.page))
+    data = {
+        "source_url": final_url,
+        "status": status,
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+        "location": args.location or "new-zealand",
+        "category": args.category,
+        "page": args.page,
+        "events": event_cards(body, args.limit),
+    }
+    emit_events(data, args.json)
+
+
+def cmd_search(args: argparse.Namespace) -> None:
+    if not args.query.strip():
+        die("search query is required")
+    started = time.perf_counter()
+    qs = urllib.parse.urlencode({"q": args.query, **({"page": args.page} if args.page > 1 else {})})
+    body, final_url, status = get(f"/search?{qs}")
+    data = {
+        "source_url": final_url,
+        "status": status,
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+        "query": args.query,
+        "page": args.page,
+        "events": event_cards(body, args.limit),
+    }
+    emit_events(data, args.json)
+
+
+def json_ld_objects(page_html: str) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for m in re.finditer(r'<script[^>]+application/ld\+json[^>]*>(.*?)</script>', page_html, flags=re.I | re.S):
+        raw = html.unescape(m.group(1)).strip()
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, list):
+            out.extend(x for x in parsed if isinstance(x, dict))
+        elif isinstance(parsed, dict):
+            out.append(parsed)
+    return out
+
+
+def simplify_offer(offer: dict[str, Any]) -> dict[str, Any]:
+    return {k: offer.get(k) for k in ("@id", "name", "price", "priceCurrency", "availability", "url") if offer.get(k) is not None}
+
+
+def cmd_event(args: argparse.Namespace) -> None:
+    started = time.perf_counter()
+    body, final_url, status = get(args.url_or_path)
+    objs = json_ld_objects(body)
+    by_id = {o.get("@id"): o for o in objs if o.get("@id")}
+    places = {o.get("@id"): o for o in objs if o.get("@type") == "Place" and o.get("@id")}
+    offers = {o.get("@id"): o for o in objs if o.get("@type") == "Offer" and o.get("@id")}
+    events = [o for o in objs if str(o.get("@type", "")).split("/")[-1] in EVENT_TYPES or str(o.get("@type", "")).endswith("Event")]
+    if not events:
+        die("no event JSON-LD found on page")
+    first = events[0]
+    loc_ref = first.get("location") if isinstance(first.get("location"), dict) else {}
+    place = places.get(loc_ref.get("@id")) or (loc_ref if isinstance(loc_ref, dict) else {})
+    resolved_offers: list[dict[str, Any]] = []
+    for ref in first.get("offers") or []:
+        if isinstance(ref, dict) and ref.get("@id") in offers:
+            resolved_offers.append(simplify_offer(offers[ref["@id"]]))
+        elif isinstance(ref, dict):
+            resolved_offers.append(simplify_offer(ref))
+    sessions = []
+    seen = set()
+    for e in events:
+        key = (e.get("startDate"), e.get("endDate"))
+        if key in seen:
+            continue
+        seen.add(key)
+        sessions.append({"start": e.get("startDate"), "end": e.get("endDate")})
+    address = place.get("address") if isinstance(place.get("address"), dict) else {}
+    event = {
+        "title": first.get("name"),
+        "type": first.get("@type"),
+        "url": first.get("url") or final_url,
+        "description": first.get("description"),
+        "image": first.get("image"),
+        "venue": place.get("name"),
+        "venue_url": place.get("url") or place.get("@id"),
+        "address": {
+            "street": address.get("streetAddress"),
+            "locality": address.get("addressLocality"),
+            "country": address.get("addressCountry"),
+        },
+        "geo": place.get("geo") if isinstance(place.get("geo"), dict) else None,
+        "sessions": sessions,
+        "offers": resolved_offers,
+    }
+    data = {
+        "source_url": final_url,
+        "status": status,
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+        "event": event,
+        "raw_json_ld": objs if args.raw else None,
+    }
+    emit_detail(data, args.json)
+
+
+def emit_events(data: dict[str, Any], as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False))
+        return
+    print(f"Eventfinda events: showing {len(data['events'])} from {data['source_url']} ({data['elapsed_ms']} ms)")
+    print()
+    for item in data["events"]:
+        print(f"{item.get('title')}")
+        bits = [item.get("date_text") or item.get("start"), item.get("location"), item.get("category")]
+        print("  " + " | ".join(str(x) for x in bits if x))
+        if item.get("badges"):
+            print("  " + "; ".join(item["badges"][:3]))
+        print(f"  {item.get('url')}")
+        print()
+
+
+def emit_detail(data: dict[str, Any], as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2, sort_keys=True, ensure_ascii=False))
+        return
+    e = data["event"]
+    print(e.get("title"))
+    print(f"  {e.get('type')} | {e.get('venue') or ''}")
+    addr = e.get("address") or {}
+    addr_text = ", ".join(str(x) for x in [addr.get("street"), addr.get("locality"), addr.get("country")] if x)
+    if addr_text:
+        print(f"  {addr_text}")
+    for s in e.get("sessions")[:8]:
+        print(f"  {s.get('start')} – {s.get('end')}")
+    if len(e.get("sessions") or []) > 8:
+        print(f"  ... {len(e['sessions']) - 8} more sessions")
+    if e.get("offers"):
+        prices = [f"{o.get('name')}: ${o.get('price')}" for o in e["offers"][:5] if o.get("price")]
+        if prices:
+            print("  offers: " + "; ".join(prices))
+    print(f"  {e.get('url') or data.get('source_url')}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Search and inspect public Eventfinda NZ event listings")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    u = sub.add_parser("upcoming", help="list upcoming Eventfinda events by location/category page")
+    u.add_argument("--location", default="new-zealand", help="location slug, e.g. new-zealand, auckland, wellington, christchurch")
+    u.add_argument("--category", help="optional category path segment, e.g. concerts-gig-guide, festivals-lifestyle")
+    u.add_argument("--page", type=int, default=1, help="one-based Eventfinda page number")
+    u.add_argument("--limit", type=int, default=10, help="max event cards to emit")
+    u.add_argument("--json", action="store_true", help="emit JSON")
+    u.set_defaults(func=cmd_upcoming)
+
+    s = sub.add_parser("search", help="search public Eventfinda pages")
+    s.add_argument("query", help="search text")
+    s.add_argument("--page", type=int, default=1, help="one-based Eventfinda page number")
+    s.add_argument("--limit", type=int, default=10, help="max event cards to emit")
+    s.add_argument("--json", action="store_true", help="emit JSON")
+    s.set_defaults(func=cmd_search)
+
+    e = sub.add_parser("event", help="inspect an event detail page URL/path using JSON-LD")
+    e.add_argument("url_or_path", help="Eventfinda event URL or path")
+    e.add_argument("--json", action="store_true", help="emit JSON")
+    e.add_argument("--raw", action="store_true", help="include raw JSON-LD objects in JSON output")
+    e.set_defaults(func=cmd_event)
+    return p
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    if hasattr(args, "limit"):
+        args.limit = min(max(1, args.limit), 50)
+    if hasattr(args, "page"):
+        args.page = max(1, args.page)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/eventfinda-nz/scripts/smoke-test.ts
+++ b/skills/eventfinda-nz/scripts/smoke-test.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const cliPath = resolve(__dirname, 'cli.py');
+
+function run(args: string[]) {
+  const result = spawnSync('python3', [cliPath, ...args], {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: 60_000,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`eventfinda-nz smoke failed: python3 ${cliPath} ${args.join(' ')}\n${result.stderr || result.stdout}`);
+  }
+  return result.stdout;
+}
+
+run(['--help']);
+const upcomingRaw = run(['upcoming', '--location', 'auckland', '--limit', '3', '--json']);
+const upcoming = JSON.parse(upcomingRaw) as { events?: Array<Record<string, unknown>> };
+if (!Array.isArray(upcoming.events) || upcoming.events.length < 1) {
+  throw new Error('Expected upcoming JSON to include events[]');
+}
+const first = upcoming.events[0];
+if (typeof first.title !== 'string' || typeof first.url !== 'string') {
+  throw new Error('Expected first upcoming event to include title and url');
+}
+const searchRaw = run(['search', 'music', '--limit', '3', '--json']);
+const search = JSON.parse(searchRaw) as { events?: Array<Record<string, unknown>> };
+if (!Array.isArray(search.events)) {
+  throw new Error('Expected search JSON to include events[]');
+}
+const detailRaw = run(['event', String(first.url), '--json']);
+const detail = JSON.parse(detailRaw) as { event?: Record<string, unknown> };
+if (!detail.event?.title || !Array.isArray(detail.event.sessions)) {
+  throw new Error('Expected event detail JSON to include title and sessions[]');
+}
+console.log('eventfinda-nz smoke ok');


### PR DESCRIPTION
## Summary
- Add eventfinda-nz skill for public Eventfinda NZ event discovery
- Include stdlib Python CLI for upcoming listings, keyword search, and event-detail JSON-LD extraction
- Document no-auth website parsing plus the official Basic-auth API caveat

## Verification
- npm run validate-skill -- skills/eventfinda-nz
- npm run typecheck
- python3 -m py_compile skills/eventfinda-nz/scripts/cli.py
- npx tsx skills/eventfinda-nz/scripts/smoke-test.ts
- Live tested upcoming Auckland listings, category listings, keyword search, raw detail JSON-LD, human output, and invalid blank search handling
- Result: FULL_EVENTFINDA_LIVE_TESTS_OK