### PR TITLE
feat(nz-airports): add AKL via adsb.lol live ADS-B

### DIFF
--- a/skills/nz-airports/SKILL.md
+++ b/skills/nz-airports/SKILL.md
@@ -1,28 +1,29 @@
 ---
 name: nz-airports
-description: Query live public New Zealand airport arrivals and departures boards for supported airports through a lightweight read-only CLI. Use when the task involves current flight board data for Christchurch, Queenstown, or Wellington airports.
+description: Query live public New Zealand airport arrivals and departures data for supported airports through a lightweight read-only CLI. Use when the task involves current flight board data for Christchurch, Queenstown, or Wellington airports, or live ADS-B aircraft positions near Auckland Airport.
 ---
 
 # NZ Airports
 
 ## Goal
 
-Query live arrivals and departures board data for supported New Zealand airports through a small deterministic CLI with human-readable and JSON output, without browser automation or account login.
+Query live arrivals and departures data for supported New Zealand airports through a small deterministic CLI with human-readable and JSON output, without browser automation or account login.
+
+CHC, ZQN, and WLG use airport/airline-published FIDS-style boards with scheduled and estimated times. AKL uses adsb.lol live ADS-B positions because Auckland Airport's public flight-board API is blocked by Cloudflare from server-side CLI fetches.
 
 ## Use this when
 
 - A user asks for current arrivals or departures at a supported NZ airport
 - A user wants to look up a flight number on a supported airport flight board
-- A user needs lightweight machine-readable NZ airport FIDS-style data
+- A user needs lightweight machine-readable NZ airport FIDS-style data, or current aircraft-position data near AKL
 - A workflow needs a fast read-only alternative to opening airport flight-board pages
 
 ## Do not use this for
 
 - Booking, check-in, ticketing, PNR, passenger, baggage ownership, or account actions
-- Aviation tracking outside the public airport flight boards
+- Aviation tracking outside the supported airport surfaces and AKL local ADS-B view
 - Historical flight status or delay analysis
 - Airports not listed by the `airports` command
-- Auckland Airport until its public flight-board surface can be fetched without Cloudflare blocking
 
 ## Preferred workflow
 
@@ -31,7 +32,7 @@ Query live arrivals and departures board data for supported New Zealand airports
 3. Use `flight <flight-number>` when the user asks about a specific flight
 4. Use `airports` to confirm currently supported airport codes
 5. Use `--json` for agent chaining, comparisons, or structured reports
-6. Mention that data is a live public airport-board snapshot and the source is unofficial
+6. Mention the source type: CHC/ZQN/WLG are live public airport-board snapshots; AKL is live ADS-B aircraft-position data
 
 ## CLI
 
@@ -43,14 +44,15 @@ python3 skills/nz-airports/scripts/cli.py <command> [flags]
 
 ## Commands
 
