### PR TITLE
feat(nz-council): add Whangarei recreation facilities

### DIFF
--- a/skills/nz-council/SKILL.md
+++ b/skills/nz-council/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nz-council
-description: Query NZ council-area event listings and public recreation facilities through a lightweight read-only CLI. Use for Auckland, Wellington, Christchurch, Rotorua, New Plymouth, Napier, Hastings, or Hamilton what's-on events; Eventfinda council-area events; Auckland Council pools/leisure centres; Wellington City pools/recreation centres; Rotorua Lakes pools and aquatic facilities; New Plymouth pools; Napier and Hastings aquatic facilities; Hamilton Pools facilities; Wellington region pools and aquatic centres for Hutt City, Porirua, Upper Hutt, and Kāpiti Coast; pool hours; and public lane availability snapshots where exposed. Not for rates, consents, rubbish, recycling, parking fines, bookings, logins, or payments.
+description: Query NZ council-area event listings and public recreation facilities through a lightweight read-only CLI. Use for Auckland, Wellington, Christchurch, Rotorua, New Plymouth, Napier, Hastings, Hamilton, or Whangarei what's-on events; Eventfinda council-area events; Auckland Council pools/leisure centres; Wellington City pools/recreation centres; Rotorua Lakes pools and aquatic facilities; New Plymouth pools; Napier and Hastings aquatic facilities; Hamilton Pools facilities; Whangarei Aquatic Centre; Wellington region pools and aquatic centres for Hutt City, Porirua, Upper Hutt, and Kāpiti Coast; pool hours; and public lane availability snapshots where exposed. Not for rates, consents, rubbish, recycling, parking fines, bookings, logins, or payments.
 ---
 
 # NZ Council
@@ -16,7 +16,7 @@ This v1 is deliberately narrow. It is not a general council-services skill.
 
 ## Use this when
 
-- The user asks what is on in Auckland, Wellington, Christchurch, Rotorua, New Plymouth, Napier, Hastings, Hamilton, or across NZ council areas.
+- The user asks what is on in Auckland, Wellington, Christchurch, Rotorua, New Plymouth, Napier, Hastings, Hamilton, Whangarei, or across NZ council areas.
 - The user asks for council-listed concerts, markets, exhibitions, kids' activities, festivals, or free events.
 - The user asks for public pools, leisure centres, gyms, recreation centres, hours, pool contact details, pool facilities, or pool lane availability.
 - You need a quick JSON feed for council-area events or recreation facility listings without browser automation.
@@ -41,7 +41,8 @@ This v1 is deliberately narrow. It is not a general council-services skill.
 9. Use `pools --council has --json` for Hastings aquatic recreation facilities, including Splash Planet and Aquatics Hastings pools.
 10. Use `pools --council ham --json` or `pool "Waterworld" --json` for Hamilton Pools facilities, including Waterworld, Gallagher Aquatic Centre, and current seasonal partner pools.
 11. Use Wellington region council codes for aquatic facilities beyond Wellington City: `hutt`, `porirua`, `uhutt`, and `kapiti`.
-12. Treat Christchurch recreation as discovered but not fully wired in v1; the public council page is protected/vendor-backed.
+12. Use `pools --council whg --json` or `pool "ASB Leisure" --json` for Whangarei Aquatic Centre. ASB Leisure is treated as a legacy/search alias for the current Ewing Road aquatic-centre source.
+13. Treat Christchurch recreation as discovered but not fully wired in v1; the public council page is protected/vendor-backed.
 
 ## CLI
 
