### PR TITLE
feat(nz-airports): add AKL scheduled FIDS via mobile app v5 API

### DIFF
--- a/skills/nz-airports/SKILL.md
+++ b/skills/nz-airports/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nz-airports
-description: Query live public New Zealand airport arrivals and departures data for supported airports through a lightweight read-only CLI. Use when the task involves current flight board data for Christchurch, Queenstown, or Wellington airports, or live ADS-B aircraft positions near Auckland Airport.
+description: Query live public New Zealand airport arrivals and departures data for supported airports through a lightweight read-only CLI. Use when the task involves current flight board data for Auckland, Christchurch, Queenstown, or Wellington airports, or live ADS-B aircraft positions near Auckland Airport.
 ---
 
 # NZ Airports
@@ -9,7 +9,7 @@ description: Query live public New Zealand airport arrivals and departures data 
 
 Query live arrivals and departures data for supported New Zealand airports through a small deterministic CLI with human-readable and JSON output, without browser automation or account login.
 
-CHC, ZQN, and WLG use airport/airline-published FIDS-style boards with scheduled and estimated times. AKL uses adsb.lol live ADS-B positions because Auckland Airport's public flight-board API is blocked by Cloudflare from server-side CLI fetches.
+AKL, CHC, ZQN, and WLG use airport/airline-published FIDS-style boards with scheduled and estimated times. AKL also keeps an optional adsb.lol live ADS-B aircraft-position view via `--source adsb`.
 
 ## Use this when
 
@@ -32,7 +32,7 @@ CHC, ZQN, and WLG use airport/airline-published FIDS-style boards with scheduled
 3. Use `flight <flight-number>` when the user asks about a specific flight
 4. Use `airports` to confirm currently supported airport codes
 5. Use `--json` for agent chaining, comparisons, or structured reports
-6. Mention the source type: CHC/ZQN/WLG are live public airport-board snapshots; AKL is live ADS-B aircraft-position data
+6. Mention the source type: AKL/CHC/ZQN/WLG default to live public airport-board snapshots; AKL `--source adsb` is live aircraft-position data
 
 ## CLI
 
@@ -44,15 +44,16 @@ python3 skills/nz-airports/scripts/cli.py <command> [flags]
 
 ## Commands
 