-- `arrivals [--airport CHC|ZQN|WLG] [--limit N] [--json]` - current arrivals board
-- `departures [--airport CHC|ZQN|WLG] [--limit N] [--json]` - current departures board
-- `flight <flight-number> [--airport CHC|ZQN|WLG] [--json]` - lookup a flight number across current boards
+- `arrivals [--airport AKL|CHC|ZQN|WLG] [--limit N] [--json]` - current arrivals board or AKL live ADS-B arrivals
+- `departures [--airport AKL|CHC|ZQN|WLG] [--limit N] [--json]` - current departures board or AKL live ADS-B departures
+- `flight <flight-number> [--airport AKL|CHC|ZQN|WLG] [--json]` - lookup a flight number across current boards, or current AKL ADS-B callsigns
 - `airports [--json]` - list supported airports and investigated gaps
 
 ## Examples
 
 ```bash
+python3 skills/nz-airports/scripts/cli.py arrivals --airport AKL --limit 5
 python3 skills/nz-airports/scripts/cli.py arrivals --airport CHC --limit 10
 python3 skills/nz-airports/scripts/cli.py departures --airport ZQN --limit 10 --json
 python3 skills/nz-airports/scripts/cli.py arrivals --airport WLG --json
@@ -60,11 +62,14 @@ python3 skills/nz-airports/scripts/cli.py airports
 
 ## Notes
 
-- Supported live sources: Christchurch (CHC), Queenstown (ZQN), and Wellington (WLG)
+- Supported sources: Auckland (AKL), Christchurch (CHC), Queenstown (ZQN), and Wellington (WLG)
+- AKL is a live ADS-B view from adsb.lol, not an airline-published schedule board. It shows aircraft actually broadcasting near Auckland Airport right now and classifies low-altitude traffic as arrivals or departures from altitude and vertical-rate signals.
+- CHC, ZQN, and WLG are scheduled FIDS-style airport boards. They expose airline-published scheduled/estimated times, gates, terminals, and status text where available.
+- AKL and CHC/ZQN/WLG answer different questions: AKL is best for "what aircraft are physically near AKL now?", while the FIDS sources are best for "what does the airport board say is scheduled or estimated?"
 - Christchurch uses public JSON endpoints split by domestic/international and arrivals/departures
 - Queenstown uses public JSON endpoints for arrivals and departures; the CLI filters to today's NZ board when possible
 - Wellington embeds the current flight-board JSON in the public flight page; departures can be empty late in the local operating day
-- Auckland (AKL) was investigated, but direct fetches and CloakBrowser/CDP attempts returned Cloudflare challenge/block pages from this environment, so AKL is not listed as supported
+- Auckland Airport's official public flight-board surface was investigated, but direct fetches and CloakBrowser/CDP attempts returned Cloudflare challenge/block pages from this environment. AKL support therefore uses the adsb.lol community ADS-B feed.
 - No API key, username, password, account cookie, browser session, or write action is required
 - Endpoint shapes can change without notice because these are unofficial public website surfaces
 - API and stability notes: `references/api-notes.md`

--- a/skills/nz-airports/references/api-notes.md
+++ b/skills/nz-airports/references/api-notes.md
@@ -1,6 +1,6 @@
 # NZ Airports API notes
 
-This skill is an unofficial lightweight wrapper around public airport flight-board surfaces. It is read-only and does not support booking, check-in, PNR lookup, account access, or passenger/baggage ownership lookup.
+This skill is an unofficial lightweight wrapper around public airport flight-board surfaces and the adsb.lol community ADS-B feed for Auckland. It is read-only and does not support booking, check-in, PNR lookup, account access, or passenger/baggage ownership lookup.
 
 ## Source and auth
 
@@ -8,15 +8,69 @@ No username, password, API key, private token, cookie, or browser session is req
 
 Implemented airports:
 
+- Auckland (AKL): `https://api.adsb.lol`
 - Christchurch (CHC): `https://www.christchurchairport.nz`
 - Queenstown (ZQN): `https://www.queenstownairport.co.nz`
 - Wellington (WLG): `https://www.wellingtonairport.co.nz`
 
-Investigated but not implemented:
+Investigated with alternate implementation:
 
-- Auckland (AKL): `https://www.prod.aucklandairport.co.nz/flights` and `https://corporate.aucklandairport.co.nz/content/aial-traveller/nz/en/flights.html` returned Cloudflare challenge/block pages from direct CLI fetches. CloakBrowser CDP navigation also returned a Cloudflare 403 block in this environment, so no stable no-login CLI endpoint was shipped.
+- Auckland Airport's official flight-board API and pages, including `https://www.prod.aucklandairport.co.nz/flights`, `https://corporate.aucklandairport.co.nz/content/aial-traveller/nz/en/flights.html`, and `https://www.aucklandairport.co.nz/content/aial/api/v1/flights`, returned Cloudflare challenge/block pages from direct CLI fetches. CloakBrowser CDP navigation also returned a Cloudflare 403 block in this environment. AKL is therefore implemented with live ADS-B positions from adsb.lol instead of scheduled airport-board data.
 
 ## Endpoint families used