@@ -56,12 +57,12 @@ Every data command supports `--json`.
 ## Commands
 
 ```bash
-python3 skills/nz-council/scripts/cli.py events [--council akl|wlg|chc|rot|npl|npr|has|ham] [--from DATE] [--to DATE] [--category SLUG] [--free] [--limit N] [--json]
+python3 skills/nz-council/scripts/cli.py events [--council akl|wlg|chc|rot|npl|npr|has|ham|whg] [--from DATE] [--to DATE] [--category SLUG] [--free] [--limit N] [--json]
 python3 skills/nz-council/scripts/cli.py event <id-or-url> [--json]
 
-python3 skills/nz-council/scripts/cli.py pools [--council akl|wlg|chc|rot|npl|npr|has|ham|hutt|porirua|uhutt|kapiti] [--region central|east|north|south|west] [--limit N] [--json]
-python3 skills/nz-council/scripts/cli.py pool <name> [--council akl|wlg|chc|rot|npl|npr|has|ham|hutt|porirua|uhutt|kapiti] [--json]
-python3 skills/nz-council/scripts/cli.py facilities [--council akl|wlg|chc|rot|npl|npr|has|ham|hutt|porirua|uhutt|kapiti] [--type pool|gym|leisure-centre|library] [--region central|east|north|south|west] [--limit N] [--json]
+python3 skills/nz-council/scripts/cli.py pools [--council akl|wlg|chc|rot|npl|npr|has|ham|hutt|porirua|uhutt|kapiti|whg] [--region central|east|north|south|west] [--limit N] [--json]
+python3 skills/nz-council/scripts/cli.py pool <name> [--council akl|wlg|chc|rot|npl|npr|has|ham|hutt|porirua|uhutt|kapiti|whg] [--json]
+python3 skills/nz-council/scripts/cli.py facilities [--council akl|wlg|chc|rot|npl|npr|has|ham|hutt|porirua|uhutt|kapiti|whg] [--type pool|gym|leisure-centre|library] [--region central|east|north|south|west] [--limit N] [--json]
 ```
 
 ## Examples
@@ -87,6 +88,8 @@ python3 skills/nz-council/scripts/cli.py pool "Waterworld" --json
 python3 skills/nz-council/scripts/cli.py pools --council hutt --json
 python3 skills/nz-council/scripts/cli.py pool "Naenae Pool" --council hutt --json
 python3 skills/nz-council/scripts/cli.py pools --council kapiti --json
+python3 skills/nz-council/scripts/cli.py pools --council whg --json
+python3 skills/nz-council/scripts/cli.py pool "ASB Leisure" --json
 ```
 
 ## Resources
@@ -109,6 +112,7 @@ python3 skills/nz-council/scripts/cli.py pools --council kapiti --json
 - Porirua Arena Aquatics uses the public Te Rauparaha Arena aquatic pages.
 - Upper Hutt H2O Xtream uses public H2O Xtream pages. Some direct requests are Akamai-denied in Python, so the CLI can use the same local CDP fallback.
 - Kāpiti Coast pools use public Kāpiti Coast Aquatics pages.
+- Whangarei recreation uses the current WDC parks/recreation landing page plus CLM's Whangarei Aquatic Centre pages. The old `wdc.govt.nz/Services/Sport-and-recreation/Pools-and-leisure` path returned a WDC 404 during discovery, and `asbleisurecentre.co.nz` did not resolve.
 - Christchurch recreation and sport pages were observed at `recandsport.ccc.govt.nz`, but the useful dynamic data is vendor-backed and is documented rather than wired in v1.
 - Napier aquatic recreation uses Napier City Council's current Napier Aquatic Centre page. The centre is also commonly known as Onekawa Pools.
 - Hastings aquatic recreation uses Hastings District Council's current swimming-pools page plus linked Aquatics Hastings and Splash Planet public pages. Frimley Pool is retained as a closed facility because HDC's current page records the September 2024 closure decision.

--- a/skills/nz-council/references/api-notes.md
+++ b/skills/nz-council/references/api-notes.md
@@ -21,6 +21,7 @@ Implemented as the primary event source.
 - List Wellington: `https://www.eventfinda.co.nz/whatson/events/wellington`
 - List Christchurch: `https://www.eventfinda.co.nz/whatson/events/christchurch`
 - List New Plymouth: `https://www.eventfinda.co.nz/whatson/events/new-plymouth`
+- List Whangarei: `https://www.eventfinda.co.nz/whatson/events/whangarei`
 - List all NZ: `https://www.eventfinda.co.nz/whatson/events/new-zealand`
 - Category form: `https://www.eventfinda.co.nz/{category}/events/{location}`
 - Pagination: `?page=N`
