### PR TITLE
feat(nz-airports): add lightweight read-only NZ airport FIDS CLI skill

### DIFF
--- a/skills/nz-airports/SKILL.md
+++ b/skills/nz-airports/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: nz-airports
+description: Query live public New Zealand airport arrivals and departures boards for supported airports through a lightweight read-only CLI. Use when the task involves current flight board data for Christchurch, Queenstown, or Wellington airports.
+---
+
+# NZ Airports
+
+## Goal
+
+Query live arrivals and departures board data for supported New Zealand airports through a small deterministic CLI with human-readable and JSON output, without browser automation or account login.
+
+## Use this when
+
+- A user asks for current arrivals or departures at a supported NZ airport
+- A user wants to look up a flight number on a supported airport flight board
+- A user needs lightweight machine-readable NZ airport FIDS-style data
+- A workflow needs a fast read-only alternative to opening airport flight-board pages
+
+## Do not use this for
+
+- Booking, check-in, ticketing, PNR, passenger, baggage ownership, or account actions
+- Aviation tracking outside the public airport flight boards
+- Historical flight status or delay analysis
+- Airports not listed by the `airports` command
+- Auckland Airport until its public flight-board surface can be fetched without Cloudflare blocking
+
+## Preferred workflow
+
+1. Run `scripts/cli.py` with the narrowest subcommand that answers the task
+2. Use `arrivals` or `departures` with `--airport CODE` when a specific airport is known
+3. Use `flight <flight-number>` when the user asks about a specific flight
+4. Use `airports` to confirm currently supported airport codes
+5. Use `--json` for agent chaining, comparisons, or structured reports
+6. Mention that data is a live public airport-board snapshot and the source is unofficial
+
+## CLI
+
+Run with:
+
+```bash
+python3 skills/nz-airports/scripts/cli.py <command> [flags]
+```
+
+## Commands
+
+- `arrivals [--airport CHC|ZQN|WLG] [--limit N] [--json]` - current arrivals board
+- `departures [--airport CHC|ZQN|WLG] [--limit N] [--json]` - current departures board
+- `flight <flight-number> [--airport CHC|ZQN|WLG] [--json]` - lookup a flight number across current boards
+- `airports [--json]` - list supported airports and investigated gaps
+
+## Examples
+
+```bash
+python3 skills/nz-airports/scripts/cli.py arrivals --airport CHC --limit 10
+python3 skills/nz-airports/scripts/cli.py departures --airport ZQN --limit 10 --json
+python3 skills/nz-airports/scripts/cli.py arrivals --airport WLG --json
+python3 skills/nz-airports/scripts/cli.py flight NZ5640 --json
+python3 skills/nz-airports/scripts/cli.py airports
+```
+
+## Notes
+
+- Supported live sources: Christchurch (CHC), Queenstown (ZQN), and Wellington (WLG)
+- Christchurch uses public JSON endpoints split by domestic/international and arrivals/departures
+- Queenstown uses public JSON endpoints for arrivals and departures; the CLI filters to today's NZ board when possible
+- Wellington embeds the current flight-board JSON in the public flight page; departures can be empty late in the local operating day
+- Auckland (AKL) was investigated, but direct fetches and CloakBrowser/CDP attempts returned Cloudflare challenge/block pages from this environment, so AKL is not listed as supported
+- No API key, username, password, account cookie, browser session, or write action is required
+- Endpoint shapes can change without notice because these are unofficial public website surfaces
+- API and stability notes: `references/api-notes.md`
+- CLI entrypoint: `scripts/cli.py`

