### PR TITLE
feat(homes-nz): add lightweight read-only homes.co.nz CLI skill

### DIFF
--- a/skills/homes-nz/SKILL.md
+++ b/skills/homes-nz/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: homes-nz
+description: Query homes.co.nz public read-only NZ residential property estimate, sales history, suburb estimate trend, and nearby comparable-property endpoints through a lightweight no-login CLI. Use when the task involves HomesEstimate/HEV lookup, council/property attributes, historical sale records, or nearby comparable homes. No login or account credentials required for supported read-only commands.
+---
+
+# Homes NZ
+
+## Goal
+
+Query live homes.co.nz residential property estimates and historical sale data through a lightweight deterministic CLI with human-readable and JSON output.
+
+## Use this when
+
+- A user asks for a homes.co.nz HomesEstimate, HEV, or estimated value for a NZ home
+- A user wants sales history for a residential property
+- A user has a homes.co.nz property id and wants property details
+- A user wants nearby comparable homes around a known property id
+- A user wants suburb-level HomesEstimate trend data
+- A workflow needs machine-readable public homes.co.nz property estimate data
+
+## Do not use this for
+
+- Trade Me current sale/rental listing searches; use `trademe-nz` for active listings and listing-market scans
+- Property valuation advice, lending decisions, or substitute professional valuation reports
+- Authenticated homes.co.nz account, claim-home, favourite, agent enquiry, lead, update, or mutation actions
+- High-volume scraping or dataset redistribution
+- Non-residential, overseas, or non-homes.co.nz property data
+
+## Preferred workflow
+
+1. Run `scripts/cli.py address` to find a property id from a partial address
+2. Use `property <id>` for HomesEstimate, beds/baths/area, council attributes, last sale, and sales history
+3. Use `nearby <id>` for compact comparable-property snapshots around a known property
+4. Use `suburb <name>` for suburb estimate trend and rental estimate snapshots
+5. Use `--json` for agent chaining, comparisons, alerts, or structured reports
+6. Mention that homes.co.nz estimates are automated public snapshots and not formal valuations
+
+## CLI
+
+Run with:
+
+```bash
+python3 skills/homes-nz/scripts/cli.py <command> [flags]
+```
+
+### Commands
+
+- `address <query> [--limit N] [--json]` — search partial addresses and return matching properties with ids, HomesEstimate, and last sale when exposed
+- `property <property-id> [--json]` — fetch full public property detail, HomesEstimate, beds/baths/area, last sale, and sales history
+- `suburb <name-or-id> [--history-limit N] [--json]` — fetch suburb HomesEstimate trend and median rent estimate
+- `nearby <property-id> [--radius N] [--limit N] [--json]` — fetch nearby comparable property snapshots around a known property id
+
+Examples:
+
+```bash
+python3 skills/homes-nz/scripts/cli.py address "100 Queen Street Auckland" --limit 5
+python3 skills/homes-nz/scripts/cli.py property 868a7ea3-36ac-4f10-8709-0023d96910a7 --json
+python3 skills/homes-nz/scripts/cli.py suburb "Northcote Point" --json
+python3 skills/homes-nz/scripts/cli.py nearby ae4c05ca-2662-44ca-9573-a3e00772fdf7 --radius 150 --limit 8 --json
+```
+
+## Resources
+
+- CLI entrypoint: `scripts/cli.py`
+- API and stability notes: `references/api-notes.md`
+
+## Notes
+
+- No API key, username, password, account cookie, private token, or browser automation is required for supported read-only commands
+- Scope is intentionally distinct from `trademe-nz`: Trade Me is for current listings and market scans; homes.co.nz is for estimated values, property attributes, and historical sales
+- Address search can return suburb/street/city suggestions without a property id; use a more specific address or select a returned property id before calling `property`
+- Treat estimates and sales data as live public snapshots; endpoint shapes and available fields can change without notice
+- Keep usage narrow and respectful