-- `arrivals [--airport AKL|CHC|ZQN|WLG] [--limit N] [--json]` - current arrivals board or AKL live ADS-B arrivals
-- `departures [--airport AKL|CHC|ZQN|WLG] [--limit N] [--json]` - current departures board or AKL live ADS-B departures
-- `flight <flight-number> [--airport AKL|CHC|ZQN|WLG] [--json]` - lookup a flight number across current boards, or current AKL ADS-B callsigns
+- `arrivals [--airport AKL|CHC|ZQN|WLG] [--source fids|adsb] [--limit N] [--json]` - current arrivals board; `--source adsb` is AKL-only
+- `departures [--airport AKL|CHC|ZQN|WLG] [--source fids|adsb] [--limit N] [--json]` - current departures board; `--source adsb` is AKL-only
+- `flight <flight-number> [--airport AKL|CHC|ZQN|WLG] [--source fids|adsb] [--json]` - lookup a flight number across current boards, or current AKL ADS-B callsigns
 - `airports [--json]` - list supported airports and investigated gaps
 
 ## Examples
 
 ```bash
 python3 skills/nz-airports/scripts/cli.py arrivals --airport AKL --limit 5
+python3 skills/nz-airports/scripts/cli.py arrivals --airport AKL --source adsb --limit 5
 python3 skills/nz-airports/scripts/cli.py arrivals --airport CHC --limit 10
 python3 skills/nz-airports/scripts/cli.py departures --airport ZQN --limit 10 --json
 python3 skills/nz-airports/scripts/cli.py arrivals --airport WLG --json
@@ -63,14 +64,15 @@ python3 skills/nz-airports/scripts/cli.py airports
 ## Notes
 
 - Supported sources: Auckland (AKL), Christchurch (CHC), Queenstown (ZQN), and Wellington (WLG)
-- AKL is a live ADS-B view from adsb.lol, not an airline-published schedule board. It shows aircraft actually broadcasting near Auckland Airport right now and classifies low-altitude traffic as arrivals or departures from altitude and vertical-rate signals.
+- AKL defaults to Auckland Airport's scheduled FIDS API from the mobile app v5 backend. It exposes airline-published scheduled/estimated times, gates, terminals, baggage carousel, and status text where available.
+- AKL `--source adsb` is a live ADS-B view from adsb.lol. It shows aircraft actually broadcasting near Auckland Airport right now and classifies low-altitude traffic as arrivals or departures from altitude and vertical-rate signals.
 - CHC, ZQN, and WLG are scheduled FIDS-style airport boards. They expose airline-published scheduled/estimated times, gates, terminals, and status text where available.
-- AKL and CHC/ZQN/WLG answer different questions: AKL is best for "what aircraft are physically near AKL now?", while the FIDS sources are best for "what does the airport board say is scheduled or estimated?"
 - Christchurch uses public JSON endpoints split by domestic/international and arrivals/departures
 - Queenstown uses public JSON endpoints for arrivals and departures; the CLI filters to today's NZ board when possible
 - Wellington embeds the current flight-board JSON in the public flight page; departures can be empty late in the local operating day
-- Auckland Airport's official public flight-board surface was investigated, but direct fetches and CloakBrowser/CDP attempts returned Cloudflare challenge/block pages from this environment. AKL support therefore uses the adsb.lol community ADS-B feed.
-- No API key, username, password, account cookie, browser session, or write action is required
+- Auckland Airport's public website flight-board surface was investigated, but direct fetches and CloakBrowser/CDP attempts returned Cloudflare challenge/block pages from this environment. The mobile app v5 FIDS API is reachable directly.
+- AKL FIDS uses public app Basic auth embedded in the Auckland Airport Android APK. The CLI ships those public app defaults and allows override with `AKL_API_USERNAME` / `AKL_API_PASSWORD` if they rotate.
+- No personal API key, account cookie, browser session, or write action is required
 - Endpoint shapes can change without notice because these are unofficial public website surfaces
 - API and stability notes: `references/api-notes.md`
 - CLI entrypoint: `scripts/cli.py`

--- a/skills/nz-airports/references/api-notes.md
+++ b/skills/nz-airports/references/api-notes.md
@@ -4,20 +4,68 @@ This skill is an unofficial lightweight wrapper around public airport flight-boa
 
 ## Source and auth
 
-No username, password, API key, private token, cookie, or browser session is required for the implemented commands.
+No personal username, password, API key, private token, cookie, or browser session is required for the implemented commands.
+
+AKL FIDS uses Auckland Airport mobile app v5 Basic auth. The default credentials are the public app credentials embedded in the Auckland Airport Android APK v8.2.2, not a user credential. They can be overridden with:
+
+- `AKL_API_USERNAME`
+- `AKL_API_PASSWORD`
 
 Implemented airports:
 
-- Auckland (AKL): `https://api.adsb.lol`
+- Auckland (AKL) scheduled FIDS default: `https://h2g.aucklandairport.co.nz`
+- Auckland (AKL) live ADS-B optional source: `https://api.adsb.lol`
 - Christchurch (CHC): `https://www.christchurchairport.nz`
 - Queenstown (ZQN): `https://www.queenstownairport.co.nz`
 - Wellington (WLG): `https://www.wellingtonairport.co.nz`
 
 Investigated with alternate implementation:
 
-- Auckland Airport's official flight-board API and pages, including `https://www.prod.aucklandairport.co.nz/flights`, `https://corporate.aucklandairport.co.nz/content/aial-traveller/nz/en/flights.html`, and `https://www.aucklandairport.co.nz/content/aial/api/v1/flights`, returned Cloudflare challenge/block pages from direct CLI fetches. CloakBrowser CDP navigation also returned a Cloudflare 403 block in this environment. AKL is therefore implemented with live ADS-B positions from adsb.lol instead of scheduled airport-board data.
+- Auckland Airport's public website flight-board API and pages, including `https://www.prod.aucklandairport.co.nz/flights`, `https://corporate.aucklandairport.co.nz/content/aial-traveller/nz/en/flights.html`, and `https://www.aucklandairport.co.nz/content/aial/api/v1/flights`, returned Cloudflare challenge/block pages from direct CLI fetches. CloakBrowser CDP navigation also returned a Cloudflare 403 block in this environment. AKL scheduled data is therefore implemented through the mobile app v5 FIDS API instead.
 
 ## Endpoint families used