@@ -434,6 +435,55 @@ Data captured:
 - Waikanae: 52 Ngarara Road, Waikanae; 04 296 4789; seasonal outdoor 33.5m pool, toddler pool, hydroslide, BBQ/gazebo bookings
 - Ōtaki: Haruātai Park, 200 Mill Road, Ōtaki; 06 364 5542; 33.5m lane pool, toddler pool, spa/sauna, slippery slope, splashpad
 - Shared email: `swim@kapiticoast.govt.nz`
+
+### Whangarei recreation facilities
+
+Implemented as a basic static facility listing for the current public aquatic-centre source.
+
+- WDC recreation landing page checked: `https://www.wdc.govt.nz/Community/Parks-and-recreation`
+- Supplied WDC path checked first: `https://www.wdc.govt.nz/Services/Sport-and-recreation/Pools-and-leisure`
+- Supplied WDC path result: direct request returned the WDC `Page Not Found - Error 404` page.
+- Supplied operator host checked first: `https://www.asbleisurecentre.co.nz`
+- Supplied operator host result: DNS resolution failed during direct fetch.
+- Current operator home: `https://www.clmnz.co.nz/whangarei-aquatic-centre/`
+- Current operator pools page: `https://www.clmnz.co.nz/whangarei-aquatic-centre/pools/`
+- Current operator contact/hours page: `https://www.clmnz.co.nz/whangarei-aquatic-centre/contact/`
+
+Observed current public pool/leisure source:
+
+```json
+{
+  "name": "Whangarei Aquatic Centre",
+  "aliases": ["ASB Leisure Centre", "ASB Leisure"],
+  "id": "whangarei-aquatic-centre",
+  "type": "pool",
+  "council": "whg",
+  "source": "clmnz-whangarei-aquatic-centre",
+  "source_url": "https://www.clmnz.co.nz/whangarei-aquatic-centre/",
+  "address": "Ewing Road, Whangarei",
+  "phone": "09 430 4072",
+  "operator": "Community Leisure Management"
+}
+```
+
+Operator pages expose:
+
+- pool hours: Monday-Friday 6:00am-8:00pm; weekends 8:00am-6:00pm
+- gym hours: Monday-Friday 6:00am-8:00pm; weekends 8:00am-4:00pm
+- pools close 15 minutes before closing
+- public-holiday notes
+- pool set: Competition Pool, Wave Pool, Tots Pool, Hydrotherapy Pool, Learn To Swim Pool, Spa Pool
+- gym, group fitness, swim school, kids programmes
+- PerfectGym public availability links for the 25m pool and wave pool
+
+Community pool check:
+
+- WDC parks/recreation and community-facilities pages expose parks, beaches/coastal facilities, sports parks, playgrounds, community halls, libraries, and Ruakaka Service Centre.
+- No current WDC page found a council-managed Kamo or Ruakaka community pool listing.
+- Kamo search results found school/private/history references rather than a current council-managed public pool.
+- Ruakaka search results found a recreation centre/service-centre/community-hub context, not a current council-managed public pool.
+
+Freshness: static facility metadata captured from current direct-fetchable public pages during discovery. Availability links are emitted, but PerfectGym availability parsing is not wired for Whangarei v1.
 
 ### Christchurch recreation and sport
 

--- a/skills/nz-council/scripts/cli.py
+++ b/skills/nz-council/scripts/cli.py
@@ -42,6 +42,12 @@ PORIRUA_ARENA_BASE = "https://terauparaha-arena.co.nz"
 UHUTT_H2O_BASE = "https://www.h2oxtream.com"
 KAPITI_AQUATICS_BASE = "https://www.kapiticoastaquatics.co.nz"
 CDP_HTTP_BASE = "http://127.0.0.1:5100"
+WHG_WDC_BASE = "https://www.wdc.govt.nz"
+WHG_CLM_BASE = "https://www.clmnz.co.nz"
+WHG_RECREATION_URL = WHG_WDC_BASE + "/Community/Parks-and-recreation"
+WHG_AQUATIC_URL = WHG_CLM_BASE + "/whangarei-aquatic-centre/"
+WHG_AQUATIC_POOLS_URL = WHG_AQUATIC_URL + "pools/"
+WHG_AQUATIC_CONTACT_URL = WHG_AQUATIC_URL + "contact/"
 
 UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146 Safari/537.36"
 