--- a/skills/nz-airports/references/api-notes.md
+++ b/skills/nz-airports/references/api-notes.md
@@ -1,0 +1,100 @@
+# NZ Airports API notes
+
+This skill is an unofficial lightweight wrapper around public airport flight-board surfaces. It is read-only and does not support booking, check-in, PNR lookup, account access, or passenger/baggage ownership lookup.
+
+## Source and auth
+
+No username, password, API key, private token, cookie, or browser session is required for the implemented commands.
+
+Implemented airports:
+
+- Christchurch (CHC): `https://www.christchurchairport.nz`
+- Queenstown (ZQN): `https://www.queenstownairport.co.nz`
+- Wellington (WLG): `https://www.wellingtonairport.co.nz`
+
+Investigated but not implemented:
+
+- Auckland (AKL): `https://www.prod.aucklandairport.co.nz/flights` and `https://corporate.aucklandairport.co.nz/content/aial-traveller/nz/en/flights.html` returned Cloudflare challenge/block pages from direct CLI fetches. CloakBrowser CDP navigation also returned a Cloudflare 403 block in this environment, so no stable no-login CLI endpoint was shipped.
+
+## Endpoint families used
+
+### Christchurch Airport
+
+Base endpoint:
+
+```text
+GET https://www.christchurchairport.nz/api/flights?maxFlights=&flightDirection={Arrive|Depart}&flightType={Domestic|International}
+```
+
+The CLI calls all four combinations:
+
+- `flightDirection=Arrive&flightType=Domestic`
+- `flightDirection=Arrive&flightType=International`
+- `flightDirection=Depart&flightType=Domestic`
+- `flightDirection=Depart&flightType=International`
+
+Response shape:
+
+- top-level `lastUpdated`, `flightType`, `flightDirection`
+- `flights[]` with `airlineCode`, `airlineName`, `flightNumbers[]`, `airports[]`, `scheduled`, `estimateActual`, `gate`, `status`, `statusColour`, `imageUrl`
+
+Observed update wording on the public page says information is updated every ten minutes by airlines. The JSON response includes `lastUpdated`.
+
+### Queenstown Airport
+
+Endpoints:
+
+```text
+GET https://www.queenstownairport.co.nz/api/flights/arrivals
+GET https://www.queenstownairport.co.nz/api/flights/departures
+```
+
+Response shape:
+
+- array of flight rows
+- each row includes `flightList[]`, `from`, `destination`, `schTime`, `schDate`, `estTime`, `estDate`, `status`, `orderByDate`, `isDomestic`, `flightType`
+
+The endpoint returns multiple dates. The CLI filters to today's `Pacific/Auckland` date when rows exist for that date, otherwise it returns the source rows as-is.
+
+### Wellington Airport
+
+Page endpoint:
+
+```text
+GET https://www.wellingtonairport.co.nz/flights/?direction={A|D}
+```
+
+The current board is embedded in:
+
+```html
+<script type="application/json" data-flights>...</script>
+```
+
+Embedded JSON shape:
+
+- top-level `is_arrivals`, `last_updated`, `day`, `flights[]`
+- `flights[]` with `place`, `scheduled`, `estimated`, `carrier_name`, `carrier_code`, `zone`, `flight_number`, `gate`, `status_text`
+
+The board can legitimately be empty for departures late in the local operating day.
+
+## Normalized CLI schema
+
+Each normalized flight includes:
+
+- `airport`, `airport_name`, `direction`
+- `flight_numbers[]`, `primary_flight`
+- `airline_code`, `airline_name`
+- `origin`, `destination`
+- `scheduled`, `estimated`
+- `gate`, `status`, `terminal`, `is_domestic`
+- `source`, `source_url`
+
+Some fields are source-dependent. Queenstown does not expose gate or airline name in the JSON endpoint. Wellington exposes one flight number per row in the embedded board. Christchurch exposes codeshare flight numbers and airline branding image URLs, but the CLI does not emit image URLs in the normalized record.
+
+## Stability and safety
+
+- Treat results as live public-board snapshots, not historical data.
+- Always prefer narrow commands and small limits for routine checks.
+- Do not use this skill for booking, check-in, account, payment, passenger, baggage ownership, or mutation workflows.
+- Endpoint shapes can change without notice because these are public website implementation details rather than official public APIs.
+- Do not commit HAR captures, screenshots, cookies, raw browser profiles, or bulky JavaScript bundles when updating this skill.