--- a/skills/homes-nz/references/api-notes.md
+++ b/skills/homes-nz/references/api-notes.md
@@ -1,0 +1,44 @@
+# Homes NZ API notes
+
+This skill is an unofficial lightweight wrapper around public read-only homes.co.nz endpoints used by the modern web app.
+
+## Source and auth
+
+- Website: `https://homes.co.nz`
+- Public gateway: `https://gateway.homes.co.nz`
+- Public detail gateway: `https://api-gateway.homes.co.nz`
+- Auth model for supported commands: none
+
+No username, password, account cookie, private token, browser session, or JavaScript rendering is required for the implemented read-only operations.
+
+## Endpoint families used
+
+- `GET /address/search?Address={query}` for address, suburb, street, and city typeahead results
+- `GET /properties?property_ids={comma_ids}` for property cards, HomesEstimate display values, property attributes, and map URLs
+- `GET https://api-gateway.homes.co.nz/details?property_id={id}` for richer public property/council detail
+- `GET /properties/sales?property_ids={comma_ids}` for public sale history attached to property ids
+- `GET /suburb/estimate_history?id={suburb_id}` for suburb HomesEstimate trend data
+- `GET /median_suburb_rent_estimate?id={suburb_id}` for suburb median rental estimate
+- `GET /map/items?...` for nearby public property cards around a bounded map viewport
+- `GET /homes_estimates/latest_date` for the latest HomesEstimate revision date
+
+The CLI sends browser-like `Accept`, `Referer`, `Origin`, and `User-Agent` headers, but it does not store or send credentials.
+
+## Discovery notes
+
+- The Angular bundle exposes `GATEWAY:{SCHEMA:"https",HOST:"gateway.homes.co.nz"}` and `API_GATEWAY:"https://api-gateway.homes.co.nz"`.
+- Address search returns mixed result types. `Type: 4` is an address result, `Type: 3` is a street result, `Type: 2` is a suburb result, and `Type: 1` is a city result.
+- Some address results do not include `PropertyID`. The CLI reports those suggestions but cannot fetch property detail until a property id is available.
+- `GET /property/resolve` was present in the bundle but returned `400` for direct no-login reproduction, so it is not exposed.
+- `GET /map/radius/addresses` was present in the bundle but returned `could not parse request body` for direct no-login reproduction, so `nearby` uses `GET /map/items` with a bounding box instead.
+- `GET /suburb/estimate_history/{id}` was present in the bundle and returned JSON, but direct live checks produced inconsistent values for known suburbs. The CLI uses the query form, which matched the expected suburb market levels in live verification.
+- No no-login suburb sales-volume aggregate was verified. The `suburb` command reports the available suburb property count from typeahead, HomesEstimate trend, and median rent estimate.
+
+## Stability and safety
+
+- Treat HomesEstimate/HEV and RentEstimate values as automated estimates, not formal valuations.
+- Treat sales histories as public snapshots; records can be corrected, removed, suppressed, or delayed.
+- Endpoint shapes and filter names can change without notice because this is not a formally supported public skill API.
+- Avoid high-volume scraping and dataset redistribution; use narrow queries and small limits.
+- Do not use this skill for claim-home updates, user accounts, favourites, saved searches, agent enquiries, lead forms, property edits, or any POST/PUT/DELETE mutation.
+- Do not commit cookies, account data, raw authenticated captures, HAR files, screenshots, JS bundles, or HTML captures.

