### PR TITLE
feat(nz-council): add Rotorua recreation facilities

### DIFF
--- a/skills/nz-council/SKILL.md
+++ b/skills/nz-council/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nz-council
-description: Query NZ council-area event listings and public recreation facilities through a lightweight read-only CLI. Use for Auckland, Wellington, or Christchurch what's-on events, Eventfinda council-area events, Auckland Council pools/leisure centres, Wellington pools/recreation centres, pool hours, and public lane availability snapshots. Not for rates, consents, rubbish, recycling, parking fines, bookings, logins, or payments.
+description: Query NZ council-area event listings and public recreation facilities through a lightweight read-only CLI. Use for Auckland, Wellington, Christchurch, or Rotorua what's-on events, Eventfinda council-area events, Auckland Council pools/leisure centres, Wellington pools/recreation centres, Rotorua Lakes pools and aquatic facilities, pool hours, and public lane availability snapshots. Not for rates, consents, rubbish, recycling, parking fines, bookings, logins, or payments.
 ---
 
 # NZ Council
@@ -16,7 +16,7 @@ This v1 is deliberately narrow. It is not a general council-services skill.
 
 ## Use this when
 
-- The user asks what is on in Auckland, Wellington, Christchurch, or across NZ council areas.
+- The user asks what is on in Auckland, Wellington, Christchurch, Rotorua, or across NZ council areas.
 - The user asks for council-listed concerts, markets, exhibitions, kids' activities, festivals, or free events.
 - The user asks for public pools, leisure centres, gyms, recreation centres, hours, or pool lane availability.
 - You need a quick JSON feed for council-area events or recreation facility listings without browser automation.
@@ -35,7 +35,8 @@ This v1 is deliberately narrow. It is not a general council-services skill.
 3. Use `pools --council akl --json` for Auckland pool lists with parsed hours.
 4. Use `pool "Tepid Baths" --json` for a single Auckland pool, including public lane availability when Auckland Leisure exposes it.
 5. Use Wellington recreation commands for basic Wellington pool/recreation-centre listings; open linked WCC pages if exact opening times are needed.
-6. Treat Christchurch recreation as discovered but not fully wired in v1; the public council page is protected/vendor-backed.
+6. Use `pools --council rot --json` or `pool "Rotorua Aquatic" --json` for Rotorua Lakes aquatic facilities.
+7. Treat Christchurch recreation as discovered but not fully wired in v1; the public council page is protected/vendor-backed.
 
 ## CLI
 
@@ -50,12 +51,12 @@ Every data command supports `--json`.
 ## Commands
 
 ```bash
-python3 skills/nz-council/scripts/cli.py events [--council akl|wlg|chc] [--from DATE] [--to DATE] [--category SLUG] [--free] [--limit N] [--json]
+python3 skills/nz-council/scripts/cli.py events [--council akl|wlg|chc|rot] [--from DATE] [--to DATE] [--category SLUG] [--free] [--limit N] [--json]
 python3 skills/nz-council/scripts/cli.py event <id-or-url> [--json]
 
-python3 skills/nz-council/scripts/cli.py pools [--council akl|wlg|chc] [--region central|east|north|south|west] [--limit N] [--json]
-python3 skills/nz-council/scripts/cli.py pool <name> [--council akl|wlg|chc] [--json]
-python3 skills/nz-council/scripts/cli.py facilities [--council akl|wlg|chc] [--type pool|gym|leisure-centre|library] [--region central|east|north|south|west] [--limit N] [--json]
+python3 skills/nz-council/scripts/cli.py pools [--council akl|wlg|chc|rot] [--region central|east|north|south|west] [--limit N] [--json]
+python3 skills/nz-council/scripts/cli.py pool <name> [--council akl|wlg|chc|rot] [--json]
+python3 skills/nz-council/scripts/cli.py facilities [--council akl|wlg|chc|rot] [--type pool|gym|leisure-centre|library] [--region central|east|north|south|west] [--limit N] [--json]
 ```
 
 ## Examples
@@ -68,6 +69,8 @@ python3 skills/nz-council/scripts/cli.py event /2026/some-event/auckland --json
 python3 skills/nz-council/scripts/cli.py pools --council akl --region central --json
 python3 skills/nz-council/scripts/cli.py pool "Tepid Baths" --json
 python3 skills/nz-council/scripts/cli.py facilities --council wlg --type pool --json