+
+### Auckland Airport via adsb.lol live ADS-B
+
+Endpoint:
+
+```text
+GET https://api.adsb.lol/v2/lat/{lat}/lon/{lon}/dist/{radiusNm}
+```
+
+Current AKL parameters:
+
+- `lat=-37.008`
+- `lon=174.785`
+- `radiusNm=30`
+
+Operational notes:
+
+- Radius is in nautical miles. The adsb.lol endpoint supports larger radii up to roughly 250 nm, but this skill keeps AKL at 30 nm to reduce payload size and stay focused on local airport activity.
+- No username, password, cookie, token, or API key is required.
+- The CLI sends `User-Agent: nz-airports-cli/1.0`.
+- The ADS-B request timeout is 6 seconds.
+- The aircraft list is capped before classification to avoid processing unexpectedly large responses.
+- There are no retry loops; if adsb.lol is unavailable, malformed, or empty, AKL returns an empty board with a source note rather than a stack trace.
+- This implementation is based on Adam Holt's working `cyclone.vaianu` Supabase function at `supabase/functions/airports-live/index.ts`.
+
+Response shape:
+
+- top-level object with `ac[]`
+- each aircraft may include `hex`, `flight`, `r` (registration), `t` (aircraft type), `alt_baro` (number or `ground`), `gs` (ground speed in knots), `baro_rate` (vertical rate in ft/min), `lat`, `lon`, `dst` (distance from query point in nautical miles), and other ADS-B fields
+
+Classification logic:
+
+- `alt_baro == "ground"` -> `ground`
+- `alt_baro < 6000` and `baro_rate < -200` -> `arrival`
+- `alt_baro < 6000` and `baro_rate > 200` -> `departure`
+- `alt_baro < 6000` with no strong climb/descent -> `arrival`, because low and level traffic near the field is likely on final approach
+- `alt_baro >= 6000`, missing altitude, or otherwise unclassified high traffic -> `overhead`
+
+The `arrivals --airport AKL` and `departures --airport AKL` commands return aircraft classified as `arrival` or `departure` respectively. Ground and overhead aircraft are counted in JSON metadata but are not returned by those board commands.
+
+Normalized AKL fields include:
+
+- `callsign` from `flight`, falling back to uppercase `hex`
+- `hex`, `registration`, `aircraft_type`
+- `classification`
+- `altitude_ft`, `altitude_baro`
+- `distance_nm`
+- `ground_speed_kt`
+- `vertical_rate_fpm`
+- `lat`, `lon`
+- `raw_adsb` with the returned ADS-B row for JSON consumers
+
+AKL is live aircraft-position data, not a scheduled FIDS board. It answers "which aircraft are physically near Auckland Airport now?" rather than "what has the airline published on the airport board?"
 
 ### Christchurch Airport
 
@@ -79,7 +133,7 @@ The board can legitimately be empty for departures late in the local operating d
 
 ## Normalized CLI schema
 
-Each normalized flight includes:
+Each normalized CHC/ZQN/WLG scheduled-board flight includes:
 
 - `airport`, `airport_name`, `direction`
 - `flight_numbers[]`, `primary_flight`
@@ -91,9 +145,12 @@ Each normalized flight includes:
 
 Some fields are source-dependent. Queenstown does not expose gate or airline name in the JSON endpoint. Wellington exposes one flight number per row in the embedded board. Christchurch exposes codeshare flight numbers and airline branding image URLs, but the CLI does not emit image URLs in the normalized record.
 
+AKL ADS-B rows use a different live-position schema. They include callsign, aircraft type, registration, altitude, distance from the airport query point, ground speed, vertical rate, location, classification, and `raw_adsb`. They do not include scheduled/estimated board times, gate, terminal, airline-published status text, origin, or destination.
+
 ## Stability and safety
 
-- Treat results as live public-board snapshots, not historical data.
+- Treat CHC/ZQN/WLG results as live public-board snapshots, not historical data.
+- Treat AKL results as live ADS-B aircraft-position snapshots, not a scheduled airport board.
 - Always prefer narrow commands and small limits for routine checks.
 - Do not use this skill for booking, check-in, account, payment, passenger, baggage ownership, or mutation workflows.
 - Endpoint shapes can change without notice because these are public website implementation details rather than official public APIs.