--- a/skills/homes-nz/scripts/cli.py
+++ b/skills/homes-nz/scripts/cli.py
@@ -1,0 +1,617 @@
+#!/usr/bin/env python3
+"""homes.co.nz lightweight property estimate CLI.
+
+Self-contained stdlib wrapper around public homes.co.nz read-only endpoints.
+No login, account state, browser automation, or third-party dependencies.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+BASE_WEB = "https://homes.co.nz"
+BASE_GATEWAY = "https://gateway.homes.co.nz"
+BASE_API = "https://api-gateway.homes.co.nz"
+UA = os.environ.get(
+    "HOMES_NZ_USER_AGENT",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
+)
+
+STATE_LABELS = {
+    0: "for_sale",
+    1: "recently_sold",
+    2: "off_market",
+    3: "for_rent",
+}
+
+
+def die(message: str, code: int = 1) -> None:
+    print(f"homes-nz: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def clean_params(params: dict[str, Any] | None) -> dict[str, str]:
+    out: dict[str, str] = {}
+    for key, value in (params or {}).items():
+        if value is None or value == "":
+            continue
+        if isinstance(value, bool):
+            out[key] = str(value).lower()
+        elif isinstance(value, (list, tuple)):
+            out[key] = ",".join(str(x) for x in value if x is not None)
+        else:
+            out[key] = str(value)
+    return out
+
+
+def request_json(base: str, path: str, params: dict[str, Any] | None = None, timeout: int = 25) -> Any:
+    url = base + path
+    clean = clean_params(params)
+    if clean:
+        url += "?" + urllib.parse.urlencode(clean)
+    headers = {
+        "Accept": "application/json, text/plain, */*",
+        "Origin": BASE_WEB,
+        "Referer": BASE_WEB + "/",
+        "User-Agent": UA,
+    }
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", "replace")
+            return json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8", "replace")
+        try:
+            payload = json.loads(raw)
+            detail = payload.get("error") or payload.get("ErrorMessage") or payload.get("message") or raw[:300]
+        except Exception:
+            detail = raw[:300]
+        die(f"HTTP {e.code} from {url}: {detail}".rstrip())
+    except urllib.error.URLError as e:
+        die(f"network error calling {url}: {e.reason}")
+    except json.JSONDecodeError as e:
+        die(f"invalid JSON from {url}: {e}")
+
+
+def as_float(value: Any) -> float | None:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def short_date(value: Any) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    return value[:10]
+
+
+def source_url(card_url: Any) -> str | None:
+    if not isinstance(card_url, str) or not card_url:
+        return None
+    if card_url.startswith("http"):
+        return card_url
+    return BASE_WEB + "/address" + card_url
+
+
+def state_label(value: Any) -> str | None:
+    if isinstance(value, int):
+        return STATE_LABELS.get(value, str(value))
+    return None
+
+
+def first_not_none(*values: Any) -> Any:
+    for value in values:
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def estimate_from_details(detail: dict[str, Any], pd: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "value": first_not_none(detail.get("estimated_value"), pd.get("estimated_value")),
+        "display": first_not_none(detail.get("display_estimated_value"), pd.get("display_estimated_value")),
+        "display_short": first_not_none(detail.get("display_estimated_value_short"), pd.get("display_estimated_value_short")),
+        "lower": first_not_none(detail.get("estimated_lower_value"), pd.get("estimated_lower_value")),
+        "upper": first_not_none(detail.get("estimated_upper_value"), pd.get("estimated_upper_value")),
+        "lower_display_short": first_not_none(detail.get("display_estimated_lower_value_short"), pd.get("display_estimated_lower_value_short")),
+        "upper_display_short": first_not_none(detail.get("display_estimated_upper_value_short"), pd.get("display_estimated_upper_value_short")),
+        "revision_date": short_date(first_not_none(detail.get("estimated_value_revision_date"), pd.get("estimated_value_revision_date"))),
+    }
+
+
+def rent_from_details(detail: dict[str, Any], pd: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "lower": first_not_none(detail.get("estimated_rental_lower_value"), pd.get("estimated_rental_lower_value")),
+        "upper": first_not_none(detail.get("estimated_rental_upper_value"), pd.get("estimated_rental_upper_value")),
+        "lower_display_short": first_not_none(detail.get("display_estimated_rental_lower_value_short"), pd.get("display_estimated_rental_lower_value_short")),
+        "upper_display_short": first_not_none(detail.get("display_estimated_rental_upper_value_short"), pd.get("display_estimated_rental_upper_value_short")),
+        "yield": first_not_none(detail.get("estimated_rental_yield"), pd.get("estimated_rental_yield")),
+        "revision_date": short_date(first_not_none(detail.get("estimated_rental_revision_date"), pd.get("estimated_rental_revision_date"))),
+    }
+
+
+def parse_sale(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": item.get("id"),
+        "property_id": item.get("property_id"),
+        "listing_id": item.get("listing_id") or None,
+        "date": short_date(item.get("price_on")),
+        "price": item.get("price") if item.get("can_display_sale_price", True) else None,
+        "display_price": item.get("display_price") if item.get("can_display_sale_price", True) else None,
+        "sale_type": item.get("sale_type"),
+        "council_confirmed": item.get("council_confirmed"),
+    }
+
+
+def parse_card(card: dict[str, Any], detail: dict[str, Any] | None = None) -> dict[str, Any]:
+    detail = detail or {}
+    pd = card.get("property_details") or {}
+    point = card.get("point") or {}
+    prop_id = first_not_none(card.get("property_id"), card.get("id"), detail.get("property_id"))
+    out = {
+        "property_id": prop_id,
+        "listing_id": card.get("listing_id") or None,
+        "state": card.get("state"),
+        "state_label": state_label(card.get("state")),
+        "address": first_not_none(pd.get("display_address"), pd.get("address")),
+        "suburb": first_not_none(detail.get("suburb_name"), pd.get("suburb")),
+        "city": first_not_none(detail.get("city_name"), pd.get("city")),
+        "suburb_id": first_not_none(detail.get("suburb_id"), pd.get("suburb_id")),
+        "city_id": first_not_none(detail.get("city_id"), pd.get("city_id")),
+        "homes_estimate": estimate_from_details(detail, pd),
+        "rent_estimate": rent_from_details(detail, pd),
+        "bedrooms": first_not_none(detail.get("bed_estimate"), pd.get("num_bedrooms"), pd.get("latest_bedrooms")),
+        "bathrooms": first_not_none(detail.get("bath_estimate"), pd.get("num_bathrooms"), pd.get("latest_bathrooms")),
+        "car_spaces": first_not_none(detail.get("num_car_spaces"), pd.get("num_car_spaces"), pd.get("latest_car_spaces")),
+        "floor_area": first_not_none(detail.get("floor_area"), pd.get("floor_area")),
+        "land_area": first_not_none(detail.get("land_area"), pd.get("land_area")),
+        "decade_built": first_not_none(detail.get("decade_built"), pd.get("decade_built")),
+        "ownership": first_not_none(detail.get("ownership"), pd.get("ownership_type")),
+        "capital_value": first_not_none(detail.get("capital_value_digit"), pd.get("capital_value")),
+        "land_value": first_not_none(detail.get("land_value_digit"), pd.get("land_value")),
+        "improvement_value": first_not_none(detail.get("improvement_value_digit"), pd.get("improvement_value")),
+        "display_capital_value_short": first_not_none(detail.get("display_capital_value_short"), pd.get("display_capital_value_short")),
+        "display_land_value_short": first_not_none(detail.get("display_land_value_short"), pd.get("display_land_value_short")),
+        "display_improvement_value_short": first_not_none(detail.get("display_improvement_value_short"), pd.get("display_improvement_value_short")),
+        "last_seen_sale_date": short_date(card.get("date")),
+        "sales_count": card.get("sales_count"),
+        "lat": point.get("lat"),
+        "long": point.get("long"),
+        "distance_m": card.get("distance_to_point"),
+        "url": source_url(card.get("url")),
+    }
+    if out["homes_estimate"].get("value") is None and card.get("state") == 2:
+        out["homes_estimate"]["value"] = card.get("price")
+    return out
+
+
+def parse_map_item(item: dict[str, Any], origin: tuple[float, float] | None = None) -> dict[str, Any]:
+    point = item.get("point") or {}
+    lat = as_float(point.get("lat"))
+    lon = as_float(point.get("long"))
+    distance = item.get("distance_to_point")
+    if distance is None and origin and lat is not None and lon is not None:
+        distance = distance_m(origin[0], origin[1], lat, lon)
+    return {
+        "property_id": item.get("id") or item.get("item_id"),
+        "state": item.get("state"),
+        "state_label": state_label(item.get("state")),
+        "address": (item.get("property_details") or {}).get("address"),
+        "price": item.get("price"),
+        "display_price": item.get("display_price") or item.get("display_price_short"),
+        "date": short_date(item.get("date")),
+        "lat": lat,
+        "long": lon,
+        "distance_m": round(distance, 1) if isinstance(distance, (int, float)) else distance,
+        "url": source_url(item.get("url")),
+    }
+
+
+def compact_card(card: dict[str, Any], origin: tuple[float, float] | None = None) -> dict[str, Any]:
+    parsed = parse_card(card)
+    if parsed.get("distance_m") is None and origin and parsed.get("lat") is not None and parsed.get("long") is not None:
+        parsed["distance_m"] = round(distance_m(origin[0], origin[1], parsed["lat"], parsed["long"]), 1)
+    return {
+        "property_id": parsed.get("property_id"),
+        "state": parsed.get("state"),
+        "state_label": parsed.get("state_label"),
+        "address": parsed.get("address"),
+        "homes_estimate": parsed.get("homes_estimate"),
+        "bedrooms": parsed.get("bedrooms"),
+        "bathrooms": parsed.get("bathrooms"),
+        "floor_area": parsed.get("floor_area"),
+        "land_area": parsed.get("land_area"),
+        "last_seen_sale_date": parsed.get("last_seen_sale_date"),
+        "sales_count": parsed.get("sales_count"),
+        "distance_m": parsed.get("distance_m"),
+        "url": parsed.get("url"),
+    }
+
+
+def get_cards(property_ids: list[str]) -> dict[str, dict[str, Any]]:
+    ids = [x for x in property_ids if x]
+    if not ids:
+        return {}
+    payload = request_json(BASE_GATEWAY, "/properties", {"property_ids": ",".join(ids)})
+    out: dict[str, dict[str, Any]] = {}
+    for card in (payload or {}).get("cards") or []:
+        if not isinstance(card, dict):
+            continue
+        prop_id = card.get("property_id") or card.get("id")
+        if prop_id:
+            out[str(prop_id)] = card
+    return out
+
+
+def get_sales(property_ids: list[str]) -> dict[str, list[dict[str, Any]]]:
+    ids = [x for x in property_ids if x]
+    if not ids:
+        return {}
+    payload = request_json(BASE_GATEWAY, "/properties/sales", {"property_ids": ",".join(ids)})
+    out: dict[str, list[dict[str, Any]]] = {}
+    for row in (payload or {}).get("properties") or []:
+        if not isinstance(row, dict):
+            continue
+        prop_id = row.get("id")
+        sales = [parse_sale(x) for x in row.get("sales") or [] if isinstance(x, dict)]
+        if prop_id:
+            out[str(prop_id)] = sales
+    return out
+
+
+def get_detail(property_id: str) -> dict[str, Any]:
+    payload = request_json(BASE_API, "/details", {"property_id": property_id})
+    return (payload or {}).get("property") or {}
+
+
+def first_sale_for(prop_id: str | None, sales_by_id: dict[str, list[dict[str, Any]]], card: dict[str, Any] | None = None) -> dict[str, Any] | None:
+    if prop_id and sales_by_id.get(prop_id):
+        return sales_by_id[prop_id][0]
+    if card and card.get("date"):
+        return {"date": short_date(card.get("date")), "price": None, "display_price": card.get("display_price")}
+    return None
+
+
+def address(args: argparse.Namespace) -> dict[str, Any]:
+    started = time.perf_counter()
+    payload = request_json(BASE_GATEWAY, "/address/search", {"Address": args.query})
+    results = [x for x in (payload or {}).get("Results") or [] if isinstance(x, dict)][: max(1, args.limit)]
+    prop_ids = [str(x.get("PropertyID")) for x in results if x.get("PropertyID")]
+    cards = get_cards(prop_ids)
+    sales = get_sales(prop_ids)
+    matches = []
+    for item in results:
+        prop_id = str(item.get("PropertyID")) if item.get("PropertyID") else None
+        card = cards.get(prop_id or "")
+        parsed_card = parse_card(card) if card else {}
+        last_sale = first_sale_for(prop_id, sales, card)
+        matches.append(
+            {
+                "title": item.get("Title"),
+                "type": item.get("Type"),
+                "score": item.get("Score"),
+                "property_id": prop_id,
+                "lat": item.get("Lat"),
+                "long": item.get("Long"),
+                "suburb_id": item.get("SuburbID"),
+                "city_id": item.get("CityID"),
+                "suburb": item.get("Suburb") or None,
+                "city": item.get("City") or None,
+                "homes_estimate": parsed_card.get("homes_estimate"),
+                "bedrooms": parsed_card.get("bedrooms"),
+                "bathrooms": parsed_card.get("bathrooms"),
+                "floor_area": parsed_card.get("floor_area"),
+                "land_area": parsed_card.get("land_area"),
+                "last_sale": last_sale,
+                "sales_count": parsed_card.get("sales_count"),
+                "url": parsed_card.get("url"),
+            }
+        )
+    return {
+        "query": args.query,
+        "count": len(matches),
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+        "matches": matches,
+        "error": (payload or {}).get("ErrorMessage") or None,
+    }
+
+
+def cmd_address(args: argparse.Namespace) -> None:
+    emit(address(args), args.json, print_address)
+
+
+def property_detail(args: argparse.Namespace) -> dict[str, Any]:
+    started = time.perf_counter()
+    cards = get_cards([args.property_id])
+    card = cards.get(args.property_id) or {}
+    detail = get_detail(args.property_id)
+    if not card and not detail:
+        die(f"no public property detail found for {args.property_id}")
+    sales_history = get_sales([args.property_id]).get(args.property_id, [])
+    summary = parse_card(card, detail)
+    if not summary.get("property_id"):
+        summary["property_id"] = args.property_id
+    summary["last_sale"] = sales_history[0] if sales_history else first_sale_for(args.property_id, {}, card)
+    return {
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+        "property": summary,
+        "sales_history_count": len(sales_history),
+        "sales_history": sales_history,
+    }
+
+
+def cmd_property(args: argparse.Namespace) -> None:
+    emit(property_detail(args), args.json, print_property)
+
+
+def resolve_suburb(value: str) -> dict[str, Any]:
+    if value.isdigit():
+        return {"SuburbID": int(value), "Title": value}
+    payload = request_json(BASE_GATEWAY, "/address/search", {"Address": value})
+    results = [x for x in (payload or {}).get("Results") or [] if isinstance(x, dict)]
+    for item in results:
+        if item.get("Type") == 2 and item.get("SuburbID"):
+            return item
+    for item in results:
+        if item.get("SuburbID"):
+            return item
+    die(f"no suburb id found for {value!r}")
+
+
+def suburb(args: argparse.Namespace) -> dict[str, Any]:
+    started = time.perf_counter()
+    resolved = resolve_suburb(args.name_or_id)
+    suburb_id = str(resolved.get("SuburbID"))
+    history_payload = request_json(BASE_GATEWAY, "/suburb/estimate_history", {"id": suburb_id})
+    rent_payload = request_json(BASE_GATEWAY, "/median_suburb_rent_estimate", {"id": suburb_id})
+    history = [x for x in (history_payload or {}).get("estimate_history") or [] if isinstance(x, dict)]
+    history = sorted(history, key=lambda x: x.get("date") or "")
+    latest = history[-1] if history else None
+    rows = history[-max(1, args.history_limit) :]
+    return {
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+        "suburb": {
+            "suburb_id": int(suburb_id) if suburb_id.isdigit() else suburb_id,
+            "title": resolved.get("Title"),
+            "suburb": resolved.get("Suburb") or None,
+            "city": resolved.get("City") or None,
+            "property_count": resolved.get("Size"),
+            "lat": resolved.get("Lat"),
+            "long": resolved.get("Long"),
+        },
+        "latest_median_estimate": {
+            "date": short_date(latest.get("date")) if latest else None,
+            "estimate": latest.get("estimate") if latest else None,
+            "display_estimate": latest.get("display_estimate") if latest else None,
+        },
+        "median_rent_estimate": {
+            "date": short_date((rent_payload or {}).get("date")),
+            "estimate": (rent_payload or {}).get("estimate"),
+        },
+        "history_count": len(history),
+        "history": [
+            {
+                "date": short_date(row.get("date")),
+                "estimate": row.get("estimate"),
+                "display_estimate": row.get("display_estimate"),
+            }
+            for row in rows
+        ],
+        "sales_volume": None,
+        "sales_volume_note": "No no-login suburb sales-volume aggregate was verified; use property sales history for known property ids.",
+    }
+
+
+def cmd_suburb(args: argparse.Namespace) -> None:
+    emit(suburb(args), args.json, print_suburb)
+
+
+def distance_m(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    radius = 6371000.0
+    p1 = math.radians(lat1)
+    p2 = math.radians(lat2)
+    dp = math.radians(lat2 - lat1)
+    dl = math.radians(lon2 - lon1)
+    a = math.sin(dp / 2) ** 2 + math.cos(p1) * math.cos(p2) * math.sin(dl / 2) ** 2
+    return 2 * radius * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def bounding_box(lat: float, lon: float, radius_m: int) -> dict[str, float]:
+    lat_delta = radius_m / 111320.0
+    lon_delta = radius_m / (111320.0 * max(0.1, math.cos(math.radians(lat))))
+    return {
+        "nw_lat": lat + lat_delta,
+        "nw_long": lon - lon_delta,
+        "se_lat": lat - lat_delta,
+        "se_long": lon + lon_delta,
+    }
+
+
+def nearby(args: argparse.Namespace) -> dict[str, Any]:
+    started = time.perf_counter()
+    source_cards = get_cards([args.property_id])
+    source_card = source_cards.get(args.property_id)
+    if not source_card:
+        die(f"no public property card found for {args.property_id}")
+    source = parse_card(source_card)
+    lat = as_float(source.get("lat"))
+    lon = as_float(source.get("long"))
+    if lat is None or lon is None:
+        die(f"property {args.property_id} has no public map point")
+    box = bounding_box(lat, lon, max(25, args.radius))
+    params: dict[str, Any] = {
+        **box,
+        "limit": min(max(args.limit * 4, 20), 100),
+        "display_rentals": False,
+    }
+    payload = request_json(BASE_GATEWAY, "/map/items", params)
+    origin = (lat, lon)
+    seen = {args.property_id}
+    rows: list[dict[str, Any]] = []
+    for card in (payload or {}).get("cards") or []:
+        if not isinstance(card, dict):
+            continue
+        prop_id = str(card.get("property_id") or card.get("id") or "")
+        if not prop_id or prop_id in seen:
+            continue
+        seen.add(prop_id)
+        rows.append(compact_card(card, origin))
+    for item in (payload or {}).get("map_items") or []:
+        if len(rows) >= args.limit * 2:
+            break
+        if not isinstance(item, dict):
+            continue
+        prop_id = str(item.get("id") or item.get("item_id") or "")
+        if not prop_id or prop_id in seen:
+            continue
+        seen.add(prop_id)
+        rows.append(parse_map_item(item, origin))
+    rows = sorted(rows, key=lambda x: (x.get("distance_m") is None, x.get("distance_m") or 0))[: args.limit]
+    return {
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+        "property_id": args.property_id,
+        "radius_m": args.radius,
+        "source_property": source,
+        "count": len(rows),
+        "comparables": rows,
+    }
+
+
+def cmd_nearby(args: argparse.Namespace) -> None:
+    emit(nearby(args), args.json, print_nearby)
+
+
+def fmt_estimate(value: dict[str, Any] | None) -> str:
+    if not value:
+        return "-"
+    display = value.get("display_short") or value.get("display")
+    lower = value.get("lower_display_short")
+    upper = value.get("upper_display_short")
+    if display and lower and upper:
+        return f"{display} ({lower}-{upper})"
+    return str(display or value.get("value") or "-")
+
+
+def fmt_sale(value: dict[str, Any] | None) -> str:
+    if not value:
+        return "-"
+    bits = [value.get("date"), value.get("display_price")]
+    return " ".join(str(x) for x in bits if x) or "-"
+
+
+def print_address(data: dict[str, Any]) -> None:
+    print(f"Homes NZ address: {data.get('count')} matches for {data.get('query')!r} ({data.get('elapsed_ms')} ms)")
+    print()
+    for item in data.get("matches") or []:
+        print(f"{item.get('property_id') or '-'}  {item.get('title')}")
+        bits = [
+            "HEV " + fmt_estimate(item.get("homes_estimate")),
+            f"{item.get('bedrooms') or '-'} bed",
+            f"{item.get('bathrooms') or '-'} bath",
+            f"last sale {fmt_sale(item.get('last_sale'))}",
+        ]
+        print("  " + " | ".join(bits))
+        if item.get("url"):
+            print(f"  {item.get('url')}")
+        print()
+
+
+def print_property(data: dict[str, Any]) -> None:
+    prop = data.get("property") or {}
+    print(f"{prop.get('property_id')}  {prop.get('address') or ''}")
+    print(f"HEV: {fmt_estimate(prop.get('homes_estimate'))}")
+    print(f"Beds/baths/cars: {prop.get('bedrooms') or '-'} / {prop.get('bathrooms') or '-'} / {prop.get('car_spaces') or '-'}")
+    print(f"Area: floor {prop.get('floor_area') or '-'} sqm | land {prop.get('land_area') or '-'} sqm")
+    print(f"CV/LV/IV: {prop.get('display_capital_value_short') or '-'} / {prop.get('display_land_value_short') or '-'} / {prop.get('display_improvement_value_short') or '-'}")
+    print(f"Last sale: {fmt_sale(prop.get('last_sale'))}")
+    if prop.get("url"):
+        print(prop["url"])
+    print()
+    print(f"Sales history: {data.get('sales_history_count')} records")
+    for sale in data.get("sales_history") or []:
+        print(f"  {sale.get('date') or '-'}  {sale.get('display_price') or '-'}  {sale.get('sale_type') or ''}".rstrip())
+
+
+def print_suburb(data: dict[str, Any]) -> None:
+    suburb = data.get("suburb") or {}
+    latest = data.get("latest_median_estimate") or {}
+    rent = data.get("median_rent_estimate") or {}
+    print(f"{suburb.get('suburb_id')}  {suburb.get('title')}")
+    print(f"Latest median HomesEstimate: {latest.get('display_estimate') or latest.get('estimate') or '-'} ({latest.get('date') or '-'})")
+    print(f"Median rent estimate: {rent.get('estimate') or '-'} ({rent.get('date') or '-'})")
+    if suburb.get("property_count") is not None:
+        print(f"Typeahead property count: {suburb.get('property_count')}")
+    print(f"History points: {data.get('history_count')}")
+    print(data.get("sales_volume_note"))
+
+
+def print_nearby(data: dict[str, Any]) -> None:
+    source = data.get("source_property") or {}
+    print(f"Nearby properties around {source.get('address') or data.get('property_id')} within {data.get('radius_m')}m ({data.get('elapsed_ms')} ms)")
+    print()
+    for item in data.get("comparables") or []:
+        dist = item.get("distance_m")
+        dist_label = f"{dist:.0f}m" if isinstance(dist, (int, float)) else "-"
+        estimate = fmt_estimate(item.get("homes_estimate")) if item.get("homes_estimate") else item.get("display_price") or "-"
+        print(f"{item.get('property_id')}  {item.get('address') or ''}")
+        print(f"  {dist_label} | {item.get('state_label') or item.get('state')} | {estimate}")
+        if item.get("url"):
+            print(f"  {item.get('url')}")
+        print()
+
+
+def emit(data: dict[str, Any], as_json: bool, printer: Any) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2, ensure_ascii=False))
+    else:
+        printer(data)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    ap = argparse.ArgumentParser(description="Lightweight homes.co.nz public read-only property estimate CLI.")
+    sub = ap.add_subparsers(dest="command", required=True)
+
+    sp = sub.add_parser("address", help="search homes.co.nz address/typeahead results")
+    sp.add_argument("query")
+    sp.add_argument("--limit", type=int, default=10)
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_address)
+
+    sp = sub.add_parser("property", help="fetch public property detail and sales history")
+    sp.add_argument("property_id")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_property)
+
+    sp = sub.add_parser("suburb", help="fetch suburb estimate trend and rent estimate")
+    sp.add_argument("name_or_id")
+    sp.add_argument("--history-limit", type=int, default=12)
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_suburb)
+
+    sp = sub.add_parser("nearby", help="fetch nearby comparable property snapshots")
+    sp.add_argument("property_id")
+    sp.add_argument("--radius", type=int, default=150, help="radius in metres")
+    sp.add_argument("--limit", type=int, default=10)
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_nearby)
+    return ap
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Adds `skills/homes-nz/`, a lightweight read-only homes.co.nz skill for NZ residential property estimates, sales history, suburb estimate trend data, and nearby comparable-property snapshots.
- Implements a stdlib-only CLI with `address`, `property`, `suburb`, and `nearby` commands.
- Documents discovered public no-login endpoints and known non-exposed/broken endpoints in `references/api-notes.md`.
- Keeps scope distinct from `trademe-nz`: Trade Me is for active listings; homes.co.nz is for automated value estimates, property attributes, and historical sales.

## Live test output

```text
$ python3 skills/homes-nz/scripts/cli.py --help
usage: cli.py [-h] {address,property,suburb,nearby} ...

Lightweight homes.co.nz public read-only property estimate CLI.

positional arguments:
  {address,property,suburb,nearby}
    address             search homes.co.nz address/typeahead results
    property            fetch public property detail and sales history
    suburb              fetch suburb estimate trend and rent estimate
    nearby              fetch nearby comparable property snapshots

options:
  -h, --help            show this help message and exit
```

```text
$ python3 skills/homes-nz/scripts/cli.py address '100 Queen Street Auckland' --limit 3
Homes NZ address: 1 matches for '100 Queen Street Auckland' (239 ms)

ae4c05ca-2662-44ca-9573-a3e00772fdf7  100 Queen Street, Northcote Point, Auckland
  HEV 2.89M (2.73M-3.06M) | 3 bed | 1 bath | last sale -
  https://homes.co.nz/address/auckland/northcote-point/100-queen-street/n7kM
```

```text
$ python3 skills/homes-nz/scripts/cli.py address '110 Queen Street Auckland' --limit 1 --json
{
  "query": "110 Queen Street Auckland",
  "count": 1,
  "matches": [
    {
      "title": "110 Queen Street, Northcote Point, Auckland",
      "property_id": "868a7ea3-36ac-4f10-8709-0023d96910a7",
      "homes_estimate": {
        "value": 2480000,
        "display_short": "2.48M",
        "lower_display_short": "2.34M",
        "upper_display_short": "2.62M",
        "revision_date": "2026-05-14"
      },
      "bedrooms": 3,
      "bathrooms": 2,
      "last_sale": {
        "date": "2001-04-30",
        "price": 535000,
        "display_price": "$535,000"
      },
      "sales_count": 3
    }
  ],
  "error": null
}
```

```text
$ python3 skills/homes-nz/scripts/cli.py property 868a7ea3-36ac-4f10-8709-0023d96910a7
868a7ea3-36ac-4f10-8709-0023d96910a7  110 Queen Street, Northcote Point, Auckland
HEV: 2.48M (2.34M-2.62M)
Beds/baths/cars: 3 / 2 / -
Area: floor 160 sqm | land 670 sqm
CV/LV/IV: 2.4M / 1.9M / 500K
Last sale: 2001-04-30 $535,000
https://homes.co.nz/address/auckland/northcote-point/110-queen-street/GRvE8

Sales history: 3 records
  2001-04-30  $535,000  S11
  1997-04-20  $535,000  S11
  1996-11-11  $500,000  S11
```

```text
$ python3 skills/homes-nz/scripts/cli.py suburb 'Northcote Point' --history-limit 3
8819  Northcote Point, Auckland
Latest median HomesEstimate: 1.56M (2026-05-14)
Median rent estimate: 913.5 (2026-05-02)
Typeahead property count: 1409
History points: 29
No no-login suburb sales-volume aggregate was verified; use property sales history for known property ids.
```

```text
$ python3 skills/homes-nz/scripts/cli.py nearby ae4c05ca-2662-44ca-9573-a3e00772fdf7 --radius 120 --limit 5
Nearby properties around 100 Queen Street, Northcote Point, Auckland within 120m (254 ms)

d64289e9-abf2-4da9-86bd-4eea54e98bbd  1/98 Queen Street, Northcote Point, Auckland
  22m | off_market | 1.24M (1.17M-1.31M)
  https://homes.co.nz/address/auckland/northcote-point/1-98-queen-street/9lnEe

13d7ab11-4db5-4228-80fc-e41e3a5199fa  2/98 Queen Street, Northcote Point, Auckland
  25m | off_market | 1.76M (1.66M-1.86M)
  https://homes.co.nz/address/auckland/northcote-point/2-98-queen-street/EALx

55d541cd-5840-4b11-b2bc-4a50aebe7347  2/102 Queen Street, Northcote Point, Auckland
  29m | recently_sold | 2.46M (2.32M-2.6M)
  https://homes.co.nz/address/auckland/northcote-point/2-102-queen-street/jrOXz
```
