### PR TITLE
feat(nz-electricity): add outages command for major NZ lines companies

### DIFF
--- a/skills/nz-electricity/SKILL.md
+++ b/skills/nz-electricity/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: nz-electricity
-description: Query public New Zealand electricity-market data through a lightweight no-login CLI. Use when the task involves current NZ wholesale regional spot prices, grid demand, current grid carbon intensity, historical nodal wholesale prices, or monthly generation output by fuel type. Read-only; uses public EM6 JSON feeds and Electricity Authority EMI CSV/report datasets.
+description: Query public New Zealand electricity-market and lines-company outage data through a lightweight no-login CLI. Use when the task involves current NZ wholesale regional spot prices, grid demand, current grid carbon intensity, historical nodal wholesale prices, monthly generation output by fuel type, or public outage records from supported NZ lines companies. Read-only; uses public EM6 JSON feeds, Electricity Authority EMI CSV/report datasets, and distributor outage feeds.
 ---
 
 # NZ Electricity
 
 ## Goal
 
-Query New Zealand electricity-market information through a small deterministic CLI with human-readable and JSON output, without browser automation, login, API keys, or local cache state.
+Query New Zealand electricity-market and outage information through a small deterministic CLI with human-readable and JSON output, without browser automation, login, private API keys, or local cache state.
 
 This skill ships support for:
 
@@ -16,6 +16,7 @@ This skill ships support for:
 - Electricity Authority EMI trading-period grid demand by New Zealand or zone region
 - Electricity Authority EMI final/interim historical energy prices by point of connection
 - Electricity Authority EMI monthly generation output by plant, aggregated by fuel type
+- Public outage feeds for supported NZ lines companies
 
 ## Use this when
 
@@ -24,6 +25,7 @@ This skill ships support for:
 - A user asks for current NZ grid carbon intensity or renewable percentage
 - A user wants historical wholesale spot prices for a node or point of connection
 - A user wants monthly NZ generation output by fuel type or generation plant
+- A user asks for current or planned public outages from supported NZ lines companies
 - A workflow needs public, no-login, machine-readable NZ electricity data
 
 ## Do not use this for
@@ -31,7 +33,7 @@ This skill ships support for:
 - Retail plan comparison, tariff advice, Powerswitch-style savings, or ICP-specific billing questions
 - Authenticated EMI API products, EM6 paid feeds, private user data, or account actions
 - Current real-time node load, current node generation, or current generation mix; the documented EM6 endpoints for those returned unauthorized in live testing
-- Outage reporting; lines-company outage feeds are not implemented
+- ICP-specific outage status, outage subscriptions, outage reporting, or fault logging
 - Redistributing public-data extracts as a standalone dataset
 
 ## Preferred workflow
@@ -41,8 +43,9 @@ This skill ships support for:
 3. Use `demand --region` for national or EMI zone-level grid demand
 4. Use `prices --node ... --from ... --to ...` for historical nodal prices
 5. Use `generation --month ... --type ...` for generation by fuel type from EMI monthly data
-6. Use `--json` when another tool or agent needs machine-readable output
-7. Mention the upstream source and whether the value is current EM6 data or EMI report/dataset data
+6. Use `outages --company ...` or `outages --region ...` for lines-company public outage records
+7. Use `--json` when another tool or agent needs machine-readable output
+8. Mention the upstream source and whether the value is current EM6 data, EMI report/dataset data, or a distributor outage feed
 
 ## CLI
 
@@ -59,6 +62,7 @@ python3 skills/nz-electricity/scripts/cli.py <command> [flags]
 - `demand [--region REGION] [--from DATE] [--to DATE] [--json]` — EMI trading-period grid demand for New Zealand or an EMI zone
 - `prices --node NODE [--from DATE] [--to DATE] [--json]` — EMI historical final/interim energy prices for a point of connection
 - `generation [--month YYYY-MM] [--type fuel] [--limit N] [--json]` — EMI monthly generation output by fuel type and plant
+- `outages [--company COMPANY] [--region REGION] [--all] [--json]` — current public outage records from supported NZ lines companies; `--all` also includes planned, scheduled, or recent records where feeds expose them
 
 Examples:
 
@@ -69,6 +73,8 @@ python3 skills/nz-electricity/scripts/cli.py carbon --json
 python3 skills/nz-electricity/scripts/cli.py demand --region UNI --from 2026-05-22 --to 2026-05-22 --json
 python3 skills/nz-electricity/scripts/cli.py prices --node BEN2201 --from 2026-05-20 --to 2026-05-20 --json
 python3 skills/nz-electricity/scripts/cli.py generation --month 2026-04 --type hydro --limit 5 --json
+python3 skills/nz-electricity/scripts/cli.py outages --company vector
+python3 skills/nz-electricity/scripts/cli.py outages --region tahawai --json
 ```
 
 ## Resources
@@ -78,13 +84,17 @@ python3 skills/nz-electricity/scripts/cli.py generation --month 2026-04 --type h
 
 ## Notes
 
-- No API key, username, password, cookie, or browser session is required for implemented commands
+- No private API key, username, password, cookie, or browser session is required for implemented commands
 - `spot` and `carbon` use EM6 public free JSON feeds from `https://api.em6.co.nz/ords/em6/data_api`
 - `demand` uses the public Electricity Authority EMI Demand trends CSV report from `https://www.emi.ea.govt.nz/Wholesale/Reports/W_GD_C`
 - `prices` and `generation` use public Electricity Authority EMI CSV dataset files from `https://www.emi.ea.govt.nz`
+- `outages` uses clean public distributor feeds for Vector, Wellington Electricity, Orion, Powerco, Aurora Energy, WEL Networks, Unison, Counties Energy, and Top Energy
+- Vector's public map exposes outage shapes only, so Vector records may only have an approximate centroid and outage type
+- Northpower was checked but not shipped because its outage map uses Livewire snapshot/update state rather than a clean stable public JSON feed
 - EM6 regional spot prices are current dispatch-price snapshots and may update every five minutes
 - EMI demand is trading-period report data in GWh; current-day data may be partial and recent periods can use final-pricing proxy conventions described by EMI
 - EMI final/interim energy prices are half-hourly by point of connection; recent files may be interim until finalized
 - EMI generation output by plant is monthly and historical, not current real-time generation mix