--- a/skills/nz-airports/scripts/cli.py
+++ b/skills/nz-airports/scripts/cli.py
@@ -28,8 +28,20 @@ UA = os.environ.get(
     "NZ_AIRPORTS_USER_AGENT",
     "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
 )
+ADSB_UA = "nz-airports-cli/1.0"
+ADSB_TIMEOUT_SECONDS = 6
+ADSB_MAX_AIRCRAFT = 250
 
 AIRPORTS: dict[str, dict[str, str]] = {
+    "AKL": {
+        "name": "Auckland Airport",
+        "city": "Auckland",
+        "iata": "AKL",
+        "icao": "NZAA",
+        "source": "adsb.lol",
+        "source_url": "https://api.adsb.lol/v2/lat/-37.008/lon/174.785/dist/30",
+        "source_kind": "live_adsb",
+    },
     "CHC": {
         "name": "Christchurch Airport",
         "city": "Christchurch",
@@ -37,6 +49,7 @@ AIRPORTS: dict[str, dict[str, str]] = {
         "icao": "NZCH",
         "source": "christchurchairport.nz",
         "source_url": "https://www.christchurchairport.nz/travellers/flights/arrivals-and-departures/",
+        "source_kind": "scheduled_fids",
     },
     "ZQN": {
         "name": "Queenstown Airport",
@@ -45,6 +58,7 @@ AIRPORTS: dict[str, dict[str, str]] = {
         "icao": "NZQN",
         "source": "queenstownairport.co.nz",
         "source_url": "https://www.queenstownairport.co.nz/",
+        "source_kind": "scheduled_fids",
     },
     "WLG": {
         "name": "Wellington Airport",
@@ -53,7 +67,12 @@ AIRPORTS: dict[str, dict[str, str]] = {
         "icao": "NZWN",
         "source": "wellingtonairport.co.nz",
         "source_url": "https://www.wellingtonairport.co.nz/flights/",
+        "source_kind": "scheduled_fids",
     },
+}
+
+ADSB_AIRPORTS: dict[str, dict[str, float]] = {
+    "AKL": {"lat": -37.008, "lon": 174.785, "radius_nm": 30},
 }
 
 CHC_API = "https://www.christchurchairport.nz/api/flights"
@@ -106,6 +125,35 @@ def request_json(url: str, timeout: int = 25) -> Any:
         die(f"invalid JSON from {url}: {e}")
 
 
+def request_adsb_aircraft(code: str) -> tuple[list[dict[str, Any]], str]:
+    url = adsb_url(code)
+    headers = {
+        "Accept": "application/json",
+        "User-Agent": ADSB_UA,
+    }
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=ADSB_TIMEOUT_SECONDS) as resp:
+            raw = resp.read().decode("utf-8", "replace")
+        payload = json.loads(raw) if raw else {}
+    except urllib.error.HTTPError as e:
+        return [], f"HTTP {e.code} from adsb.lol"
+    except urllib.error.URLError as e:
+        return [], f"network error calling adsb.lol: {e.reason}"
+    except json.JSONDecodeError as e:
+        return [], f"invalid JSON from adsb.lol: {e}"
+
+    if not isinstance(payload, dict):
+        return [], "unexpected adsb.lol payload shape"
+    aircraft = payload.get("ac")
+    if not isinstance(aircraft, list):
+        return [], clean(payload.get("msg"))
+    rows = [row for row in aircraft if isinstance(row, dict)]
+    if len(rows) > ADSB_MAX_AIRCRAFT:
+        return rows[:ADSB_MAX_AIRCRAFT], f"capped ADS-B aircraft at {ADSB_MAX_AIRCRAFT} of {len(rows)}"
+    return rows, ""
+
+
 def now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
 
@@ -120,6 +168,14 @@ def clean(value: Any) -> str:
     if value is None:
         return ""
     return " ".join(str(value).split())
+
+
+def numeric(value: Any) -> int | float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return value
+    return None
 
 
 def airport_code(raw: str | None) -> str | None:
@@ -243,6 +299,63 @@ def normalize_wlg(row: dict[str, Any], direction: str, day: str) -> dict[str, An
     }
 
 
+def classify_adsb_aircraft(aircraft: dict[str, Any]) -> str:
+    if aircraft.get("alt_baro") == "ground":
+        return "ground"
+    alt = numeric(aircraft.get("alt_baro"))
+    rate = numeric(aircraft.get("baro_rate")) or 0
+    if alt is None:
+        return "overhead"
+    if alt < 6000:
+        if rate < -200:
+            return "arrival"
+        if rate > 200:
+            return "departure"
+        return "arrival"
+    return "overhead"
+
+
+def normalize_adsb(row: dict[str, Any], direction: str) -> dict[str, Any]:
+    hex_value = clean(row.get("hex")).upper()
+    callsign = clean(row.get("flight")).upper().replace(" ", "") or hex_value
+    alt_baro = row.get("alt_baro")
+    altitude_ft = 0 if alt_baro == "ground" else numeric(alt_baro)
+    classification = classify_adsb_aircraft(row)
+    return {
+        "airport": "AKL",
+        "airport_name": AIRPORTS["AKL"]["name"],
+        "direction": direction,
+        "data_type": "live_adsb",
+        "flight_numbers": [callsign] if callsign else [],
+        "primary_flight": callsign,
+        "callsign": callsign,
+        "hex": hex_value,
+        "registration": clean(row.get("r")),
+        "aircraft_type": clean(row.get("t")),
+        "classification": classification,
+        "altitude_ft": altitude_ft,
+        "altitude_baro": alt_baro,
+        "distance_nm": numeric(row.get("dst")),
+        "ground_speed_kt": numeric(row.get("gs")),
+        "vertical_rate_fpm": numeric(row.get("baro_rate")),
+        "lat": numeric(row.get("lat")),
+        "lon": numeric(row.get("lon")),
+        "airline_code": carrier_from_flight(callsign),
+        "airline_name": "",
+        "origin": "",
+        "destination": "",
+        "scheduled": "",
+        "estimated": "",
+        "gate": "",
+        "status": classification,
+        "terminal": "",
+        "is_domestic": None,
+        "source": AIRPORTS["AKL"]["source"],
+        "source_url": AIRPORTS["AKL"]["source_url"],
+        "raw_adsb": row,
+    }
+
+
 def fetch_chc(direction: str) -> dict[str, Any]:
     api_direction = "Arrive" if direction == "arrivals" else "Depart"
     flights: list[dict[str, Any]] = []
@@ -301,6 +414,41 @@ def fetch_wlg(direction: str) -> dict[str, Any]:
     return board_result("WLG", direction, flights, clean(payload.get("last_updated")))
 
 
+def adsb_url(code: str) -> str:
+    meta = ADSB_AIRPORTS[code]
+    return f"https://api.adsb.lol/v2/lat/{meta['lat']}/lon/{meta['lon']}/dist/{meta['radius_nm']}"
+
+
+def fetch_adsb_akl(direction: str) -> dict[str, Any]:
+    aircraft, source_note = request_adsb_aircraft("AKL")
+    counts = {"arrival": 0, "departure": 0, "ground": 0, "overhead": 0}
+    normalized: list[dict[str, Any]] = []
+    for row in aircraft:
+        classification = classify_adsb_aircraft(row)
+        counts[classification] += 1
+        if classification == direction.rstrip("s"):
+            normalized.append(normalize_adsb(row, direction))
+    normalized.sort(
+        key=lambda flight: (
+            flight.get("distance_nm") is None,
+            flight.get("distance_nm") if flight.get("distance_nm") is not None else 999,
+        )
+    )
+    result = board_result("AKL", direction, normalized, "")
+    result.update(
+        {
+            "data_type": "live_adsb",
+            "adsb_endpoint": adsb_url("AKL"),
+            "adsb_radius_nm": ADSB_AIRPORTS["AKL"]["radius_nm"],
+            "adsb_total_aircraft": len(aircraft),
+            "classification_counts": counts,
+        }
+    )
+    if source_note:
+        result["source_note"] = source_note
+    return result
+
+
 def board_result(airport: str, direction: str, flights: list[dict[str, Any]], source_last_updated: str) -> dict[str, Any]:
     meta = AIRPORTS[airport]
     return {
@@ -309,6 +457,7 @@ def board_result(airport: str, direction: str, flights: list[dict[str, Any]], so
         "direction": direction,
         "source": meta["source"],
         "source_url": meta["source_url"],
+        "data_type": meta["source_kind"],
         "source_last_updated": source_last_updated,
         "fetched_at": now_iso(),
         "total_flights": len(flights),
@@ -317,6 +466,7 @@ def board_result(airport: str, direction: str, flights: list[dict[str, Any]], so
 
 
 FETCHERS = {
+    "AKL": fetch_adsb_akl,
     "CHC": fetch_chc,
     "ZQN": fetch_zqn,
     "WLG": fetch_wlg,
@@ -392,16 +542,11 @@ def cmd_airports(args: argparse.Namespace) -> None:
                 "icao": meta["icao"],
                 "source": meta["source"],
                 "source_url": meta["source_url"],
+                "source_kind": meta["source_kind"],
             }
             for code, meta in AIRPORTS.items()
         ],
-        "not_wired": [
-            {
-                "code": "AKL",
-                "name": "Auckland Airport",
-                "reason": "public flight board blocked direct and CDP fetches with Cloudflare in this environment",
-            }
-        ],
+        "not_wired": [],
     }
     emit_airports(data, args.json)
 
@@ -421,6 +566,8 @@ def time_label(flight: dict[str, Any]) -> str:
 
 
 def flight_line(flight: dict[str, Any]) -> str:
+    if flight.get("data_type") == "live_adsb":
+        return adsb_flight_line(flight)
     nums = "/".join(flight.get("flight_numbers") or [flight.get("primary_flight") or "-"])
     airline = flight.get("airline_name") or flight.get("airline_code") or ""
     gate = f" gate {flight['gate']}" if flight.get("gate") else ""
@@ -429,11 +576,60 @@ def flight_line(flight: dict[str, Any]) -> str:
     return f"  {time_label(flight):<28} {nums:<18} {route_label(flight)}{gate}{terminal} {airline}{status}".rstrip()
 
 
+def adsb_altitude_label(flight: dict[str, Any]) -> str:
+    if flight.get("altitude_baro") == "ground":
+        return "ground"
+    altitude = numeric(flight.get("altitude_ft"))
+    return f"{altitude:.0f} ft" if altitude is not None else "-"
+
+
+def adsb_number_label(value: Any, suffix: str, decimals: int = 0) -> str:
+    number = numeric(value)
+    if number is None:
+        return "-"
+    return f"{number:.{decimals}f} {suffix}"
+
+
+def adsb_flight_line(flight: dict[str, Any]) -> str:
+    callsign = flight.get("callsign") or flight.get("hex") or "-"
+    aircraft = flight.get("aircraft_type") or "-"
+    registration = flight.get("registration") or "-"
+    altitude = adsb_altitude_label(flight)
+    distance = adsb_number_label(flight.get("distance_nm"), "nm", 1)
+    speed = adsb_number_label(flight.get("ground_speed_kt"), "kt")
+    vertical = adsb_number_label(flight.get("vertical_rate_fpm"), "fpm")
+    return (
+        f"  {callsign:<10} {aircraft:<8} {registration:<9} "
+        f"alt {altitude:<8} dist {distance:<8} gs {speed:<7} vr {vertical}"
+    ).rstrip()
+
+
 def print_board(result: dict[str, Any]) -> None:
+    if result.get("data_type") == "live_adsb":
+        print_adsb_board(result)
+        return
     updated = f", updated {result['source_last_updated']}" if result.get("source_last_updated") else ""
     print(f"{result['airport']} {result['direction']}: {result.get('returned', len(result['flights']))} of {result['total_flights']} flights ({result['source']}{updated})")
     if not result["flights"]:
         print("  No flights currently listed.")
+        return
+    for flight in result["flights"]:
+        print(flight_line(flight))
+
+
+def print_adsb_board(result: dict[str, Any]) -> None:
+    returned = result.get("returned", len(result["flights"]))
+    total = result["total_flights"]
+    nearby = result.get("adsb_total_aircraft", 0)
+    radius = result.get("adsb_radius_nm")
+    print(
+        f"{result['airport']} {result['direction']}: {returned} of {total} classified live aircraft "
+        f"({result['source']}, {nearby} nearby within {radius:g} nm)"
+    )
+    if result.get("source_note"):
+        print(f"  Source note: {result['source_note']}")
+    if not result["flights"]:
+        print(f"  No live ADS-B aircraft currently classified as {result['direction']} near this airport.")
         return
     for flight in result["flights"]:
         print(flight_line(flight))
@@ -474,11 +670,13 @@ def emit_airports(data: dict[str, Any], as_json: bool) -> None:
         return
     print(f"Supported airports: {data['count']}")
     for airport in data["airports"]:
-        print(f"  {airport['code']}  {airport['name']} ({airport['source']})")
-    print()
-    print("Not wired:")
-    for airport in data["not_wired"]:
-        print(f"  {airport['code']}  {airport['name']} - {airport['reason']}")
+        kind = "live ADS-B aircraft positions" if airport["source_kind"] == "live_adsb" else "scheduled FIDS board"
+        print(f"  {airport['code']}  {airport['name']} ({airport['source']}; {kind})")
+    if data["not_wired"]:
+        print()
+        print("Not wired:")
+        for airport in data["not_wired"]:
+            print(f"  {airport['code']}  {airport['name']} - {airport['reason']}")
 
 
 def positive_int(raw: str) -> int:


### PR DESCRIPTION
## Summary
- Adds Auckland Airport (AKL) to the nz-airports skill using adsb.lol live ADS-B positions.
- Keeps CHC, ZQN, and WLG on their existing scheduled FIDS-style airport-board sources.
- Adds AKL classification metadata, human output, JSON raw ADS-B rows, and docs/API notes crediting Adam Holt cyclone.vaianu as the reference implementation.

## Source distinction
AKL is live aircraft-position data: aircraft broadcasting near Auckland Airport right now, classified from altitude and vertical rate. CHC/ZQN/WLG remain airline-published airport-board data with scheduled and estimated times. Both are useful, but they answer different questions.

## Live test output
```text
$ python3 skills/nz-airports/scripts/cli.py arrivals --airport AKL --limit 5
AKL arrivals: 2 of 2 classified live aircraft (adsb.lol, 4 nearby within 30 nm)
  PLC3       B429     ZK-IPJ    alt 1700 ft  dist 7.3 nm   gs 68 kt   vr 128 fpm
  MAS133     A339     9M-MNJ    alt 3700 ft  dist 16.9 nm  gs 238 kt  vr -448 fpm

$ python3 skills/nz-airports/scripts/cli.py departures --airport AKL --limit 5
AKL departures: 0 of 0 classified live aircraft (adsb.lol, 4 nearby within 30 nm)
  No live ADS-B aircraft currently classified as departures near this airport.
```

## Validation
- python3 -m py_compile skills/nz-airports/scripts/cli.py
- python3 skills/nz-airports/scripts/cli.py airports --json
- python3 skills/nz-airports/scripts/cli.py arrivals --airport AKL --limit 5
- python3 skills/nz-airports/scripts/cli.py arrivals --airport AKL --limit 5 --json
- python3 skills/nz-airports/scripts/cli.py departures --airport AKL --limit 5
- python3 skills/nz-airports/scripts/cli.py departures --airport AKL --limit 5 --json
- python3 skills/nz-airports/scripts/cli.py flight ANZ1234 --airport AKL
- python3 skills/nz-airports/scripts/cli.py arrivals/departures --airport CHC|ZQN|WLG --limit 1
- bun run validate-skill -- skills/nz-airports