+
+### Auckland Airport scheduled FIDS via mobile app v5 API
+
+Base endpoint:
+
+```text
+GET https://h2g.aucklandairport.co.nz/api/{arrivals|departures}?range={domestic|international}&date={YYYY-MM-DD}
+```
+
+The CLI calls all four combinations for today's `Pacific/Auckland` date:
+
+- `arrivals?range=domestic`
+- `arrivals?range=international`
+- `departures?range=domestic`
+- `departures?range=international`
+
+Auth and headers:
+
+- HTTP Basic auth with public mobile-app credentials embedded in the APK.
+- Defaults can be overridden with `AKL_API_USERNAME` and `AKL_API_PASSWORD`.
+- `Content-Type: application/vnd.api+json`
+- `App-Version: android|8.2.2`
+
+Response shape:
+
+- top-level `data[]`
+- each row has `type`, `id`, and `attributes`
+- `attributes` includes `range`, `iataCode`, `origin`, `destination`, `codeshares`, `time`, `state`
+- departures include `checkin.zone`, `checkin.status`, `boarding.gate`, `boarding.status`
+- arrivals include `landing.baggageNumber`, `landing.status`
+
+Normalized AKL FIDS fields include:
+
+- `flight_id`
+- `flight_numbers[]`, including codeshares
+- `primary_flight`, `airline_code`
+- `origin`, `origin_airport_code`, `destination`, `destination_airport_code`
+- `scheduled`, `estimated`, `actual` formatted in `Pacific/Auckland`
+- `scheduled_utc`, `estimated_utc`, `actual_utc`
+- `gate`, `checkin_zone`, `checkin_status`, `boarding_status`
+- `baggage_carousel`, `landing_status`
+- `status`, `status_code`, `terminal`, `is_domestic`
 
 ### Auckland Airport via adsb.lol live ADS-B
 
@@ -56,7 +104,7 @@ Classification logic:
 - `alt_baro < 6000` with no strong climb/descent -> `arrival`, because low and level traffic near the field is likely on final approach
 - `alt_baro >= 6000`, missing altitude, or otherwise unclassified high traffic -> `overhead`
 
-The `arrivals --airport AKL` and `departures --airport AKL` commands return aircraft classified as `arrival` or `departure` respectively. Ground and overhead aircraft are counted in JSON metadata but are not returned by those board commands.
+The `arrivals --airport AKL --source adsb` and `departures --airport AKL --source adsb` commands return aircraft classified as `arrival` or `departure` respectively. Ground and overhead aircraft are counted in JSON metadata but are not returned by those board commands.
 
 Normalized AKL fields include:
 
@@ -70,7 +118,7 @@ Normalized AKL fields include:
 - `lat`, `lon`
 - `raw_adsb` with the returned ADS-B row for JSON consumers
 
-AKL is live aircraft-position data, not a scheduled FIDS board. It answers "which aircraft are physically near Auckland Airport now?" rather than "what has the airline published on the airport board?"
+AKL `--source adsb` is live aircraft-position data, not a scheduled FIDS board. It answers "which aircraft are physically near Auckland Airport now?" rather than "what has the airline published on the airport board?"
 
 ### Christchurch Airport
 
@@ -133,7 +181,7 @@ The board can legitimately be empty for departures late in the local operating d
 
 ## Normalized CLI schema
 
-Each normalized CHC/ZQN/WLG scheduled-board flight includes:
+Each normalized AKL/CHC/ZQN/WLG scheduled-board flight includes:
 
 - `airport`, `airport_name`, `direction`
 - `flight_numbers[]`, `primary_flight`
@@ -143,14 +191,15 @@ Each normalized CHC/ZQN/WLG scheduled-board flight includes:
 - `gate`, `status`, `terminal`, `is_domestic`
 - `source`, `source_url`
 
-Some fields are source-dependent. Queenstown does not expose gate or airline name in the JSON endpoint. Wellington exposes one flight number per row in the embedded board. Christchurch exposes codeshare flight numbers and airline branding image URLs, but the CLI does not emit image URLs in the normalized record.
+Some fields are source-dependent. Auckland exposes check-in zone, boarding gate, baggage carousel, and codeshares through the mobile app API. Queenstown does not expose gate or airline name in the JSON endpoint. Wellington exposes one flight number per row in the embedded board. Christchurch exposes codeshare flight numbers and airline branding image URLs, but the CLI does not emit image URLs in the normalized record.
 
 AKL ADS-B rows use a different live-position schema. They include callsign, aircraft type, registration, altitude, distance from the airport query point, ground speed, vertical rate, location, classification, and `raw_adsb`. They do not include scheduled/estimated board times, gate, terminal, airline-published status text, origin, or destination.
 
 ## Stability and safety
 
 - Treat CHC/ZQN/WLG results as live public-board snapshots, not historical data.