+- Distributor outage feeds vary by company and may omit cause, customer count, or restoration time
 - Default output is human-readable; every data command supports `--json` for chaining into other tools
 - Avoid high-volume polling; use narrow regions, nodes, date ranges, and months

--- a/skills/nz-electricity/references/api-notes.md
+++ b/skills/nz-electricity/references/api-notes.md
@@ -1,6 +1,6 @@
 # NZ Electricity API Notes
 
-This skill is a read-only wrapper around public New Zealand electricity data sources. It does not use authenticated API products, cookies, browser sessions, or paid feeds.
+This skill is a read-only wrapper around public New Zealand electricity data sources. It does not use authenticated API products, private credentials, cookies, browser sessions, or paid feeds.
 
 ## Sources shipped
 
@@ -58,6 +58,95 @@ Implemented datasets:
   - Data freshness: monthly, historical; latest observed file on 23 May 2026 was `202604_Generation_MD.csv`
   - Units: source columns are kWh by trading period; CLI aggregates to GWh
 
+### NZ lines-company public outage feeds
+
+- Command: `outages`
+- Auth model for implemented feeds: no login, cookies, browser session, or private credentials
+- Default behavior: fetch current/active outage records from every supported company
+- `--all`: include planned, scheduled, or recent records where the company feed exposes them
+- `--region`: case-insensitive text filter over company, location, cause, outage id, and raw record text
+
+Implemented feeds:
+
+- Vector
+  - Current endpoint: `GET https://outagereporter.api.vector.co.nz/outagereporter/outages/shapes`
+  - Planned endpoint used with `--all`: `GET https://outage-centre.api.vector.co.nz/v1/outages/planned-outages/shapes`
+  - Required header: public browser `apikey` value read from `https://help.vector.co.nz/address/config.js`
+  - Response shape: GeoJSON `FeatureCollection`; features include geometry and `properties.outageType`
+  - CLI mapping: location is an approximate geometry centroid; cause/status use `outageType`
+  - Quirks: public shape feed does not expose suburb, customer count, start time, restoration time, or a stable outage id. The more detailed `/outagereporter/outages` endpoint returned `403`, and subscription endpoints returned `401`.
+  - Refresh rate: not documented in the public config; the map fetches the feed on load.
+
+- Wellington Electricity
+  - Endpoint: `GET https://www.welectricity.co.nz/outages/getalloutages`
+  - Response shape: object with `plannedOutages` and `unplannedOutages` arrays
+  - Useful fields: `suburbsText`, `lastUpdatedCustomersAffected`, `lastUpdatedComments`, `lastUpdatedEta`, `timeOfFault`, `timeBasedStatus`, `customersAffected`, `reasonForOutage`, `outageStartDateTime`, `outageEndDateTime`
+  - CLI mapping: default includes unplanned rows with `timeBasedStatus=current` plus planned rows whose start/end window is active; `--all` includes all non-cancelled planned rows and current/recent unplanned rows
+  - Quirks: the page states there may be a short delay and that outages affecting fewer than 10 properties may not appear.
+  - Refresh rate: not documented; the endpoint is called directly by the outage page.
+
+- Orion
+  - Endpoint: `GET https://www.oriongroup.co.nz/outages-and-support/outages/refresh-outages`
+  - Response shape: object with `CurrentOutages`, `PlannedOutages`, `RecentOutages`, and `TimeStamp`
+  - Useful fields: `Areas`, `Streets`, `TotalNumberOff`, `MaxNumberOff`, `OutageCause`, `PublicComments`, `TimeDown`, `EstTimeUp`, `PlannedStart`, `PlannedEnd`, `IncidentRef`, `Latitude`, `Longitude`
+  - CLI mapping: default includes `CurrentOutages`; `--all` also includes non-cancelled `PlannedOutages`
+  - Quirks: the older APIM URL referenced by page JavaScript (`https://apim.oriongroup.co.nz/ws/rest/api/v1/outages`) returned `401`; the same page exposes the clean refresh endpoint above.
+  - Refresh rate: not documented; response includes its own `TimeStamp`.
+
+- Powerco
+  - Endpoint: `GET https://outages.powerco.co.nz/server/rest/services/Hosted/Outages/FeatureServer/1/query`
+  - Query parameters: `f=json`, `where=1=1`, `outFields=*`, `returnGeometry=true`, `orderByFields=interruption_start_date DESC`
+  - Response shape: ArcGIS FeatureServer `features[].attributes`
+  - Useful fields: `suburb`, `town`, `feeder`, `number_of_detail_records`, `interruption_reason`, `interruption_start_date`, `interruption_restore_date`, `distributor_event_number`, `planned_outage`
+  - CLI mapping: ArcGIS epoch millisecond timestamps are converted to ISO UTC; `planned_outage` controls the status label
+  - Quirks: the outage page redirects to an ArcGIS ExperienceBuilder app; the FeatureServer layer URL is in the app config.
+  - Refresh rate: not documented; treated as a live hosted ArcGIS layer.
+
+- Aurora Energy
+  - Current endpoint: `GET https://www.auroraenergy.co.nz/Umbraco/Api/Outage/currentCenterPoints`
+  - Planned endpoint used with `--all`: `GET https://www.auroraenergy.co.nz/Umbraco/Api/Outage/plannedCenterPoints`
+  - Related endpoints observed but not used: `currentPolygons`, `plannedPolygons`, `restoredCenterPoints`, `currentCounts`, `plannedCounts`
+  - Response shape: GeoJSON `FeatureCollection`; useful values live in `features[].properties`
+  - Useful fields: `eventNumber`, `eventStatus`, `suburbsAffected`, `town`, `streetsAffected`, `currentAffectedCustomers`, `plannedAffectedCustomers`, `totalFaultAffectedCustomers`, `groupOutages`, `eventCause`, `startDateTime`, `endDateTime`
+  - CLI mapping: current endpoint is used by default; `--all` also adds planned center points; grouped customer counts are used when the summary count is zero or missing.
+  - Refresh rate: not documented in the public JavaScript.
+
+- WEL Networks
+  - Endpoint: `POST https://server.ourpower.co.nz/api/?FETCH_GROUPED_FAULTS`
+  - Request body: `{"application":"outages","emit":true,"type":"FETCH_GROUPED_FAULTS"}`
+  - Response shape: object with `payload.groupedFaults[].incidents[]`
+  - Useful fields: group `lat`, group `lng`, incident `faultType`, `suburb`, `street`, `propertiesAffected`, `reason`, `start`, `end`, `incidentReference`
+  - CLI mapping: `faultType == 1` is planned; default includes unplanned incidents and planned incidents only when their start/end window is active; `--all` includes all planned rows.
+  - Quirks: `https://wel.co.nz/outages/` embeds `https://outages.wel.co.nz/?embed=true`; the embedded app calls this OurPower endpoint.
+  - Refresh rate: public app JavaScript polls every 60 seconds.
+
+- Unison
+  - Endpoint: `GET https://www.unison.co.nz/api/outages`
+  - Response shape: JSON array of outage objects
+  - Useful fields: `outageID`, `outageState`, `outageStatus`, `outageType`, `networkRegion`, `areaAffected`, `customersOff`, `interruptionReason`, `startTime`, `finishTime`
+  - CLI mapping: default includes states such as `current` and `ongoing`; `--all` also includes other non-cancelled, non-completed, non-recent states.
+  - Quirks: detailed time windows can appear under `outageWindows`; the CLI keeps the top-level fields in normal output and full raw record in JSON.
+  - Refresh rate: public React widget polls every 300,000 ms (5 minutes).
+
+- Counties Energy
+  - Current endpoint: `GET https://api.integration.countiesenergy.co.nz/user/v1.0/outages`
+  - Planned endpoint: `GET https://api.integration.countiesenergy.co.nz/user/v1.0/shutdowns`
+  - Current response shape: object with `service_orders[]`
+  - Planned response shape: object with `planned_outages[]`
+  - Useful fields: current `address`, `customersAffected`, `description`, `crewStatus`, `etrDateTime`, `serviceOrderDateTime`, `no`, `lat`, `lng`; planned `address`, `affectedCustomers`, `projectType`, `latestInformation`, `shutdownPeriods`, `id`, `lat`, `lng`
+  - CLI mapping: current service orders are always current records; planned rows are included by default only when their shutdown window is active, and all planned rows are included with `--all`.
+  - Quirks: `https://countiesenergy.co.nz/outages/` links to `https://app.countiesenergy.co.nz/#/`; the app bundle uses the integration endpoints above.
+  - Refresh rate: public app cache `staleTime` is 300,000 ms (5 minutes).
+
+- Top Energy
+  - Endpoint used by CLI: `GET https://outages.topenergy.co.nz/api/outages/regions`
+  - Related endpoint observed but not used for detail: `GET https://outages.topenergy.co.nz/api/outages`
+  - Response shape: object with `active[]` and `planned[]` arrays
+  - Useful fields: `name`, `circuitName`, `customersCurrentlyOff`, `additionalInformation`, `startDateTime`, `endDateTime`, `isActive`
+  - CLI mapping: active rows are current records; planned rows are included by default only when `isActive` is true, and all planned rows are included with `--all`.
+  - Quirks: the `/api/outages` marker endpoint is useful for map coordinates, but `/api/outages/regions` carries better outage details.
+  - Refresh rate: public app JavaScript checks poll state every 60 seconds.
+
 ## Official vs derived values
 
 - Official values:
@@ -77,4 +166,5 @@ Implemented datasets:
 - EM6 `price/24hrs/{node_id}`, `current_load/{node_id}`, `recent_load/{node_id}`, `current_generation/{node_id}`, `recent_generation/{node_id}`, `generation_type/24hrs/`, `nz/24hrs/`, and regional peak/load endpoints were documented in the EM6 guide but returned unauthorized or forbidden in live no-login testing from the public API base.
 - EMI Azure API products for real-time prices and dispatch require subscription-key access, so they are out of scope for this no-login skill.
 - Powerswitch plan comparison was skipped because it requires user-specific inputs and is not suitable for a stateless read-only market-data CLI.
-- Lines-company outage feeds were not implemented because no single clean national public API surface was identified during this build.
+- Northpower outage data was checked at `https://northpower.com/electricity/current-outages` and `https://outages.northpower.nz`. The public app renders Livewire snapshots and uses Livewire websocket/update calls with snapshot and CSRF state. No clean stable unauthenticated JSON or ArcGIS FeatureServer feed was found, so `outages --company northpower` reports a warning instead of scraping the rendered app state. The page says the outage list refreshes at least every 15 minutes.
+- Bonus distributors from the follow-up list (Mainpower, Marlborough Lines, Network Tasman, Electra, Westpower, Network Waitaki) were not investigated in this pass after nine of the top-ten target companies were wired.

--- a/skills/nz-electricity/scripts/cli.py
+++ b/skills/nz-electricity/scripts/cli.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 """NZ electricity public-data CLI.
 
-Read-only stdlib wrapper around public EM6 JSON feeds and EMI CSV datasets.
-No login, API key, browser automation, cache, or data mutation.
+Read-only stdlib wrapper around public electricity JSON feeds and EMI CSV datasets.
+No login, private API key, browser automation, cache, or data mutation.
 """
 from __future__ import annotations
 