@@ -54,6 +60,7 @@ COUNCIL_LOCATIONS = {
     "npr": "napier",
     "has": "hastings",
     "ham": "hamilton",
+    "whg": "whangarei",
 }
 
 COUNCIL_NAMES = {
@@ -69,9 +76,10 @@ COUNCIL_NAMES = {
     "porirua": "Porirua City",
     "uhutt": "Upper Hutt City",
     "kapiti": "Kāpiti Coast",
+    "whg": "Whangarei",
 }
 
-RECREATION_COUNCILS = ("akl", "wlg", "chc", "rot", "npl", "npr", "has", "ham", "hutt", "porirua", "uhutt", "kapiti")
+RECREATION_COUNCILS = ("akl", "wlg", "chc", "rot", "npl", "npr", "has", "ham", "hutt", "porirua", "uhutt", "kapiti", "whg")
 
 AKL_AREA_IDS = {
     "central": "1134",
@@ -491,6 +499,68 @@ HAM_MAIN_POOL_PATHS = (
 )
 
 HAM_PARTNER_POOLS_PATH = "/facilities/partner-pools"
+
+WHG_POOL_NO_COMMUNITY_NOTE = (
+    "Current public Whangarei District Council pages checked for v1 expose parks, beaches, sports parks, "
+    "and community facilities but no council-managed Kamo or Ruakaka community pool listing. "
+    "Whangarei Aquatic Centre is the public pool/leisure-centre source currently wired."
+)
+
+WHG_FACILITIES = [
+    {
+        "name": "Whangarei Aquatic Centre",
+        "id": "whangarei-aquatic-centre",
+        "aliases": ["ASB Leisure Centre", "ASB Leisure", "Whangarei Aquatic Centre"],
+        "type": "pool",
+        "facility_types": ["pool", "gym", "leisure-centre"],
+        "council": "whg",
+        "council_name": "Whangarei",
+        "source": "clmnz-whangarei-aquatic-centre",
+        "source_url": WHG_AQUATIC_URL,
+        "listing_source_url": WHG_RECREATION_URL,
+        "operator": "Community Leisure Management",
+        "address": "Ewing Road, Whangarei",
+        "phone": "09 430 4072",
+        "email": "whr@clmnz.co.nz",
+        "description": (
+            "Public aquatic and leisure centre with pool, spa, sauna, gym, swim school, "
+            "kids programmes, and pool availability links."
+        ),
+        "hours": [
+            {"label": "Pool hours", "text": "Monday-Friday 6:00am-8:00pm; Saturday-Sunday 8:00am-6:00pm"},
+            {"label": "Gym hours", "text": "Monday-Friday 6:00am-8:00pm; weekends 8:00am-4:00pm"},
+            {
+                "label": "Public holidays",
+                "text": "10:00am-6:00pm; Good Friday closed; Anzac Day 1:00pm-6:00pm",
+            },
+        ],
+        "hours_summary": "Monday-Friday 6:00am-8:00pm; Saturday-Sunday 8:00am-6:00pm",
+        "hours_note": "Pools close 15 minutes before centre closing.",
+        "features": [
+            "Competition Pool",
+            "Wave Pool",
+            "Tots Pool",
+            "Hydrotherapy Pool",
+            "Learn To Swim Pool",
+            "Spa Pool",
+            "Sauna",
+            "Gym",
+            "Group fitness",
+            "Swim school",
+        ],
+        "availability_urls": [
+            {
+                "label": "25m Pool Lane Availability",
+                "url": "https://clm.perfectgym.com.au/ClientPortal2/ClubZoneOccupancyCalendar/15e262e78",
+            },
+            {
+                "label": "Wave Pool Availability",
+                "url": "https://clm.perfectgym.com.au/ClientPortal2/ClubZoneOccupancyCalendar/08ad415711",
+            },
+        ],
+        "source_urls": [WHG_RECREATION_URL, WHG_AQUATIC_URL, WHG_AQUATIC_POOLS_URL, WHG_AQUATIC_CONTACT_URL],
+    },
+]
 
 EVENT_TYPES = {
     "Event",
@@ -1481,6 +1551,17 @@ def static_recreation_facilities(council: str, kind: str | None = None) -> tuple
     return facilities, source_url
 
 
+def fetch_whg_facilities(kind: str) -> tuple[list[dict[str, Any]], str, str | None]:
+    if kind == "library":
+        return [], WHG_WDC_BASE, "Libraries are outside this skill's recreation-focused v1 data source."
+    facilities: list[dict[str, Any]] = []
+    for item in WHG_FACILITIES:
+        if kind in item.get("facility_types", []) or kind == item.get("type"):
+            facilities.append(dict(item))
+    note = WHG_POOL_NO_COMMUNITY_NOTE if kind == "pool" else None
+    return facilities, WHG_RECREATION_URL, note
+
+
 def parse_time_label(value: str) -> dt.datetime | None:
     for fmt in ("%I:%M %p", "%I %p"):
         try:
@@ -1931,11 +2012,22 @@ def pool_detail_for_council(council: str, name: str) -> tuple[dict[str, Any] | N
             "facility": regional_pool_detail(card),
             "lane_availability_today": None,
         }, listing_url, []
+    if council == "whg":
+        cards, listing_url, note = fetch_whg_facilities("pool")
+        card = find_facility(cards, name)
+        if not card:
+            return None, listing_url, [c["name"] for c in cards[:10]]
+        return {
+            "facility": card,
+            "lane_availability_today": None,
+            "note": note,
+        }, listing_url, []
     die("Christchurch pool detail is not wired in v1")
 
 
 def cmd_pools(args: argparse.Namespace) -> None:
     started = time.perf_counter()
+    note = None
     if args.council == "akl":
         pools, source_url = akl_location_listing("pool", args.region)
         pools = pools[: args.limit]
@@ -1964,11 +2056,17 @@ def cmd_pools(args: argparse.Namespace) -> None:
         if args.region:
             die("--region is only supported for Auckland pools")
         pools, source_url = fetch_ham_facilities("pool")
+        note = "Hamilton Pools currently lists Waterworld, Gallagher Aquatic Centre, and seasonal partner pools; Founders Memorial Theatre Pool is not listed as an active pool."
         pools = pools[: args.limit]
     elif args.council in REGIONAL_POOL_CATALOG:
         if args.region:
             die("--region is only supported for Auckland pools")
         pools, source_url, _ = regional_pool_cards(args.council)
+        pools = pools[: args.limit]
+    elif args.council == "whg":
+        if args.region:
+            die("--region is only supported for Auckland pools")
+        pools, source_url, note = fetch_whg_facilities("pool")
         pools = pools[: args.limit]
     else:
         die("Christchurch pools are not wired in v1 because the public council recreation source is JS/vendor-backed")
@@ -1977,7 +2075,7 @@ def cmd_pools(args: argparse.Namespace) -> None:
         "query": {"council": args.council, "region": args.region, "limit": args.limit},
         "source_url": source_url,
         "elapsed_ms": round((time.perf_counter() - started) * 1000),
-        "note": "Hamilton Pools currently lists Waterworld, Gallagher Aquatic Centre, and seasonal partner pools; Founders Memorial Theatre Pool is not listed as an active pool." if args.council == "ham" else None,
+        "note": note,
         "pools": pools,
     }
     emit_facility_list(data, "pools", args.json)
@@ -1985,7 +2083,7 @@ def cmd_pools(args: argparse.Namespace) -> None:
 
 def cmd_pool(args: argparse.Namespace) -> None:
     started = time.perf_counter()
-    councils = [args.council] if args.council else ["npr", "has", "npl", "rot", "akl", "wlg", "ham", "hutt", "porirua", "uhutt", "kapiti"]
+    councils = [args.council] if args.council else ["whg", "npr", "has", "npl", "rot", "akl", "wlg", "ham", "hutt", "porirua", "uhutt", "kapiti"]
     suggestions_by_council: list[str] = []
     for council in councils:
         detail, listing_url, suggestions = pool_detail_for_council(council, args.name)
@@ -1997,6 +2095,8 @@ def cmd_pool(args: argparse.Namespace) -> None:
                 "facility": detail["facility"],
                 "lane_availability_today": detail["lane_availability_today"],
             }
+            if detail.get("note"):
+                data["note"] = detail["note"]
             emit_pool_detail(data, args.json)
             return
         if suggestions:
@@ -2087,6 +2187,11 @@ def cmd_facilities(args: argparse.Namespace) -> None:
         else:
             facilities = []
             note = f"{COUNCIL_NAMES.get(args.council, args.council)} recreation support is currently wired for public aquatic facilities only."
+    elif args.council == "whg":
+        if args.region:
+            die("--region is only supported for Auckland facilities")
+        facilities, source_url, note = fetch_whg_facilities(args.type)
+        facilities = facilities[: args.limit]
     else:
         facilities, source_url = [], "https://recandsport.ccc.govt.nz/"
         note = "Christchurch recreation uses a vendor-backed source that is documented in references but not wired in v1."


### PR DESCRIPTION
## Sources

- Whangarei District Council recreation landing page: https://www.wdc.govt.nz/Community/Parks-and-recreation
- Current operator home: https://www.clmnz.co.nz/whangarei-aquatic-centre/
- Operator pools page: https://www.clmnz.co.nz/whangarei-aquatic-centre/pools/
- Operator contact/hours page: https://www.clmnz.co.nz/whangarei-aquatic-centre/contact/
- Supplied WDC path checked first and returned WDC 404: https://www.wdc.govt.nz/Services/Sport-and-recreation/Pools-and-leisure
- Supplied operator host checked first and DNS did not resolve: https://www.asbleisurecentre.co.nz
- CDP fallback was not needed; direct fetches were enough to identify the live source and stale paths.

## Sample output

`python3 skills/nz-council/scripts/cli.py pools --council whg --json`

```json
{
  "query": {"council": "whg", "region": null, "limit": 50},
  "source_url": "https://www.wdc.govt.nz/Community/Parks-and-recreation",
  "note": "Current public Whangarei District Council pages checked for v1 expose parks, beaches, sports parks, and community facilities but no council-managed Kamo or Ruakaka community pool listing. Whangarei Aquatic Centre is the public pool/leisure-centre source currently wired.",
  "pools": [
    {
      "name": "Whangarei Aquatic Centre",
      "aliases": ["ASB Leisure Centre", "ASB Leisure", "Whangarei Aquatic Centre"],
      "address": "Ewing Road, Whangarei",
      "phone": "09 430 4072",
      "hours_summary": "Monday-Friday 6:00am-8:00pm; Saturday-Sunday 8:00am-6:00pm",
      "features": ["Competition Pool", "Wave Pool", "Tots Pool", "Hydrotherapy Pool", "Learn To Swim Pool", "Spa Pool", "Sauna", "Gym", "Group fitness", "Swim school"],
      "source_url": "https://www.clmnz.co.nz/whangarei-aquatic-centre/"
    }
  ]
}
```

`python3 skills/nz-council/scripts/cli.py pool 'ASB Leisure' --json` resolves the ASB Leisure alias to Whangarei Aquatic Centre.

## Checks

- `python3 -m py_compile skills/nz-council/scripts/cli.py`
- `python3 skills/nz-council/scripts/cli.py pools --council whg --json`
- `python3 skills/nz-council/scripts/cli.py pool 'ASB Leisure' --json`
- `python3 skills/nz-council/scripts/cli.py pool 'Not A Real Pool' --council whg --json` exits gracefully with suggestions
- `python3 skills/nz-council/scripts/cli.py pool 'Tepid Baths' --json`
- `python3 skills/nz-council/scripts/cli.py pools --council wlg --limit 1 --json`
- `python3 skills/nz-council/scripts/cli.py pools --council rot --limit 1 --json`
- `python3 skills/nz-council/scripts/cli.py events --council whg --limit 1 --json`
- `git diff --check`