+python3 skills/nz-council/scripts/cli.py pools --council rot --json
+python3 skills/nz-council/scripts/cli.py pool "Rotorua Aquatic" --json
 ```
 
 ## Resources
@@ -83,4 +86,5 @@ python3 skills/nz-council/scripts/cli.py facilities --council wlg --type pool --
 - Christchurch City Council's direct events page was protected by an Incapsula challenge during discovery, so Christchurch event queries use Eventfinda public pages.
 - Auckland pools and leisure facilities use `aucklandleisure.co.nz` public location pages and the public Auckland Leisure portal resource-availability page when present.
 - Wellington pools and recreation centres use public `wellington.govt.nz` listing pages.
+- Rotorua Lakes pools and aquatic facilities use public `rotorualakescouncil.nz` recreation and park pages plus the CLM Rotorua Aquatic Centre operator pages.
 - Christchurch recreation and sport pages were observed at `recandsport.ccc.govt.nz`, but the useful dynamic data is vendor-backed and is documented rather than wired in v1.

--- a/skills/nz-council/references/api-notes.md
+++ b/skills/nz-council/references/api-notes.md
@@ -171,6 +171,49 @@ Schema parsed:
 
 Freshness: live static listing page. Opening hours remain on linked detail pages in v1.
 
+### Rotorua Lakes pools and aquatic facilities
+
+Implemented as a static public facility source, based on Rotorua Lakes Council recreation and park pages plus the Rotorua Aquatic Centre operator site.
+
+- Rotorua Lakes recreation entry: `https://www.rotorualakescouncil.nz/parks-lakes-recreation`
+- Rotorua Aquatic Centre council page: `https://www.rotorualakescouncil.nz/parks-lakes-recreation/recreational-venues/aquatic-centre`
+- Rotorua Aquatic Centre operator pages:
+  - `https://www.clmnz.co.nz/rotorua-aquatic-centre/`
+  - `https://www.clmnz.co.nz/rotorua-aquatic-centre/pools/`
+  - `https://www.clmnz.co.nz/rotorua-aquatic-centre/contact/`
+- Direct checks of `rotoruaaquaticcentre.co.nz` and `www.rotoruaaquaticcentre.co.nz` did not resolve during discovery; the council page links to the CLM operator path above.
+- Butcher's Pool council page: `https://www.rotorualakescouncil.nz/parks-lakes-recreation/park-reserves/butchers-pool`
+- Kuirau Park council page: `https://www.rotorualakescouncil.nz/parks-lakes-recreation/park-reserves/kuirau-park`
+- Council OIA cross-check: `https://www.rotorualakescouncil.nz/our-council/officialinformation/official-information-requests?item=id%3A2qgeujsul17q9sfg7ls7`
+
+Observed facilities:
+
+- Rotorua Aquatic Centre
+- Butcher's Pool
+- Kuirau Park foot pools and paddling pool
+
+Rotorua Aquatic Centre fields are sourced from the council page and CLM operator pages:
+
+```json
+{
+  "name": "Rotorua Aquatic Centre",
+  "id": "rotorua-aquatic-centre",
+  "type": "pool",
+  "council": "rot",
+  "source": "rotorua-lakes-council",
+  "address": "Kuirau Park, 18 Tarewa Rd, Rotorua 3010",
+  "operator": "Community Leisure Management (CLM)",
+  "hours_summary": "Monday - Sunday: 6:00am - 9:00pm",
+  "features": ["Outdoor 50m heated pool", "Indoor 25m heated pool", "Indoor learner pool", "Gym"]
+}
+```
+
+Butcher's Pool is listed separately because the public park-reserve page describes it as a free hot mineral pool and says Rotorua Lakes Council manages the changing rooms and toilets. The CLI includes the linked safety notes that the pool is unsupervised and users should keep their head above water.
+
+Kuirau Park is included as a public council-managed park water facility because the council page lists foot pools and a paddling pool among park facilities. It is not treated as a lane-swimming pool.
+
+Freshness: static source records derived from public pages. Rotorua Aquatic Centre's CLM pages expose current lane availability links through Perfect Gym-backed pages; v1 links those pages but does not scrape the dynamic availability payload.
+
 ### Christchurch recreation and sport
 
 Discovered, documented, not wired in v1.