-- Treat AKL results as live ADS-B aircraft-position snapshots, not a scheduled airport board.
+- Treat default AKL results as live public-board snapshots.
+- Treat AKL `--source adsb` results as live ADS-B aircraft-position snapshots, not a scheduled airport board.
 - Always prefer narrow commands and small limits for routine checks.
 - Do not use this skill for booking, check-in, account, payment, passenger, baggage ownership, or mutation workflows.
 - Endpoint shapes can change without notice because these are public website implementation details rather than official public APIs.

--- a/skills/nz-airports/scripts/cli.py
+++ b/skills/nz-airports/scripts/cli.py
@@ -7,6 +7,7 @@ No login, booking, PNR lookup, browser automation, or third-party dependencies.
 from __future__ import annotations
 
 import argparse
+import base64
 import html
 import json
 import os
@@ -38,9 +39,9 @@ AIRPORTS: dict[str, dict[str, str]] = {
         "city": "Auckland",
         "iata": "AKL",
         "icao": "NZAA",
-        "source": "adsb.lol",
-        "source_url": "https://api.adsb.lol/v2/lat/-37.008/lon/174.785/dist/30",
-        "source_kind": "live_adsb",
+        "source": "h2g.aucklandairport.co.nz",
+        "source_url": "https://h2g.aucklandairport.co.nz/api/",
+        "source_kind": "scheduled_fids",
     },
     "CHC": {
         "name": "Christchurch Airport",
@@ -78,6 +79,11 @@ ADSB_AIRPORTS: dict[str, dict[str, float]] = {
 CHC_API = "https://www.christchurchairport.nz/api/flights"
 ZQN_API = "https://www.queenstownairport.co.nz/api/flights"
 WLG_FLIGHTS = "https://www.wellingtonairport.co.nz/flights/"
+AKL_FIDS_API = "https://h2g.aucklandairport.co.nz/api"
+AKL_FIDS_USERNAME = os.environ.get("AKL_API_USERNAME", "app-v5")
+AKL_FIDS_PASSWORD = os.environ.get("AKL_API_PASSWORD", "AWLyxd6{zxGsVg?coY")
+AKL_FIDS_APP_VERSION = "android|8.2.2"
+AKL_ADSB_SOURCE = "adsb.lol"
 
 
 def die(message: str, code: int = 1) -> None:
@@ -118,6 +124,42 @@ def request_json(url: str, timeout: int = 25) -> Any:
     except urllib.error.HTTPError as e:
         raw = e.read().decode("utf-8", "replace")
         detail = raw[:300].replace("\n", " ")
+        die(f"HTTP {e.code} from {url}: {detail}")
+    except urllib.error.URLError as e:
+        die(f"network error calling {url}: {e.reason}")
+    except json.JSONDecodeError as e:
+        die(f"invalid JSON from {url}: {e}")
+
+
+def akl_fids_auth_header() -> str:
+    if not AKL_FIDS_USERNAME or not AKL_FIDS_PASSWORD:
+        die("AKL FIDS requires AKL_API_USERNAME and AKL_API_PASSWORD")
+    token = base64.b64encode(f"{AKL_FIDS_USERNAME}:{AKL_FIDS_PASSWORD}".encode("utf-8")).decode("ascii")
+    return f"Basic {token}"
+
+
+def request_akl_fids_json(endpoint: str, params: dict[str, str], timeout: int = 25) -> Any:
+    url = f"{AKL_FIDS_API}/{endpoint}?" + urllib.parse.urlencode(params)
+    headers = {
+        "Accept": "application/json, text/plain, */*",
+        "App-Version": AKL_FIDS_APP_VERSION,
+        "Authorization": akl_fids_auth_header(),
+        "Content-Type": "application/vnd.api+json",
+        "User-Agent": UA,
+    }
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", "replace")
+            return json.loads(raw) if raw else None
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8", "replace")
+        detail = raw[:300].replace("\n", " ")
+        if e.code in (401, 403):
+            die(
+                f"HTTP {e.code} from Auckland Airport FIDS API; "
+                "set AKL_API_USERNAME/AKL_API_PASSWORD if the public app credentials have rotated"
+            )
         die(f"HTTP {e.code} from {url}: {detail}")
     except urllib.error.URLError as e:
         die(f"network error calling {url}: {e.reason}")
@@ -170,6 +212,15 @@ def clean(value: Any) -> str:
     return " ".join(str(value).split())
 
 
+def dig(data: Any, *path: str) -> Any:
+    current = data
+    for key in path:
+        if not isinstance(current, dict):
+            return None
+        current = current.get(key)
+    return current
+
+
 def numeric(value: Any) -> int | float | None:
     if isinstance(value, bool):
         return None
@@ -209,10 +260,83 @@ def carrier_from_flight(number: str) -> str:
     return match.group(1) if match else ""
 
 
+def format_nz_time(value: Any) -> str:
+    text = clean(value)
+    if not text:
+        return ""
+    try:
+        dt = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return text
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    if ZoneInfo is not None:
+        dt = dt.astimezone(ZoneInfo("Pacific/Auckland"))
+    return dt.strftime("%Y-%m-%d %H:%M")
+
+
 def combine_date_time(date_value: str, time_value: str) -> str:
     if not date_value or not time_value:
         return clean(time_value or date_value)
     return f"{date_value} {time_value}"
+
+
+def akl_codeshares(values: Any) -> list[str]:
+    out: list[str] = []
+    if not isinstance(values, list):
+        return out
+    for item in values:
+        value = item[0] if isinstance(item, list) and item else item
+        number = clean(value).upper().replace(" ", "")
+        if number:
+            out.append(number)
+    return out
+
+
+def normalize_akl_fids(row: dict[str, Any], direction: str) -> dict[str, Any]:
+    attrs = row.get("attributes") if isinstance(row.get("attributes"), dict) else {}
+    iata_code = attrs.get("iataCode")
+    primary = clean((iata_code or [""])[0] if isinstance(iata_code, list) else iata_code).upper().replace(" ", "")
+    numbers = flight_numbers([primary, *akl_codeshares(attrs.get("codeshares"))])
+    scheduled_utc = clean(dig(attrs, "time", "scheduled"))
+    estimated_utc = clean(dig(attrs, "time", "estimated"))
+    actual_utc = clean(dig(attrs, "time", "actual"))
+    range_name = clean(attrs.get("range"))
+    is_arrival = direction == "arrivals"
+    status = "Cancelled" if dig(attrs, "state", "cancelled") else clean(dig(attrs, "time", "status"))
+    baggage = clean(dig(attrs, "landing", "baggageNumber")) if is_arrival else ""
+    return {
+        "airport": "AKL",
+        "airport_name": AIRPORTS["AKL"]["name"],
+        "direction": direction,
+        "flight_id": clean(row.get("id")),
+        "flight_numbers": numbers,
+        "primary_flight": numbers[0] if numbers else primary,
+        "airline_code": carrier_from_flight(numbers[0]) if numbers else carrier_from_flight(primary),
+        "airline_name": "",
+        "origin": clean(dig(attrs, "origin", "city")),
+        "origin_airport_code": clean(dig(attrs, "origin", "airportCode")),
+        "destination": clean(dig(attrs, "destination", "city")),
+        "destination_airport_code": clean(dig(attrs, "destination", "airportCode")),
+        "scheduled": format_nz_time(scheduled_utc),
+        "estimated": format_nz_time(estimated_utc),
+        "actual": format_nz_time(actual_utc),
+        "scheduled_utc": scheduled_utc,
+        "estimated_utc": estimated_utc,
+        "actual_utc": actual_utc,
+        "gate": clean(dig(attrs, "boarding", "gate")) if not is_arrival else "",
+        "checkin_zone": clean(dig(attrs, "checkin", "zone")) if not is_arrival else "",
+        "checkin_status": clean(dig(attrs, "checkin", "status")) if not is_arrival else "",
+        "boarding_status": clean(dig(attrs, "boarding", "status")) if not is_arrival else "",
+        "baggage_carousel": baggage,
+        "landing_status": clean(dig(attrs, "landing", "status")) if is_arrival else "",
+        "status": status,
+        "status_code": clean(dig(attrs, "time", "statusCode")),
+        "terminal": range_name,
+        "is_domestic": range_name == "domestic",
+        "source": AIRPORTS["AKL"]["source"],
+        "source_url": AIRPORTS["AKL"]["source_url"],
+    }
 
 
 def normalize_chc(row: dict[str, Any], direction: str, flight_type: str) -> dict[str, Any]:
@@ -350,10 +474,40 @@ def normalize_adsb(row: dict[str, Any], direction: str) -> dict[str, Any]:
         "status": classification,
         "terminal": "",
         "is_domestic": None,
-        "source": AIRPORTS["AKL"]["source"],
-        "source_url": AIRPORTS["AKL"]["source_url"],
+        "source": AKL_ADSB_SOURCE,
+        "source_url": adsb_url("AKL"),
         "raw_adsb": row,
     }
+
+
+def fetch_akl_fids(direction: str) -> dict[str, Any]:
+    endpoint = "arrivals" if direction == "arrivals" else "departures"
+    flights: list[dict[str, Any]] = []
+    for range_name in ("domestic", "international"):
+        payload = request_akl_fids_json(
+            endpoint,
+            {
+                "range": range_name,
+                "date": nz_today(),
+            },
+        )
+        if not isinstance(payload, dict) or not isinstance(payload.get("data"), list):
+            die(f"unexpected Auckland Airport FIDS payload from {AKL_FIDS_API}/{endpoint}")
+        flights.extend(
+            normalize_akl_fids(row, direction)
+            for row in payload["data"]
+            if isinstance(row, dict)
+        )
+    flights.sort(
+        key=lambda flight: (
+            flight.get("scheduled_utc") or flight.get("scheduled") or "",
+            flight.get("primary_flight") or "",
+        )
+    )
+    result = board_result("AKL", direction, flights, "")
+    result["board_date"] = nz_today()
+    result["fids_endpoint"] = f"{AKL_FIDS_API}/{endpoint}"
+    return result
 
 
 def fetch_chc(direction: str) -> dict[str, Any]:
@@ -438,6 +592,8 @@ def fetch_adsb_akl(direction: str) -> dict[str, Any]:
     result.update(
         {
             "data_type": "live_adsb",
+            "source": AKL_ADSB_SOURCE,
+            "source_url": adsb_url("AKL"),
             "adsb_endpoint": adsb_url("AKL"),
             "adsb_radius_nm": ADSB_AIRPORTS["AKL"]["radius_nm"],
             "adsb_total_aircraft": len(aircraft),
@@ -466,14 +622,18 @@ def board_result(airport: str, direction: str, flights: list[dict[str, Any]], so
 
 
 FETCHERS = {
-    "AKL": fetch_adsb_akl,
+    "AKL": fetch_akl_fids,
     "CHC": fetch_chc,
     "ZQN": fetch_zqn,
     "WLG": fetch_wlg,
 }
 
 
-def fetch_board(code: str, direction: str) -> dict[str, Any]:
+def fetch_board(code: str, direction: str, source: str | None = None) -> dict[str, Any]:
+    if source == "adsb":
+        if code != "AKL":
+            die("--source adsb is only supported with --airport AKL")
+        return fetch_adsb_akl(direction)
     return FETCHERS[code](direction)
 
 
@@ -491,7 +651,8 @@ def selected_airports(raw: str | None) -> list[str]:
 
 
 def cmd_board(args: argparse.Namespace, direction: str) -> None:
-    results = [limited_board(fetch_board(code, direction), args.limit) for code in selected_airports(args.airport)]
+    validate_source_args(args)
+    results = [limited_board(fetch_board(code, direction, args.source), args.limit) for code in selected_airports(args.airport)]
     if args.airport:
         emit_board(results[0], args.json)
     else:
@@ -512,11 +673,12 @@ def cmd_departures(args: argparse.Namespace) -> None:
 
 
 def cmd_flight(args: argparse.Namespace) -> None:
+    validate_source_args(args)
     needle = args.flight_number.upper().replace(" ", "")
     matches: list[dict[str, Any]] = []
     for code in selected_airports(args.airport):
         for direction in ("arrivals", "departures"):
-            result = fetch_board(code, direction)
+            result = fetch_board(code, direction, args.source)
             for flight in result["flights"]:
                 if needle in flight.get("flight_numbers", []):
                     matches.append(flight)
@@ -571,9 +733,10 @@ def flight_line(flight: dict[str, Any]) -> str:
     nums = "/".join(flight.get("flight_numbers") or [flight.get("primary_flight") or "-"])
     airline = flight.get("airline_name") or flight.get("airline_code") or ""
     gate = f" gate {flight['gate']}" if flight.get("gate") else ""
+    baggage = f" bag {flight['baggage_carousel']}" if flight.get("baggage_carousel") else ""
     terminal = f" {flight['terminal']}" if flight.get("terminal") else ""
     status = f" - {flight['status']}" if flight.get("status") else ""
-    return f"  {time_label(flight):<28} {nums:<18} {route_label(flight)}{gate}{terminal} {airline}{status}".rstrip()
+    return f"  {time_label(flight):<28} {nums:<18} {route_label(flight)}{gate}{baggage}{terminal} {airline}{status}".rstrip()
 
 
 def adsb_altitude_label(flight: dict[str, Any]) -> str:
@@ -671,7 +834,8 @@ def emit_airports(data: dict[str, Any], as_json: bool) -> None:
     print(f"Supported airports: {data['count']}")
     for airport in data["airports"]:
         kind = "live ADS-B aircraft positions" if airport["source_kind"] == "live_adsb" else "scheduled FIDS board"
-        print(f"  {airport['code']}  {airport['name']} ({airport['source']}; {kind})")
+        extra = "; ADS-B available with --source adsb" if airport["code"] == "AKL" else ""
+        print(f"  {airport['code']}  {airport['name']} ({airport['source']}; {kind}{extra})")
     if data["not_wired"]:
         print()
         print("Not wired:")
@@ -689,9 +853,21 @@ def positive_int(raw: str) -> int:
     return value
 
 
+def validate_source_args(args: argparse.Namespace) -> None:
+    source = getattr(args, "source", None)
+    if source == "adsb" and airport_code(args.airport) != "AKL":
+        die("--source adsb requires --airport AKL")
+
+
 def add_board_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--airport", choices=sorted(AIRPORTS), help="airport code; defaults to all supported airports")
     parser.add_argument("--limit", type=positive_int, default=20, help="max flights to show per airport (default 20)")
+    parser.add_argument(
+        "--source",
+        choices=["fids", "adsb"],
+        default="fids",
+        help="AKL source: scheduled FIDS by default, or live ADS-B with --source adsb",
+    )
     parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
 
 
@@ -710,6 +886,12 @@ def build_parser() -> argparse.ArgumentParser:
     sp = sub.add_parser("flight", help="lookup a flight number across current boards")
     sp.add_argument("flight_number", help="flight number, e.g. NZ5640")
     sp.add_argument("--airport", choices=sorted(AIRPORTS), help="airport code; defaults to all supported airports")
+    sp.add_argument(
+        "--source",
+        choices=["fids", "adsb"],
+        default="fids",
+        help="AKL source: scheduled FIDS by default, or live ADS-B with --source adsb",
+    )
     sp.add_argument("--json", action="store_true", help="emit machine-readable JSON")
     sp.set_defaults(func=cmd_flight)
 


### PR DESCRIPTION
## Summary
- adds Auckland Airport scheduled FIDS as the default AKL arrivals/departures source
- keeps the existing AKL adsb.lol live aircraft view behind --source adsb
- documents the mobile app v5 endpoint, public app Basic auth defaults, and env overrides

## Validation
- python3 -m py_compile skills/nz-airports/scripts/cli.py
- python3 skills/nz-airports/scripts/cli.py arrivals --airport AKL --limit 10
- python3 skills/nz-airports/scripts/cli.py arrivals --airport AKL --limit 3 --json
- python3 skills/nz-airports/scripts/cli.py departures --airport AKL --limit 10
- python3 skills/nz-airports/scripts/cli.py flight NZ1 --airport AKL
- python3 skills/nz-airports/scripts/cli.py arrivals --airport AKL --source adsb --limit 5
- python3 skills/nz-airports/scripts/cli.py arrivals --airport CHC --limit 3
- python3 skills/nz-airports/scripts/cli.py departures --airport ZQN --limit 3
- python3 skills/nz-airports/scripts/cli.py arrivals --airport WLG --limit 3