@@ -106,6 +106,30 @@ def request_json(path: str, params: dict[str, Any] | None = None, timeout: int =
         die(f"network error calling {url}: {e.reason}")
     except json.JSONDecodeError as e:
         die(f"invalid JSON from {url}: {e}")
+
+
+def request_url_json(
+    url: str,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    method: str = "GET",
+    body: dict[str, Any] | None = None,
+    timeout: int = 20,
+) -> Any:
+    if params:
+        clean = {k: str(v) for k, v in params.items() if v is not None}
+        url += "?" + urllib.parse.urlencode(clean)
+    req_headers = {"User-Agent": UA, "Accept": "application/json, */*"}
+    if headers:
+        req_headers.update(headers)
+    data = None
+    if body is not None:
+        data = json.dumps(body).encode("utf-8")
+        req_headers.setdefault("Content-Type", "application/json")
+    req = urllib.request.Request(url, headers=req_headers, data=data, method=method)
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        raw = resp.read().decode("utf-8", "replace")
+        return json.loads(raw) if raw else None
 
 
 def read_url_text(url: str, timeout: int = 30) -> str:
@@ -608,6 +632,641 @@ def cmd_generation(args: argparse.Namespace) -> None:
     emit(data, args.json, render_generation)
 
 
+def clean_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).replace("\r", " ").replace("\n", " ").strip()
+    text = re.sub(r"\s+", " ", text)
+    if len(text) >= 2 and text[0] == text[-1] == '"':
+        text = text[1:-1].strip()
+    return text or None
+
+
+def first_value(*values: Any) -> Any:
+    for value in values:
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def safe_int(value: Any) -> int | str | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        return int(str(value).replace(",", "").strip())
+    except (TypeError, ValueError):
+        return clean_text(value)
+
+
+def join_parts(*parts: Any) -> str | None:
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for part in parts:
+        text = clean_text(part)
+        if not text:
+            continue
+        key = text.lower()
+        if key in seen:
+            continue
+        cleaned.append(text)
+        seen.add(key)
+    return ", ".join(cleaned) if cleaned else None
+
+
+def parse_datetime_value(value: Any) -> dt.datetime | None:
+    text = clean_text(value)
+    if not text:
+        return None
+    try:
+        if text.endswith("Z"):
+            return dt.datetime.fromisoformat(text[:-1] + "+00:00")
+        return dt.datetime.fromisoformat(text)
+    except ValueError:
+        pass
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            return dt.datetime.strptime(text, fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def is_active_window(start: Any, end: Any) -> bool:
+    parsed_start = parse_datetime_value(start)
+    parsed_end = parse_datetime_value(end)
+    if not parsed_start or not parsed_end:
+        return False
+    now = dt.datetime.now(parsed_start.tzinfo) if parsed_start.tzinfo else dt.datetime.now()
+    if parsed_end.tzinfo and not now.tzinfo:
+        now = now.replace(tzinfo=parsed_end.tzinfo)
+    return parsed_start <= now <= parsed_end
+
+
+def epoch_ms_to_iso(value: Any) -> str | None:
+    if value is None or value == "":
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return clean_text(value)
+    if number <= 0:
+        return None
+    return dt.datetime.fromtimestamp(number / 1000, dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def iter_geojson_lonlat(value: Any) -> Iterable[tuple[float, float]]:
+    if not isinstance(value, list):
+        return
+    if len(value) >= 2 and all(isinstance(v, (int, float)) for v in value[:2]):
+        yield float(value[0]), float(value[1])
+        return
+    for item in value:
+        yield from iter_geojson_lonlat(item)
+
+
+def geojson_centroid(geometry: dict[str, Any] | None) -> dict[str, float] | None:
+    if not geometry:
+        return None
+    coords = list(iter_geojson_lonlat(geometry.get("coordinates")))
+    if not coords:
+        return None
+    lon = sum(item[0] for item in coords) / len(coords)
+    lat = sum(item[1] for item in coords) / len(coords)
+    return {"lat": round(lat, 6), "lng": round(lon, 6)}
+
+
+def outage_record(
+    company_key: str,
+    company: str,
+    status: str,
+    location: str | None,
+    customers: Any,
+    cause: Any,
+    estimated_restoration_time: Any,
+    outage_start_time: Any,
+    source_url: str,
+    outage_id: Any = None,
+    coordinates: dict[str, float] | None = None,
+    raw: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return {
+        "company_key": company_key,
+        "company": company,
+        "status": status,
+        "location": location or "Unknown location",
+        "customers_affected": safe_int(customers),
+        "cause": clean_text(cause),
+        "estimated_restoration_time": clean_text(estimated_restoration_time),
+        "outage_start_time": clean_text(outage_start_time),
+        "outage_id": clean_text(outage_id),
+        "coordinates": coordinates,
+        "source_url": source_url,
+        "raw": raw or {},
+    }
+
+
+def group_customers(properties: dict[str, Any]) -> int | None:
+    groups = properties.get("groupOutages")
+    if not isinstance(groups, list):
+        return None
+    total = 0
+    found = False
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        value = safe_int(group.get("AffectedCustomers"))
+        if isinstance(value, int):
+            total += value
+            found = True
+    return total if found else None
+
+
+def fetch_vector_outages(include_all: bool) -> list[dict[str, Any]]:
+    feeds = [
+        (
+            "https://outagereporter.api.vector.co.nz/outagereporter/outages/shapes",
+            "current",
+            {"apikey": "o2AGN2LXeYbNvyE5cytNGX9INtcPLfj7"},
+        )
+    ]
+    if include_all:
+        feeds.append(
+            (
+                "https://outage-centre.api.vector.co.nz/v1/outages/planned-outages/shapes",
+                "planned",
+                {"apikey": "378657d8-674d-4e20-9fcc-4e23fdfdf224"},
+            )
+        )
+    records: list[dict[str, Any]] = []
+    for url, status, headers in feeds:
+        payload = request_url_json(url, headers=headers)
+        for feature in payload.get("features") or []:
+            if not isinstance(feature, dict):
+                continue
+            props = feature.get("properties") or {}
+            centroid = geojson_centroid(feature.get("geometry"))
+            location = None
+            if centroid:
+                location = f"approx {centroid['lat']:.5f}, {centroid['lng']:.5f}"
+            outage_type = clean_text(props.get("outageType")) or status
+            records.append(
+                outage_record(
+                    "vector",
+                    "Vector",
+                    outage_type.lower(),
+                    location,
+                    None,
+                    outage_type,
+                    None,
+                    None,
+                    url,
+                    coordinates=centroid,
+                    raw={"properties": props, "geometry_type": (feature.get("geometry") or {}).get("type")},
+                )
+            )
+    return records
+
+
+def fetch_wellington_outages(include_all: bool) -> list[dict[str, Any]]:
+    url = "https://www.welectricity.co.nz/outages/getalloutages"
+    payload = request_url_json(url)
+    records: list[dict[str, Any]] = []
+    for item in payload.get("unplannedOutages") or []:
+        status = clean_text(item.get("timeBasedStatus") or item.get("status") or "current") or "current"
+        if not include_all and status.lower() != "current":
+            continue
+        records.append(
+            outage_record(
+                "wellington",
+                "Wellington Electricity",
+                status.lower(),
+                item.get("suburbsText"),
+                item.get("lastUpdatedCustomersAffected"),
+                item.get("lastUpdatedComments"),
+                item.get("lastUpdatedEta"),
+                item.get("timeOfFault"),
+                url,
+                outage_id=item.get("id"),
+                coordinates=item.get("location") if isinstance(item.get("location"), dict) else None,
+                raw=item,
+            )
+        )
+    for item in payload.get("plannedOutages") or []:
+        if clean_text(item.get("status")) == "Cancelled":
+            continue
+        start = item.get("alternateStartDateTime") if item.get("useAlternateDate") else item.get("outageStartDateTime")
+        end = item.get("alternateEndDateTime") if item.get("useAlternateDate") else item.get("outageEndDateTime")
+        if not include_all and not is_active_window(start, end):
+            continue
+        records.append(
+            outage_record(
+                "wellington",
+                "Wellington Electricity",
+                clean_text(item.get("timeBasedStatus") or item.get("status") or "planned") or "planned",
+                item.get("suburbsText"),
+                item.get("customersAffected"),
+                item.get("reasonForOutage"),
+                end,
+                start,
+                url,
+                outage_id=item.get("distributorEventNumber") or item.get("id"),
+                coordinates=item.get("location") if isinstance(item.get("location"), dict) else None,
+                raw=item,
+            )
+        )
+    return records
+
+
+def fetch_orion_outages(include_all: bool) -> list[dict[str, Any]]:
+    url = "https://www.oriongroup.co.nz/outages-and-support/outages/refresh-outages"
+    payload = request_url_json(url)
+    groups = [("CurrentOutages", "current")]
+    if include_all:
+        groups.append(("PlannedOutages", "planned"))
+    records: list[dict[str, Any]] = []
+    for key, status in groups:
+        for item in payload.get(key) or []:
+            if clean_text(item.get("JobStatus")) == "Cancelled":
+                continue
+            start = item.get("PlannedStart") if status == "planned" else item.get("TimeDown")
+            end = first_value(item.get("PlannedEnd"), item.get("EstTimeUp"), item.get("TimeUp"))
+            customers = item.get("MaxNumberOff") if status == "planned" else first_value(item.get("TotalNumberOff"), item.get("MaxNumberOff"))
+            records.append(
+                outage_record(
+                    "orion",
+                    "Orion",
+                    status,
+                    join_parts(item.get("Areas"), item.get("Streets")),
+                    customers,
+                    first_value(item.get("OutageCause"), item.get("PublicComments")),
+                    end,
+                    start,
+                    url,
+                    outage_id=item.get("IncidentRef") or item.get("Id"),
+                    coordinates={"lat": item.get("Latitude"), "lng": item.get("Longitude")}
+                    if item.get("Latitude") is not None and item.get("Longitude") is not None
+                    else None,
+                    raw=item,
+                )
+            )
+    return records
+
+
+def fetch_powerco_outages(include_all: bool) -> list[dict[str, Any]]:
+    url = "https://outages.powerco.co.nz/server/rest/services/Hosted/Outages/FeatureServer/1/query"
+    payload = request_url_json(
+        url,
+        params={
+            "f": "json",
+            "where": "1=1",
+            "outFields": "*",
+            "returnGeometry": "true",
+            "orderByFields": "interruption_start_date DESC",
+        },
+    )
+    records: list[dict[str, Any]] = []
+    for feature in payload.get("features") or []:
+        attrs = feature.get("attributes") or {}
+        status = "planned" if attrs.get("planned_outage") else "current"
+        records.append(
+            outage_record(
+                "powerco",
+                "Powerco",
+                status,
+                join_parts(attrs.get("suburb"), attrs.get("town"), attrs.get("feeder")),
+                attrs.get("number_of_detail_records"),
+                attrs.get("interruption_reason"),
+                epoch_ms_to_iso(attrs.get("interruption_restore_date")),
+                epoch_ms_to_iso(attrs.get("interruption_start_date")),
+                url,
+                outage_id=attrs.get("distributor_event_number") or attrs.get("objectid"),
+                raw=attrs,
+            )
+        )
+    return records
+
+
+def fetch_aurora_outages(include_all: bool) -> list[dict[str, Any]]:
+    feeds = [
+        ("https://www.auroraenergy.co.nz/Umbraco/Api/Outage/currentCenterPoints", "current"),
+    ]
+    if include_all:
+        feeds.append(("https://www.auroraenergy.co.nz/Umbraco/Api/Outage/plannedCenterPoints", "planned"))
+    records: list[dict[str, Any]] = []
+    for url, status in feeds:
+        payload = request_url_json(url)
+        for feature in payload.get("features") or []:
+            props = feature.get("properties") or {}
+            if clean_text(props.get("eventStatus")) == "Cancelled":
+                continue
+            customers = first_value(
+                props.get("currentAffectedCustomers"),
+                props.get("plannedAffectedCustomers"),
+                props.get("totalFaultAffectedCustomers"),
+                group_customers(props),
+            )
+            if customers == 0:
+                customers = group_customers(props) or customers
+            records.append(
+                outage_record(
+                    "aurora",
+                    "Aurora Energy",
+                    status,
+                    join_parts(props.get("suburbsAffected"), props.get("town"), props.get("streetsAffected")),
+                    customers,
+                    props.get("eventCause"),
+                    props.get("endDateTime"),
+                    props.get("startDateTime"),
+                    url,
+                    outage_id=props.get("eventNumber"),
+                    coordinates=geojson_centroid(feature.get("geometry")),
+                    raw=props,
+                )
+            )
+    return records
+
+
+def fetch_wel_outages(include_all: bool) -> list[dict[str, Any]]:
+    url = "https://server.ourpower.co.nz/api/?FETCH_GROUPED_FAULTS"
+    payload = request_url_json(
+        url,
+        method="POST",
+        body={"application": "outages", "emit": True, "type": "FETCH_GROUPED_FAULTS"},
+    )
+    grouped = (payload.get("payload") or {}).get("groupedFaults") or []
+    records: list[dict[str, Any]] = []
+    for group in grouped:
+        coordinates = None
+        if group.get("lat") is not None and group.get("lng") is not None:
+            coordinates = {"lat": group.get("lat"), "lng": group.get("lng")}
+        for incident in group.get("incidents") or []:
+            planned = incident.get("faultType") == 1
+            start = incident.get("start")
+            end = incident.get("end")
+            if not include_all and planned and not is_active_window(start, end):
+                continue
+            status = "planned" if planned else "current"
+            records.append(
+                outage_record(
+                    "wel",
+                    "WEL Networks",
+                    status,
+                    join_parts(incident.get("suburb"), incident.get("street")) or (
+                        f"approx {coordinates['lat']:.5f}, {coordinates['lng']:.5f}" if coordinates else None
+                    ),
+                    incident.get("propertiesAffected"),
+                    incident.get("reason"),
+                    end,
+                    start,
+                    url,
+                    outage_id=incident.get("incidentReference"),
+                    coordinates=coordinates,
+                    raw=incident,
+                )
+            )
+    return records
+
+
+def fetch_unison_outages(include_all: bool) -> list[dict[str, Any]]:
+    url = "https://www.unison.co.nz/api/outages"
+    payload = request_url_json(url)
+    records: list[dict[str, Any]] = []
+    for item in payload if isinstance(payload, list) else []:
+        state = clean_text(item.get("outageState") or item.get("outageStatus") or item.get("outageType")) or "unknown"
+        state_key = state.lower()
+        if state_key in ("cancelled", "completed", "recent"):
+            continue
+        if not include_all and state_key not in ("current", "ongoing"):
+            continue
+        records.append(
+            outage_record(
+                "unison",
+                "Unison",
+                state_key,
+                join_parts(item.get("networkRegion"), item.get("areaAffected")),
+                item.get("customersOff"),
+                item.get("interruptionReason"),
+                item.get("finishTime"),
+                item.get("startTime"),
+                url,
+                outage_id=item.get("outageID"),
+                raw={k: v for k, v in item.items() if k != "outageWindows"},
+            )
+        )
+    return records
+
+
+def fetch_counties_outages(include_all: bool) -> list[dict[str, Any]]:
+    unplanned_url = "https://api.integration.countiesenergy.co.nz/user/v1.0/outages"
+    planned_url = "https://api.integration.countiesenergy.co.nz/user/v1.0/shutdowns"
+    records: list[dict[str, Any]] = []
+    unplanned = request_url_json(unplanned_url)
+    for item in unplanned.get("service_orders") or []:
+        records.append(
+            outage_record(
+                "counties",
+                "Counties Energy",
+                "current",
+                item.get("address"),
+                item.get("customersAffected"),
+                first_value(item.get("description"), item.get("crewStatus")),
+                first_value(item.get("etrDateTime"), item.get("estimatedRestoration"), item.get("etrTime")),
+                item.get("serviceOrderDateTime"),
+                unplanned_url,
+                outage_id=item.get("no"),
+                coordinates={"lat": item.get("lat"), "lng": item.get("lng")}
+                if item.get("lat") is not None and item.get("lng") is not None
+                else None,
+                raw={k: v for k, v in item.items() if k != "hull"},
+            )
+        )
+    planned = request_url_json(planned_url)
+    for item in planned.get("planned_outages") or []:
+        periods = item.get("shutdownPeriods") or []
+        start = periods[0].get("start") if periods and isinstance(periods[0], dict) else item.get("shutdownDateTime")
+        end = periods[-1].get("end") if periods and isinstance(periods[-1], dict) else None
+        if not include_all and not is_active_window(start, end):
+            continue
+        records.append(
+            outage_record(
+                "counties",
+                "Counties Energy",
+                "planned",
+                item.get("address"),
+                item.get("affectedCustomers"),
+                first_value(item.get("projectType"), item.get("latestInformation")),
+                end,
+                start,
+                planned_url,
+                outage_id=item.get("id"),
+                coordinates={"lat": item.get("lat"), "lng": item.get("lng")}
+                if item.get("lat") is not None and item.get("lng") is not None
+                else None,
+                raw={k: v for k, v in item.items() if k != "hull"},
+            )
+        )
+    return records
+
+
+def fetch_top_outages(include_all: bool) -> list[dict[str, Any]]:
+    url = "https://outages.topenergy.co.nz/api/outages/regions"
+    payload = request_url_json(url)
+    records: list[dict[str, Any]] = []
+    for item in payload.get("active") or []:
+        records.append(
+            outage_record(
+                "top",
+                "Top Energy",
+                "current",
+                item.get("circuitName") or item.get("name"),
+                item.get("customersCurrentlyOff"),
+                first_value(item.get("additionalInformation"), "Unplanned outage"),
+                item.get("endDateTime"),
+                item.get("startDateTime"),
+                url,
+                outage_id=item.get("name"),
+                raw=item,
+            )
+        )
+    for item in payload.get("planned") or []:
+        if not include_all and not item.get("isActive"):
+            continue
+        records.append(
+            outage_record(
+                "top",
+                "Top Energy",
+                "planned",
+                item.get("circuitName") or item.get("name"),
+                item.get("customersCurrentlyOff"),
+                first_value(item.get("additionalInformation"), "Planned outage"),
+                item.get("endDateTime"),
+                item.get("startDateTime"),
+                url,
+                outage_id=item.get("name"),
+                raw=item,
+            )
+        )
+    return records
+
+
+OUTAGE_FETCHERS: dict[str, tuple[str, Callable[[bool], list[dict[str, Any]]]]] = {
+    "vector": ("Vector", fetch_vector_outages),
+    "wellington": ("Wellington Electricity", fetch_wellington_outages),
+    "orion": ("Orion", fetch_orion_outages),
+    "powerco": ("Powerco", fetch_powerco_outages),
+    "aurora": ("Aurora Energy", fetch_aurora_outages),
+    "wel": ("WEL Networks", fetch_wel_outages),
+    "unison": ("Unison", fetch_unison_outages),
+    "counties": ("Counties Energy", fetch_counties_outages),
+    "top": ("Top Energy", fetch_top_outages),
+}
+
+OUTAGE_COMPANY_ALIASES = {
+    "welectricity": "wellington",
+    "wellington-electricity": "wellington",
+    "wel-networks": "wel",
+    "counties-energy": "counties",
+    "top-energy": "top",
+    "topenergy": "top",
+}
+
+OUTAGE_UNSUPPORTED = {
+    "northpower": "Northpower renders outage data through Livewire snapshots and websocket/update calls; no clean stable public JSON endpoint was found.",
+    "mainpower": "not investigated in this pass",
+    "marlborough": "not investigated in this pass",
+    "marlborough-lines": "not investigated in this pass",
+    "network-tasman": "not investigated in this pass",
+    "electra": "not investigated in this pass",
+    "westpower": "not investigated in this pass",
+    "network-waitaki": "not investigated in this pass",
+}
+
+
+def resolve_outage_company(raw: str) -> str:
+    key = raw.strip().lower().replace("_", "-").replace(" ", "-")
+    return OUTAGE_COMPANY_ALIASES.get(key, key)
+
+
+def fetch_company_outages(company_key: str, include_all: bool) -> tuple[list[dict[str, Any]], str | None]:
+    label, fetcher = OUTAGE_FETCHERS[company_key]
+    try:
+        return fetcher(include_all), None
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode("utf-8", "replace")[:180]
+        return [], f"{label}: HTTP {e.code} {detail}".strip()
+    except urllib.error.URLError as e:
+        return [], f"{label}: network error {e.reason}"
+    except json.JSONDecodeError as e:
+        return [], f"{label}: invalid JSON ({e})"
+    except TimeoutError as e:
+        return [], f"{label}: timeout ({e})"
+    except Exception as e:
+        return [], f"{label}: {type(e).__name__}: {e}"
+
+
+def record_matches_region(record: dict[str, Any], region: str) -> bool:
+    needle = region.strip().lower()
+    haystack = [
+        record.get("company"),
+        record.get("location"),
+        record.get("cause"),
+        record.get("outage_id"),
+        json.dumps(record.get("raw") or {}, ensure_ascii=False),
+    ]
+    return any(needle in str(value).lower() for value in haystack if value)
+
+
+def cmd_outages(args: argparse.Namespace) -> None:
+    started = time.perf_counter()
+    errors: list[str] = []
+    if args.company:
+        company_key = resolve_outage_company(args.company)
+        if company_key in OUTAGE_UNSUPPORTED:
+            data = {
+                "source": "NZ lines-company public outage feeds",
+                "count": 0,
+                "companies_queried": [],
+                "region_filter": args.region,
+                "include_scheduled": args.all,
+                "elapsed_ms": round((time.perf_counter() - started) * 1000),
+                "outages": [],
+                "errors": [f"{args.company}: {OUTAGE_UNSUPPORTED[company_key]}"],
+            }
+            emit(data, args.json, render_outages)
+            return
+        if company_key not in OUTAGE_FETCHERS:
+            valid = ", ".join(sorted(OUTAGE_FETCHERS))
+            die(f"unknown outage company '{args.company}'. Supported companies: {valid}")
+        company_keys = [company_key]
+    else:
+        company_keys = list(OUTAGE_FETCHERS)
+
+    outages: list[dict[str, Any]] = []
+    for company_key in company_keys:
+        company_outages, error = fetch_company_outages(company_key, args.all)
+        if error:
+            errors.append(error)
+        outages.extend(company_outages)
+
+    if args.region:
+        outages = [record for record in outages if record_matches_region(record, args.region)]
+
+    outages.sort(key=lambda item: (item.get("company") or "", item.get("status") or "", item.get("outage_start_time") or ""))
+    data = {
+        "source": "NZ lines-company public outage feeds",
+        "count": len(outages),
+        "companies_queried": [OUTAGE_FETCHERS[key][0] for key in company_keys],
+        "region_filter": args.region,
+        "include_scheduled": args.all,
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+        "outages": outages,
+        "errors": errors,
+    }
+    emit(data, args.json, render_outages)
+
+
 def money(value: Any) -> str:
     if value is None:
         return "-"
@@ -718,6 +1377,47 @@ def render_generation(data: dict[str, Any]) -> str:
     return "\n".join(lines).rstrip()
 
 
+def render_outages(data: dict[str, Any]) -> str:
+    outages = data.get("outages") or []
+    mode = "current, scheduled, and recent" if data.get("include_scheduled") else "current"
+    if not outages:
+        lines = [
+            f"No {mode} outages returned from {len(data.get('companies_queried') or [])} supported company feed(s)"
+            f" ({data.get('elapsed_ms')} ms)."
+        ]
+    else:
+        lines = [
+            f"NZ lines-company outages: {len(outages)} {mode} record(s) from "
+            f"{len(data.get('companies_queried') or [])} feed(s) ({data.get('elapsed_ms')} ms)"
+        ]
+        if data.get("region_filter"):
+            lines.append(f"Region filter: {data.get('region_filter')}")
+        lines.append("")
+        for item in outages:
+            parts = [
+                item.get("company") or "Unknown company",
+                item.get("status") or "unknown",
+                item.get("location") or "Unknown location",
+            ]
+            customers = item.get("customers_affected")
+            if customers is not None:
+                parts.append(f"{customers} customers")
+            if item.get("cause"):
+                parts.append(f"cause {item.get('cause')}")
+            if item.get("outage_start_time"):
+                parts.append(f"start {item.get('outage_start_time')}")
+            if item.get("estimated_restoration_time"):
+                parts.append(f"ETR {item.get('estimated_restoration_time')}")
+            if item.get("outage_id"):
+                parts.append(f"id {item.get('outage_id')}")
+            lines.append(" | ".join(str(part) for part in parts if part))
+    if data.get("errors"):
+        lines.append("")
+        lines.append("Warnings:")
+        lines.extend(str(error) for error in data["errors"])
+    return "\n".join(lines).rstrip()
+
+
 def emit(data: dict[str, Any], as_json: bool, render: Callable[[dict[str, Any]], str]) -> None:
     if as_json:
         print(json.dumps(data, indent=2, ensure_ascii=False))
@@ -770,6 +1470,13 @@ def build_parser() -> argparse.ArgumentParser:
     sp.add_argument("--limit", type=positive_int, help="limit returned top plants; default 20")
     sp.add_argument("--json", action="store_true")
     sp.set_defaults(func=cmd_generation)
+
+    sp = sub.add_parser("outages", help="current public outage records from supported NZ lines companies")
+    sp.add_argument("--company", help="supported company key, e.g. vector, wellington, powerco, aurora, wel")
+    sp.add_argument("--region", help="case-insensitive suburb, town, region, or street text filter")
+    sp.add_argument("--all", action="store_true", help="include planned, scheduled, or recent outage records where feeds expose them")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_outages)
 
     return ap
 


### PR DESCRIPTION
## Summary

- Adds an `outages` subcommand to `skills/nz-electricity/scripts/cli.py` using Python stdlib only.
- Normalizes supported distributor feeds into company, location, customers affected, cause, ETR, start time, id, source URL, coordinates, and raw JSON.
- Keeps per-company failures isolated as warnings and supports `--company`, `--region`, `--all`, and `--json`.
- Updates `SKILL.md` and `references/api-notes.md` with endpoint notes, response shapes, quirks, and refresh cadence where observed.

## Companies wired

- Vector
- Wellington Electricity
- Orion
- Powerco
- Aurora Energy
- WEL Networks
- Unison
- Counties Energy
- Top Energy

## Checked but skipped

- Northpower: outage app renders Livewire snapshots and uses Livewire websocket/update calls with CSRF/snapshot state. I did not find a clean stable unauthenticated JSON or ArcGIS FeatureServer feed.
- Bonus distributors from the prompt were not investigated after wiring 9 of the top 10 target companies.

## Live test output

```text
$ python3 skills/nz-electricity/scripts/cli.py outages --help
usage: cli.py outages [-h] [--company COMPANY] [--region REGION] [--all]
                      [--json]
```

```text
$ python3 skills/nz-electricity/scripts/cli.py outages
NZ lines-company outages: 7 current record(s) from 9 feed(s) (3087 ms)
Counties Energy | current | E Coast Rd Kaiaua Waikato Region | 0 customers | cause No power to installation | start 2026-05-23T20:45:46+12:00 | ETR This job is currently on hold, estimated time of restoration is unknown. | id WO2000076871
Powerco | current | Tahawai, LINDERMANN RD | 1 customers | cause Land Slip | start 2026-02-06T04:02:00Z | id JE26007033
Vector | unplanned | approx -36.37215, 174.62970 | cause Unplanned
```

```text
$ python3 skills/nz-electricity/scripts/cli.py outages --company vector
NZ lines-company outages: 1 current record(s) from 1 feed(s) (171 ms)
Vector | unplanned | approx -36.37215, 174.62970 | cause Unplanned

$ python3 skills/nz-electricity/scripts/cli.py outages --company wellington --json
{
  "source": "NZ lines-company public outage feeds",
  "count": 0,
  "companies_queried": ["Wellington Electricity"],
  "errors": []
}

$ python3 skills/nz-electricity/scripts/cli.py outages --region tahawai
NZ lines-company outages: 1 current record(s) from 9 feed(s) (1592 ms)
Powerco | current | Tahawai, LINDERMANN RD | 1 customers | cause Land Slip | start 2026-02-06T04:02:00Z | id JE26007033
```

Per-company fetch checks:

```text
orion --all: 123 records
powerco: 5 records
aurora --all: 89 records
wel --all: 37 records
unison --all: 106 records
counties --all: 25 records
top --all: 14 records
northpower: warning only, no supported feed
```

Graceful behavior checks:

```text
wellington --json: empty feed returned count 0 with no error
simulated timeout fetcher: [] / Timeout Test: timeout (simulated)
```

Existing command smoke checks:

```text
spot --region auckland: Auckland $37.62/MWh
carbon: 47.71 gCO2/kWh, 93.55% renewable
demand --region NZ --from 2026-05-22 --to 2026-05-22: 48 trading periods, 108.024 GWh
prices --node BEN2201 --from 2026-05-20 --to 2026-05-20: 48 trading periods, average $120.56/MWh
generation --month 2026-04 --type hydro --limit 2: 1776.284 GWh
```

Additional checks:

```text
python3 -m py_compile skills/nz-electricity/scripts/cli.py
git diff --check
```