--- a/skills/nz-council/scripts/cli.py
+++ b/skills/nz-council/scripts/cli.py
@@ -24,6 +24,8 @@ EVENTFINDA_BASE = "https://www.eventfinda.co.nz"
 AKL_LEISURE_BASE = "https://www.aucklandleisure.co.nz"
 AKL_LOCATION_ENDPOINT = AKL_LEISURE_BASE + "/umbraco/surface/LocationListing/RenderLocationListing"
 WLG_BASE = "https://wellington.govt.nz"
+ROT_BASE = "https://www.rotorualakescouncil.nz"
+ROT_AQUATIC_BASE = "https://www.clmnz.co.nz/rotorua-aquatic-centre"
 
 UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146 Safari/537.36"
 
@@ -31,12 +33,14 @@ COUNCIL_LOCATIONS = {
     "akl": "auckland",
     "wlg": "wellington",
     "chc": "christchurch",
+    "rot": "rotorua",
 }
 
 COUNCIL_NAMES = {
     "akl": "Auckland",
     "wlg": "Wellington",
     "chc": "Christchurch",
+    "rot": "Rotorua Lakes",
 }
 
 AKL_AREA_IDS = {
@@ -51,6 +55,102 @@ AKL_FACILITY_IDS = {
     "pool": "1126",
     "gym": "1119",
 }
+
+ROT_RECREATION_SOURCE_URL = ROT_BASE + "/parks-lakes-recreation"
+ROT_PARK_RESERVES_SOURCE_URL = ROT_BASE + "/parks-lakes-recreation/park-reserves"
+ROT_FACILITIES: list[dict[str, Any]] = [
+    {
+        "name": "Rotorua Aquatic Centre",
+        "id": "rotorua-aquatic-centre",
+        "type": "pool",
+        "facility_types": ["pool", "gym", "leisure-centre"],
+        "council": "rot",
+        "council_name": "Rotorua Lakes",
+        "source": "rotorua-lakes-council",
+        "source_url": ROT_BASE + "/parks-lakes-recreation/recreational-venues/aquatic-centre",
+        "operator_source_url": ROT_AQUATIC_BASE + "/",
+        "pools_source_url": ROT_AQUATIC_BASE + "/pools/",
+        "contact_source_url": ROT_AQUATIC_BASE + "/contact/",
+        "listing_source_url": ROT_RECREATION_SOURCE_URL,
+        "address": "Kuirau Park, 18 Tarewa Rd, Rotorua 3010",
+        "operator": "Community Leisure Management (CLM)",
+        "status": None,
+        "description": (
+            "Main Rotorua aquatic centre for aquatic sports, recreation, health, fitness, "
+            "leisure programmes, swimming lessons, and community use."
+        ),
+        "hours": [{"label": "Opening hours", "text": "Monday - Sunday: 6:00am - 9:00pm"}],
+        "hours_summary": "Monday - Sunday: 6:00am - 9:00pm",
+        "phone": "07 348 8833",
+        "email": "racr@clmnz.co.nz",
+        "features": [
+            "Outdoor 50m heated pool",
+            "Indoor 25m heated pool",
+            "Indoor learner pool",
+            "Gym",
+            "Fitness classes",
+            "Swim programmes",
+            "Birthday party spaces",
+        ],
+        "availability_urls": [
+            {
+                "label": "Outdoor Pool Availability",
+                "url": "https://clm.perfectgym.com.au/ClientPortal2/ClubZoneOccupancyCalendar/6935ad313",
+            },
+            {
+                "label": "Indoor Pool Availability",
+                "url": "https://clm.perfectgym.com.au/ClientPortal2/ClubZoneOccupancyCalendar/d905956020",
+            },
+        ],
+        "hours_note": "Use the linked operator pages for live lane availability and programme changes.",
+    },
+    {
+        "name": "Butcher's Pool",
+        "id": "butchers-pool",
+        "type": "pool",
+        "facility_types": ["pool"],
+        "council": "rot",
+        "council_name": "Rotorua Lakes",
+        "source": "rotorua-lakes-council",
+        "source_url": ROT_BASE + "/parks-lakes-recreation/park-reserves/butchers-pool",
+        "listing_source_url": ROT_PARK_RESERVES_SOURCE_URL,
+        "address": "Broadlands Road, 1.8km south of Reporoa Village",
+        "operator": "Rotorua Lakes Council",
+        "status": "Unsupervised",
+        "description": "Free hot mineral pool with mineral water piped from an adjacent spring.",
+        "hours": None,
+        "hours_summary": None,
+        "hours_note": "Free public hot mineral pool; no opening hours are published on the council page.",
+        "phone": None,
+        "email": None,
+        "features": ["Hot mineral pool", "Changing rooms", "Toilets"],
+        "safety_notes": [
+            "Keep your head above water to avoid amoebic meningitis risk.",
+            "Pool is unsupervised.",
+        ],
+    },
+    {
+        "name": "Kuirau Park foot pools and paddling pool",
+        "id": "kuirau-park-foot-pools-paddling-pool",
+        "type": "pool",
+        "facility_types": ["pool"],
+        "council": "rot",
+        "council_name": "Rotorua Lakes",
+        "source": "rotorua-lakes-council",
+        "source_url": ROT_BASE + "/parks-lakes-recreation/park-reserves/kuirau-park",
+        "listing_source_url": ROT_PARK_RESERVES_SOURCE_URL,
+        "address": "Corner of Ranolf Street and Lake Road, Rotorua",
+        "operator": "Rotorua Lakes Council",
+        "status": None,
+        "description": "Public park facilities include geothermal foot pools and a paddling pool.",
+        "hours": None,
+        "hours_summary": None,
+        "hours_note": "Park page lists facilities but not pool opening hours; stay on tracks around geothermal features.",
+        "phone": None,
+        "email": None,
+        "features": ["Foot pools", "Paddling pool", "BBQs", "Picnic tables", "Playground", "Public toilets"],
+    },
+]
 
 EVENT_TYPES = {
     "Event",
@@ -547,6 +647,15 @@ def fetch_wlg_facilities(kind: str) -> tuple[list[dict[str, Any]], str]:
     return facilities, final_url
 
 
+def fetch_rot_facilities(kind: str | None = "pool") -> tuple[list[dict[str, Any]], str]:
+    facilities: list[dict[str, Any]] = []
+    for facility in ROT_FACILITIES:
+        if kind and kind not in facility.get("facility_types", []):
+            continue
+        facilities.append(dict(facility))
+    return facilities, ROT_RECREATION_SOURCE_URL
+
+
 def parse_time_label(value: str) -> dt.datetime | None:
     for fmt in ("%I:%M %p", "%I %p"):
         try:
@@ -644,6 +753,11 @@ def cmd_pools(args: argparse.Namespace) -> None:
         if args.region:
             die("--region is only supported for Auckland pools")
         pools = pools[: args.limit]
+    elif args.council == "rot":
+        if args.region:
+            die("--region is only supported for Auckland pools")
+        pools, source_url = fetch_rot_facilities("pool")
+        pools = pools[: args.limit]
     else:
         die("Christchurch pools are not wired in v1 because the public council recreation source is JS/vendor-backed")
 
@@ -656,42 +770,71 @@ def cmd_pools(args: argparse.Namespace) -> None:
     emit_facility_list(data, "pools", args.json)
 
 
-def cmd_pool(args: argparse.Namespace) -> None:
-    started = time.perf_counter()
-    if args.council == "akl":
+def pool_detail_for_council(council: str, name: str, started: float) -> tuple[dict[str, Any] | None, str | None]:
+    if council == "akl":
         cards, listing_url = akl_location_listing("pool", None)
-        card = find_facility(cards, args.name)
+        card = find_facility(cards, name)
         if not card:
             suggestions = ", ".join(c["name"] for c in cards[:10])
-            die(f"no Auckland pool matched {args.name!r}. Try one of: {suggestions}")
+            return None, f"Auckland: {suggestions}"
         body, final_url, _ = fetch_text(card["source_url"], AKL_LEISURE_BASE)
         facility = parse_akl_detail(body, final_url, card)
         availability = None
         if facility.get("resource_availability_url"):
             availability = parse_akl_availability(facility["resource_availability_url"])
-        data = {
-            "query": {"council": args.council, "name": args.name},
+        return {
+            "query": {"council": council, "name": name},
             "listing_source_url": listing_url,
             "elapsed_ms": round((time.perf_counter() - started) * 1000),
             "facility": facility,
             "lane_availability_today": availability,
-        }
-    elif args.council == "wlg":
+        }, None
+    if council == "wlg":
         cards, listing_url = fetch_wlg_facilities("pool")
-        card = find_facility(cards, args.name)
+        card = find_facility(cards, name)
         if not card:
             suggestions = ", ".join(c["name"] for c in cards[:10])
-            die(f"no Wellington pool matched {args.name!r}. Try one of: {suggestions}")
-        data = {
-            "query": {"council": args.council, "name": args.name},
+            return None, f"Wellington: {suggestions}"
+        return {
+            "query": {"council": council, "name": name},
             "listing_source_url": listing_url,
             "elapsed_ms": round((time.perf_counter() - started) * 1000),
             "facility": card,
             "lane_availability_today": None,
-        }
-    else:
-        die("Christchurch pool detail is not wired in v1")
-    emit_pool_detail(data, args.json)
+        }, None
+    if council == "rot":
+        cards, listing_url = fetch_rot_facilities("pool")
+        card = find_facility(cards, name)
+        if not card:
+            suggestions = ", ".join(c["name"] for c in cards[:10])
+            return None, f"Rotorua Lakes: {suggestions}"
+        return {
+            "query": {"council": council, "name": name},
+            "listing_source_url": listing_url,
+            "elapsed_ms": round((time.perf_counter() - started) * 1000),
+            "facility": card,
+            "lane_availability_today": None,
+        }, None
+    die("Christchurch pool detail is not wired in v1")
+
+
+def cmd_pool(args: argparse.Namespace) -> None:
+    started = time.perf_counter()
+    councils = [args.council] if args.council else ["rot", "akl", "wlg"]
+    misses: list[str] = []
+    for council in councils:
+        data, miss = pool_detail_for_council(council, args.name, started)
+        if data:
+            emit_pool_detail(data, args.json)
+            return
+        if miss:
+            misses.append(miss)
+    if args.council:
+        council_name = COUNCIL_NAMES.get(args.council, args.council)
+        suggestion = misses[0] if misses else "no suggestions available"
+        die(f"no {council_name} pool matched {args.name!r}. Try one of: {suggestion}")
+    suggestion_text = " | ".join(misses) if misses else "use --council akl, wlg, or rot"
+    die(f"no pool matched {args.name!r}. Try one of: {suggestion_text}")
 
 
 def cmd_facilities(args: argparse.Namespace) -> None:
@@ -715,6 +858,18 @@ def cmd_facilities(args: argparse.Namespace) -> None:
         else:
             facilities, source_url = fetch_wlg_facilities(args.type)
             note = None
+        facilities = facilities[: args.limit]
+    elif args.council == "rot":
+        if args.region:
+            die("--region is only supported for Auckland facilities")
+        if args.type == "library":
+            facilities, source_url = [], ROT_RECREATION_SOURCE_URL
+            note = "Libraries are outside this skill's recreation-focused v1 data source."
+        else:
+            facilities, source_url = fetch_rot_facilities(args.type)
+            note = None
+            if args.type == "gym":
+                note = "Rotorua Aquatic Centre includes a gym; linked operator pages have current programme details."
         facilities = facilities[: args.limit]
     else:
         facilities, source_url = [], "https://recandsport.ccc.govt.nz/"
@@ -816,7 +971,7 @@ def build_parser() -> argparse.ArgumentParser:
     sub = parser.add_subparsers(dest="command", required=True)
 
     events = sub.add_parser("events", help="list council-area public events")
-    events.add_argument("--council", choices=sorted(COUNCIL_LOCATIONS), help="council area: akl, wlg, or chc")
+    events.add_argument("--council", choices=sorted(COUNCIL_LOCATIONS), help="council area: akl, wlg, chc, or rot")
     events.add_argument("--from", dest="date_from", help="start date filter, ISO yyyy-mm-dd")
     events.add_argument("--to", dest="date_to", help="end date filter, ISO yyyy-mm-dd")
     events.add_argument("--category", help="Eventfinda category slug, e.g. concerts-gig-guide")
@@ -831,7 +986,7 @@ def build_parser() -> argparse.ArgumentParser:
     event.set_defaults(func=cmd_event)
 
     pools = sub.add_parser("pools", help="list public pools with available hours where supported")
-    pools.add_argument("--council", choices=["akl", "wlg", "chc"], default="akl", help="council recreation source")
+    pools.add_argument("--council", choices=["akl", "wlg", "chc", "rot"], default="akl", help="council recreation source")
     pools.add_argument("--region", choices=sorted(AKL_AREA_IDS), help="Auckland region filter")
     pools.add_argument("--limit", type=int, default=50, help="maximum pools to emit")
     pools.add_argument("--json", action="store_true", help="emit JSON")
@@ -839,12 +994,12 @@ def build_parser() -> argparse.ArgumentParser:
 
     pool = sub.add_parser("pool", help="show one pool detail and lane availability where supported")
     pool.add_argument("name", help="pool name or slug, e.g. Tepid Baths")
-    pool.add_argument("--council", choices=["akl", "wlg", "chc"], default="akl", help="council recreation source")
+    pool.add_argument("--council", choices=["akl", "wlg", "chc", "rot"], help="council recreation source; default searches supported pool sources")
     pool.add_argument("--json", action="store_true", help="emit JSON")
     pool.set_defaults(func=cmd_pool)
 
     facilities = sub.add_parser("facilities", help="list recreation facilities")
-    facilities.add_argument("--council", choices=["akl", "wlg", "chc"], default="akl", help="council recreation source")
+    facilities.add_argument("--council", choices=["akl", "wlg", "chc", "rot"], default="akl", help="council recreation source")
     facilities.add_argument("--type", choices=["pool", "gym", "leisure-centre", "library"], default="pool", help="facility type")
     facilities.add_argument("--region", choices=sorted(AKL_AREA_IDS), help="Auckland region filter")
     facilities.add_argument("--limit", type=int, default=50, help="maximum facilities to emit")


### PR DESCRIPTION
## Summary

Adds Rotorua Lakes Council support to `skills/nz-council/scripts/cli.py` using council code `rot`.

## Sources

- Rotorua Lakes Council recreation: https://www.rotorualakescouncil.nz/parks-lakes-recreation
- Rotorua Aquatic Centre council page: https://www.rotorualakescouncil.nz/parks-lakes-recreation/recreational-venues/aquatic-centre
- Rotorua Aquatic Centre operator: https://www.clmnz.co.nz/rotorua-aquatic-centre/
- Rotorua Aquatic Centre pools: https://www.clmnz.co.nz/rotorua-aquatic-centre/pools/
- Rotorua Aquatic Centre contact: https://www.clmnz.co.nz/rotorua-aquatic-centre/contact/
- Butcher's Pool: https://www.rotorualakescouncil.nz/parks-lakes-recreation/park-reserves/butchers-pool
- Kuirau Park: https://www.rotorualakescouncil.nz/parks-lakes-recreation/park-reserves/kuirau-park
- Council/public owned pools OIA cross-check: https://www.rotorualakescouncil.nz/our-council/officialinformation/official-information-requests?item=id%3A2qgeujsul17q9sfg7ls7

Direct checks of `rotoruaaquaticcentre.co.nz` and `www.rotoruaaquaticcentre.co.nz` did not resolve; Rotorua Lakes Council links to the CLM operator path above.

## Sample Output

`python3 skills/nz-council/scripts/cli.py pools --council rot --json`

```json
{
  "pools": [
    {
      "name": "Rotorua Aquatic Centre",
      "address": "Kuirau Park, 18 Tarewa Rd, Rotorua 3010",
      "hours_summary": "Monday - Sunday: 6:00am - 9:00pm",
      "features": ["Outdoor 50m heated pool", "Indoor 25m heated pool", "Indoor learner pool", "Gym"]
    },
    {
      "name": "Butcher's Pool",
      "address": "Broadlands Road, 1.8km south of Reporoa Village",
      "status": "Unsupervised"
    },
    {
      "name": "Kuirau Park foot pools and paddling pool",
      "address": "Corner of Ranolf Street and Lake Road, Rotorua"
    }
  ]
}
```

`python3 skills/nz-council/scripts/cli.py pool 'Rotorua Aquatic' --json`

```json
{
  "facility": {
    "name": "Rotorua Aquatic Centre",
    "council": "rot",
    "operator": "Community Leisure Management (CLM)",
    "phone": "07 348 8833",
    "email": "racr@clmnz.co.nz"
  },
  "lane_availability_today": null
}
```

## Validation

- `python3 -m py_compile skills/nz-council/scripts/cli.py`
- `python3 skills/nz-council/scripts/cli.py pools --council rot --json`
- `python3 skills/nz-council/scripts/cli.py pool 'Rotorua Aquatic' --json`
- `python3 skills/nz-council/scripts/cli.py pool 'Definitely Not A Rotorua Pool' --council rot --json`
- `python3 skills/nz-council/scripts/cli.py pools --council wlg --limit 1 --json`
- `python3 skills/nz-council/scripts/cli.py pools --council akl --limit 1 --json`
- `python3 skills/nz-council/scripts/cli.py events --council rot --limit 1 --json`
- `git diff --check`