--- a/skills/nz-airports/scripts/cli.py
+++ b/skills/nz-airports/scripts/cli.py
@@ -1,0 +1,532 @@
+#!/usr/bin/env python3
+"""NZ airports lightweight live flight-board CLI.
+
+Self-contained stdlib wrapper around public airport arrivals/departures boards.
+No login, booking, PNR lookup, browser automation, or third-party dependencies.
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any
+
+try:
+    from zoneinfo import ZoneInfo
+except Exception:  # pragma: no cover - Python <3.9 fallback
+    ZoneInfo = None  # type: ignore[assignment]
+
+
+UA = os.environ.get(
+    "NZ_AIRPORTS_USER_AGENT",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
+)
+
+AIRPORTS: dict[str, dict[str, str]] = {
+    "CHC": {
+        "name": "Christchurch Airport",
+        "city": "Christchurch",
+        "iata": "CHC",
+        "icao": "NZCH",
+        "source": "christchurchairport.nz",
+        "source_url": "https://www.christchurchairport.nz/travellers/flights/arrivals-and-departures/",
+    },
+    "ZQN": {
+        "name": "Queenstown Airport",
+        "city": "Queenstown",
+        "iata": "ZQN",
+        "icao": "NZQN",
+        "source": "queenstownairport.co.nz",
+        "source_url": "https://www.queenstownairport.co.nz/",
+    },
+    "WLG": {
+        "name": "Wellington Airport",
+        "city": "Wellington",
+        "iata": "WLG",
+        "icao": "NZWN",
+        "source": "wellingtonairport.co.nz",
+        "source_url": "https://www.wellingtonairport.co.nz/flights/",
+    },
+}
+
+CHC_API = "https://www.christchurchairport.nz/api/flights"
+ZQN_API = "https://www.queenstownairport.co.nz/api/flights"
+WLG_FLIGHTS = "https://www.wellingtonairport.co.nz/flights/"
+
+
+def die(message: str, code: int = 1) -> None:
+    print(f"nz-airports: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def request_text(url: str, timeout: int = 25) -> str:
+    headers = {
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,application/json;q=0.8,*/*;q=0.7",
+        "User-Agent": UA,
+    }
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+            charset = resp.headers.get_content_charset() or "utf-8"
+            return raw.decode(charset, "replace")
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8", "replace")
+        detail = raw[:300].replace("\n", " ")
+        die(f"HTTP {e.code} from {url}: {detail}")
+    except urllib.error.URLError as e:
+        die(f"network error calling {url}: {e.reason}")
+
+
+def request_json(url: str, timeout: int = 25) -> Any:
+    headers = {
+        "Accept": "application/json, text/plain, */*",
+        "Referer": url.rsplit("/", 1)[0] + "/",
+        "User-Agent": UA,
+    }
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", "replace")
+            return json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8", "replace")
+        detail = raw[:300].replace("\n", " ")
+        die(f"HTTP {e.code} from {url}: {detail}")
+    except urllib.error.URLError as e:
+        die(f"network error calling {url}: {e.reason}")
+    except json.JSONDecodeError as e:
+        die(f"invalid JSON from {url}: {e}")
+
+
+def now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def nz_today() -> str:
+    if ZoneInfo is None:
+        return datetime.now(timezone.utc).date().isoformat()
+    return datetime.now(ZoneInfo("Pacific/Auckland")).date().isoformat()
+
+
+def clean(value: Any) -> str:
+    if value is None:
+        return ""
+    return " ".join(str(value).split())
+
+
+def airport_code(raw: str | None) -> str | None:
+    if raw is None:
+        return None
+    code = raw.upper()
+    if code not in AIRPORTS:
+        die(f"unsupported airport {raw}; run `airports` for supported codes")
+    return code
+
+
+def flight_numbers(values: Any) -> list[str]:
+    if isinstance(values, list):
+        raw = values
+    elif values:
+        raw = [values]
+    else:
+        raw = []
+    out: list[str] = []
+    seen = set()
+    for item in raw:
+        value = clean(item).upper().replace(" ", "")
+        if value and value not in seen:
+            out.append(value)
+            seen.add(value)
+    return out
+
+
+def carrier_from_flight(number: str) -> str:
+    match = re.match(r"^([A-Z]{2,3})", number.upper())
+    return match.group(1) if match else ""
+
+
+def combine_date_time(date_value: str, time_value: str) -> str:
+    if not date_value or not time_value:
+        return clean(time_value or date_value)
+    return f"{date_value} {time_value}"
+
+
+def normalize_chc(row: dict[str, Any], direction: str, flight_type: str) -> dict[str, Any]:
+    numbers = flight_numbers(row.get("flightNumbers"))
+    airport_names = [clean(x) for x in row.get("airports") or [] if clean(x)]
+    other_side = " / ".join(airport_names)
+    is_arrival = direction == "arrivals"
+    return {
+        "airport": "CHC",
+        "airport_name": AIRPORTS["CHC"]["name"],
+        "direction": direction,
+        "flight_numbers": numbers,
+        "primary_flight": numbers[0] if numbers else "",
+        "airline_code": clean(row.get("airlineCode")),
+        "airline_name": clean(row.get("airlineName")),
+        "origin": other_side if is_arrival else "Christchurch",
+        "destination": "Christchurch" if is_arrival else other_side,
+        "scheduled": clean(row.get("scheduled")),
+        "estimated": clean(row.get("estimateActual")),
+        "gate": clean(row.get("gate")),
+        "status": clean(row.get("status")),
+        "terminal": flight_type.lower(),
+        "is_domestic": flight_type == "Domestic",
+        "source": AIRPORTS["CHC"]["source"],
+        "source_url": AIRPORTS["CHC"]["source_url"],
+    }
+
+
+def normalize_zqn(row: dict[str, Any], direction: str) -> dict[str, Any]:
+    numbers = flight_numbers(row.get("flightList"))
+    scheduled = combine_date_time(clean(row.get("schDate")), clean(row.get("schTime")))
+    estimated = combine_date_time(clean(row.get("estDate")), clean(row.get("estTime")))
+    return {
+        "airport": "ZQN",
+        "airport_name": AIRPORTS["ZQN"]["name"],
+        "direction": direction,
+        "flight_numbers": numbers,
+        "primary_flight": numbers[0] if numbers else "",
+        "airline_code": carrier_from_flight(numbers[0]) if numbers else "",
+        "airline_name": "",
+        "origin": clean(row.get("from")),
+        "destination": clean(row.get("destination")),
+        "scheduled": scheduled,
+        "estimated": estimated,
+        "scheduled_date": clean(row.get("schDate")),
+        "estimated_date": clean(row.get("estDate")),
+        "gate": "",
+        "status": clean(row.get("status")),
+        "terminal": "domestic" if row.get("isDomestic") else "international",
+        "is_domestic": bool(row.get("isDomestic")),
+        "order_by": clean(row.get("orderByDate")),
+        "source": AIRPORTS["ZQN"]["source"],
+        "source_url": AIRPORTS["ZQN"]["source_url"],
+    }
+
+
+def normalize_wlg(row: dict[str, Any], direction: str, day: str) -> dict[str, Any]:
+    number = clean(row.get("flight_number")).upper().replace(" ", "")
+    numbers = flight_numbers(number)
+    is_arrival = direction == "arrivals"
+    place = clean(row.get("place"))
+    scheduled_time = clean(row.get("scheduled"))
+    estimated_time = clean(row.get("estimated"))
+    return {
+        "airport": "WLG",
+        "airport_name": AIRPORTS["WLG"]["name"],
+        "direction": direction,
+        "flight_numbers": numbers,
+        "primary_flight": numbers[0] if numbers else "",
+        "airline_code": clean(row.get("carrier_code")),
+        "airline_name": clean(row.get("carrier_name")),
+        "origin": place if is_arrival else "Wellington",
+        "destination": "Wellington" if is_arrival else place,
+        "scheduled": combine_date_time(day, scheduled_time),
+        "estimated": combine_date_time(day, estimated_time),
+        "scheduled_time": scheduled_time,
+        "estimated_time": estimated_time,
+        "gate": clean(row.get("gate")),
+        "status": clean(row.get("status_text")),
+        "terminal": clean(row.get("zone")),
+        "is_domestic": clean(row.get("zone")).upper() != "I",
+        "source": AIRPORTS["WLG"]["source"],
+        "source_url": AIRPORTS["WLG"]["source_url"],
+    }
+
+
+def fetch_chc(direction: str) -> dict[str, Any]:
+    api_direction = "Arrive" if direction == "arrivals" else "Depart"
+    flights: list[dict[str, Any]] = []
+    updated: list[str] = []
+    for flight_type in ("Domestic", "International"):
+        params = {
+            "maxFlights": "",
+            "flightDirection": api_direction,
+            "flightType": flight_type,
+        }
+        url = CHC_API + "?" + urllib.parse.urlencode(params)
+        payload = request_json(url)
+        if not isinstance(payload, dict):
+            die(f"unexpected Christchurch payload from {url}")
+        if payload.get("lastUpdated"):
+            updated.append(clean(payload.get("lastUpdated")))
+        for row in payload.get("flights") or []:
+            if isinstance(row, dict):
+                flights.append(normalize_chc(row, direction, flight_type))
+    return board_result("CHC", direction, flights, ", ".join(sorted(set(updated))))
+
+
+def fetch_zqn(direction: str) -> dict[str, Any]:
+    endpoint = "arrivals" if direction == "arrivals" else "departures"
+    payload = request_json(f"{ZQN_API}/{endpoint}")
+    if not isinstance(payload, list):
+        die(f"unexpected Queenstown payload from {ZQN_API}/{endpoint}")
+    today = nz_today()
+    todays_rows = [
+        row for row in payload
+        if isinstance(row, dict) and (row.get("schDate") == today or row.get("estDate") == today)
+    ]
+    rows = todays_rows if todays_rows else [row for row in payload if isinstance(row, dict)]
+    flights = [normalize_zqn(row, direction) for row in rows]
+    return board_result("ZQN", direction, flights, "")
+
+
+def fetch_wlg(direction: str) -> dict[str, Any]:
+    query = urllib.parse.urlencode({"direction": "A" if direction == "arrivals" else "D"})
+    url = f"{WLG_FLIGHTS}?{query}"
+    text = request_text(url)
+    match = re.search(
+        r'<script[^>]*type=["\']application/json["\'][^>]*data-flights[^>]*>\s*(\{.*?\})\s*</script>',
+        text,
+        re.S,
+    )
+    if not match:
+        die(f"could not find Wellington embedded flight JSON at {url}")
+    try:
+        payload = json.loads(html.unescape(match.group(1)))
+    except json.JSONDecodeError as e:
+        die(f"invalid Wellington embedded flight JSON at {url}: {e}")
+    rows = payload.get("flights") or []
+    day = clean(payload.get("day"))
+    flights = [normalize_wlg(row, direction, day) for row in rows if isinstance(row, dict)]
+    return board_result("WLG", direction, flights, clean(payload.get("last_updated")))
+
+
+def board_result(airport: str, direction: str, flights: list[dict[str, Any]], source_last_updated: str) -> dict[str, Any]:
+    meta = AIRPORTS[airport]
+    return {
+        "airport": airport,
+        "airport_name": meta["name"],
+        "direction": direction,
+        "source": meta["source"],
+        "source_url": meta["source_url"],
+        "source_last_updated": source_last_updated,
+        "fetched_at": now_iso(),
+        "total_flights": len(flights),
+        "flights": flights,
+    }
+
+
+FETCHERS = {
+    "CHC": fetch_chc,
+    "ZQN": fetch_zqn,
+    "WLG": fetch_wlg,
+}
+
+
+def fetch_board(code: str, direction: str) -> dict[str, Any]:
+    return FETCHERS[code](direction)
+
+
+def limited_board(result: dict[str, Any], limit: int) -> dict[str, Any]:
+    flights = result["flights"][:limit]
+    out = dict(result)
+    out["returned"] = len(flights)
+    out["flights"] = flights
+    return out
+
+
+def selected_airports(raw: str | None) -> list[str]:
+    code = airport_code(raw)
+    return [code] if code else list(AIRPORTS)
+
+
+def cmd_board(args: argparse.Namespace, direction: str) -> None:
+    results = [limited_board(fetch_board(code, direction), args.limit) for code in selected_airports(args.airport)]
+    if args.airport:
+        emit_board(results[0], args.json)
+    else:
+        data = {
+            "direction": direction,
+            "fetched_at": now_iso(),
+            "airports": results,
+        }
+        emit_boards(data, args.json)
+
+
+def cmd_arrivals(args: argparse.Namespace) -> None:
+    cmd_board(args, "arrivals")
+
+
+def cmd_departures(args: argparse.Namespace) -> None:
+    cmd_board(args, "departures")
+
+
+def cmd_flight(args: argparse.Namespace) -> None:
+    needle = args.flight_number.upper().replace(" ", "")
+    matches: list[dict[str, Any]] = []
+    for code in selected_airports(args.airport):
+        for direction in ("arrivals", "departures"):
+            result = fetch_board(code, direction)
+            for flight in result["flights"]:
+                if needle in flight.get("flight_numbers", []):
+                    matches.append(flight)
+    data = {
+        "query": needle,
+        "airport": airport_code(args.airport),
+        "fetched_at": now_iso(),
+        "total_matches": len(matches),
+        "flights": matches,
+    }
+    emit_flight_matches(data, args.json)
+
+
+def cmd_airports(args: argparse.Namespace) -> None:
+    data = {
+        "count": len(AIRPORTS),
+        "airports": [
+            {
+                "code": code,
+                "name": meta["name"],
+                "city": meta["city"],
+                "iata": meta["iata"],
+                "icao": meta["icao"],
+                "source": meta["source"],
+                "source_url": meta["source_url"],
+            }
+            for code, meta in AIRPORTS.items()
+        ],
+        "not_wired": [
+            {
+                "code": "AKL",
+                "name": "Auckland Airport",
+                "reason": "public flight board blocked direct and CDP fetches with Cloudflare in this environment",
+            }
+        ],
+    }
+    emit_airports(data, args.json)
+
+
+def route_label(flight: dict[str, Any]) -> str:
+    if flight.get("direction") == "arrivals":
+        return f"from {flight.get('origin') or '-'}"
+    return f"to {flight.get('destination') or '-'}"
+
+
+def time_label(flight: dict[str, Any]) -> str:
+    scheduled = flight.get("scheduled") or "-"
+    estimated = flight.get("estimated")
+    if estimated and estimated != scheduled:
+        return f"{scheduled} (est {estimated})"
+    return str(scheduled)
+
+
+def flight_line(flight: dict[str, Any]) -> str:
+    nums = "/".join(flight.get("flight_numbers") or [flight.get("primary_flight") or "-"])
+    airline = flight.get("airline_name") or flight.get("airline_code") or ""
+    gate = f" gate {flight['gate']}" if flight.get("gate") else ""
+    terminal = f" {flight['terminal']}" if flight.get("terminal") else ""
+    status = f" - {flight['status']}" if flight.get("status") else ""
+    return f"  {time_label(flight):<28} {nums:<18} {route_label(flight)}{gate}{terminal} {airline}{status}".rstrip()
+
+
+def print_board(result: dict[str, Any]) -> None:
+    updated = f", updated {result['source_last_updated']}" if result.get("source_last_updated") else ""
+    print(f"{result['airport']} {result['direction']}: {result.get('returned', len(result['flights']))} of {result['total_flights']} flights ({result['source']}{updated})")
+    if not result["flights"]:
+        print("  No flights currently listed.")
+        return
+    for flight in result["flights"]:
+        print(flight_line(flight))
+
+
+def emit_board(data: dict[str, Any], as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2, ensure_ascii=False))
+    else:
+        print_board(data)
+
+
+def emit_boards(data: dict[str, Any], as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2, ensure_ascii=False))
+    else:
+        for index, result in enumerate(data["airports"]):
+            if index:
+                print()
+            print_board(result)
+
+
+def emit_flight_matches(data: dict[str, Any], as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2, ensure_ascii=False))
+        return
+    print(f"{data['query']}: {data['total_matches']} matches")
+    if not data["flights"]:
+        print("  No matching flights currently listed.")
+        return
+    for flight in data["flights"]:
+        print(f"  {flight['airport']} {flight['direction']}: {flight_line(flight).strip()}")
+
+
+def emit_airports(data: dict[str, Any], as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2, ensure_ascii=False))
+        return
+    print(f"Supported airports: {data['count']}")
+    for airport in data["airports"]:
+        print(f"  {airport['code']}  {airport['name']} ({airport['source']})")
+    print()
+    print("Not wired:")
+    for airport in data["not_wired"]:
+        print(f"  {airport['code']}  {airport['name']} - {airport['reason']}")
+
+
+def positive_int(raw: str) -> int:
+    try:
+        value = int(raw)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"expected integer, received {raw}")
+    if value <= 0:
+        raise argparse.ArgumentTypeError("expected a positive integer")
+    return value
+
+
+def add_board_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--airport", choices=sorted(AIRPORTS), help="airport code; defaults to all supported airports")
+    parser.add_argument("--limit", type=positive_int, default=20, help="max flights to show per airport (default 20)")
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description="Lightweight read-only NZ airport arrivals/departures CLI.")
+    sub = ap.add_subparsers(dest="command", required=True)
+
+    sp = sub.add_parser("arrivals", help="show current arrivals board")
+    add_board_args(sp)
+    sp.set_defaults(func=cmd_arrivals)
+
+    sp = sub.add_parser("departures", help="show current departures board")
+    add_board_args(sp)
+    sp.set_defaults(func=cmd_departures)
+
+    sp = sub.add_parser("flight", help="lookup a flight number across current boards")
+    sp.add_argument("flight_number", help="flight number, e.g. NZ5640")
+    sp.add_argument("--airport", choices=sorted(AIRPORTS), help="airport code; defaults to all supported airports")
+    sp.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    sp.set_defaults(func=cmd_flight)
+
+    sp = sub.add_parser("airports", help="list supported airports")
+    sp.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    sp.set_defaults(func=cmd_airports)
+    return ap
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds `skills/nz-airports/` with a lightweight, read-only Python stdlib CLI for live airport flight boards.
- Wires Christchurch (CHC), Queenstown (ZQN), and Wellington (WLG).
- Documents Auckland (AKL) as investigated but not shipped because direct fetches and CloakBrowser/CDP returned Cloudflare challenge/block pages from this environment.
- Keeps scope read-only: no booking, PNR, account, passenger, baggage ownership, or mutation workflows.

## Airports wired

- CHC: `https://www.christchurchairport.nz/api/flights?maxFlights=&flightDirection={Arrive|Depart}&flightType={Domestic|International}`
- ZQN: `https://www.queenstownairport.co.nz/api/flights/{arrivals|departures}`
- WLG: embedded `<script type="application/json" data-flights>` from `https://www.wellingtonairport.co.nz/flights/?direction={A|D}`

## Live validation

```text
$ python3 -m py_compile skills/nz-airports/scripts/cli.py
passed

$ python3 skills/nz-airports/scripts/cli.py --help
commands: arrivals, departures, flight, airports

$ bun run validate-skill -- skills/nz-airports
[OK] skills/nz-airports
[OK] All skills passed validation with no issues.

$ python3 skills/nz-airports/scripts/cli.py arrivals --airport CHC --limit 2 --json
returned=2 total_flights=85 updated="10:21 PM" first="NZ573/QF8543 from Auckland gate 19 Landed 10:02 PM"

$ python3 skills/nz-airports/scripts/cli.py departures --airport CHC --limit 2 --json
returned=2 total_flights=90 updated="10:21 PM" first="NZ582 to Auckland gate 20"

$ python3 skills/nz-airports/scripts/cli.py arrivals --airport ZQN --limit 2 --json
returned=2 total_flights=22 first="NZ5641 from Christchurch Landed"

$ python3 skills/nz-airports/scripts/cli.py departures --airport ZQN --limit 2 --json
returned=2 total_flights=22 first="QF124 to Sydney Departed"

$ python3 skills/nz-airports/scripts/cli.py arrivals --airport WLG --limit 2
WLG arrivals: 2 of 3 flights; first="NZ5386 from Christchurch gate 18 Arrived at Gate"

$ python3 skills/nz-airports/scripts/cli.py flight NZ5640 --airport ZQN --json
total_matches=1 match="ZQN departure NZ5640 Queenstown to Christchurch"
```

`bun run typecheck` was also attempted, but the fresh checkout reports existing repo-wide TypeScript issues unrelated to this Python skill, primarily missing Node/js-yaml type declarations and pre-existing `nz-news` strictness errors.
