### PR TITLE
feat(nz-council): add Nelson + Tasman recreation facilities

### DIFF
--- a/skills/nz-council/SKILL.md
+++ b/skills/nz-council/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nz-council
-description: Query NZ council-area event listings and public recreation facilities through a lightweight read-only CLI. Use for Auckland, Wellington, Christchurch, Rotorua, New Plymouth, Napier, Hastings, Hamilton, Whangarei, Palmerston North, Tauranga, or Queenstown Lakes what's-on events; Eventfinda council-area events; Auckland Council pools/leisure centres; Wellington City pools/recreation centres; Rotorua Lakes pools and aquatic facilities; New Plymouth pools; Napier and Hastings aquatic facilities; Hamilton Pools facilities; Whangarei Aquatic Centre; Palmerston North swimming facilities; Wellington region pools and aquatic centres for Hutt City, Porirua, Upper Hutt, and Kāpiti Coast; Tauranga pools/aquatic centres; Queenstown Lakes pools/recreation facilities; pool hours; and public lane availability snapshots where exposed. Not for rates, consents, rubbish, recycling, parking fines, bookings, logins, or payments.
+description: Query NZ council-area event listings and public recreation facilities through a lightweight read-only CLI. Use for Auckland, Wellington, Christchurch, Rotorua, New Plymouth, Nelson, Tasman, Napier, Hastings, Hamilton, Whangarei, Palmerston North, Tauranga, Queenstown Lakes, or Dunedin what's-on events; Eventfinda council-area events; Auckland Council pools/leisure centres; Wellington City pools/recreation centres; Rotorua Lakes pools and aquatic facilities; New Plymouth pools; Nelson pools; Tasman pools/recreation centres; Napier and Hastings aquatic facilities; Hamilton Pools facilities; Whangarei Aquatic Centre; Palmerston North swimming facilities; Wellington region pools and aquatic centres for Hutt City, Porirua, Upper Hutt, and Kāpiti Coast; Tauranga pools/aquatic centres; Queenstown Lakes pools/recreation facilities; Dunedin pools; pool hours; and public lane availability snapshots where exposed. Not for rates, consents, rubbish, recycling, parking fines, bookings, logins, or payments.
 ---
 
 # NZ Council
@@ -16,7 +16,7 @@ This v1 is deliberately narrow. It is not a general council-services skill.
 
 ## Use this when
 
-- The user asks what is on in Auckland, Wellington, Christchurch, Rotorua, New Plymouth, Napier, Hastings, Hamilton, Whangarei, Palmerston North, Tauranga, Queenstown Lakes, or across NZ council areas.
+- The user asks what is on in Auckland, Wellington, Christchurch, Rotorua, New Plymouth, Nelson, Tasman, Napier, Hastings, Hamilton, Whangarei, Palmerston North, Tauranga, Queenstown Lakes, Dunedin, or across NZ council areas.
 - The user asks for council-listed concerts, markets, exhibitions, kids' activities, festivals, or free events.
 - The user asks for public pools, leisure centres, gyms, recreation centres, hours, pool contact details, pool facilities, or pool lane availability.
 - You need a quick JSON feed for council-area events or recreation facility listings without browser automation.
@@ -42,10 +42,11 @@ This v1 is deliberately narrow. It is not a general council-services skill.
 10. Use `pools --council ham --json` or `pool "Waterworld" --json` for Hamilton Pools facilities, including Waterworld, Gallagher Aquatic Centre, and current seasonal partner pools.
 11. Use Wellington region council codes for aquatic facilities beyond Wellington City: `hutt`, `porirua`, `uhutt`, and `kapiti`.
 12. Use `pools --council whg --json` or `pool "ASB Leisure" --json` for Whangarei Aquatic Centre. ASB Leisure is treated as a legacy/search alias for the current Ewing Road aquatic-centre source.
-13. Use `pools --council chc --json`, `facilities --council chc --type pool --json`, or `pool "Jellie Park" --json` for Christchurch Recreation and Sport facilities. The CLI reads public recandsport CCC endpoints and public facility pages; it does not book sessions or use authenticated portals.
-14. Use `pools --council pmn --json` or `pool "Lido" --json` for Palmerston North council-listed swimming facilities, with PNCC details and public CLM hours where linked.
-15. Use `pools --council tga --json` or `facilities --council tga --type pool --json` for Tauranga City Council aquatic centres operated by Bay Venues, including current closed-status notes where exposed.
-16. Use Queenstown Lakes recreation commands for QLDC pools, Queenstown Events Centre, Wānaka Recreation Centre, Paetara Aspiring Central, and Alpine Health and Fitness.
+13. Use Nelson and Tasman recreation commands for council-sourced static facility details; open linked council/operator pages for current hours.
+14. Use `pools --council chc --json`, `facilities --council chc --type pool --json`, or `pool "Jellie Park" --json` for Christchurch Recreation and Sport facilities. The CLI reads public recandsport CCC endpoints and public facility pages; it does not book sessions or use authenticated portals.
+15. Use `pools --council pmn --json` or `pool "Lido" --json` for Palmerston North council-listed swimming facilities, with PNCC details and public CLM hours where linked.
+16. Use `pools --council tga --json` or `facilities --council tga --type pool --json` for Tauranga City Council aquatic centres operated by Bay Venues, including current closed-status notes where exposed.
+17. Use Queenstown Lakes recreation commands for QLDC pools, Queenstown Events Centre, Wānaka Recreation Centre, Paetara Aspiring Central, and Alpine Health and Fitness.
 
 ## CLI
 
@@ -60,12 +61,12 @@ Every data command supports `--json`.
 ## Commands
 
 ```bash
-python3 skills/nz-council/scripts/cli.py events [--council akl|wlg|chc|rot|npl|npr|has|ham|whg|pmn|tga|qldc] [--from DATE] [--to DATE] [--category SLUG] [--free] [--limit N] [--json]
+python3 skills/nz-council/scripts/cli.py events [--council akl|wlg|chc|rot|npl|nsn|tdc|npr|has|ham|whg|pmn|tga|qldc|dud] [--from DATE] [--to DATE] [--category SLUG] [--free] [--limit N] [--json]
 python3 skills/nz-council/scripts/cli.py event <id-or-url> [--json]
 
-python3 skills/nz-council/scripts/cli.py pools [--council akl|wlg|chc|rot|npl|npr|has|ham|hutt|porirua|uhutt|kapiti|whg|pmn|tga|qldc] [--region central|east|north|south|west] [--limit N] [--json]
-python3 skills/nz-council/scripts/cli.py pool <name> [--council akl|wlg|chc|rot|npl|npr|has|ham|hutt|porirua|uhutt|kapiti|whg|pmn|tga|qldc] [--json]
-python3 skills/nz-council/scripts/cli.py facilities [--council akl|wlg|chc|rot|npl|npr|has|ham|hutt|porirua|uhutt|kapiti|whg|pmn|tga|qldc] [--type pool|gym|leisure-centre|library] [--region central|east|north|south|west] [--limit N] [--json]
+python3 skills/nz-council/scripts/cli.py pools [--council akl|wlg|chc|rot|npl|nsn|tdc|npr|has|ham|hutt|porirua|uhutt|kapiti|whg|pmn|tga|qldc|dud] [--region central|east|north|south|west] [--limit N] [--json]
+python3 skills/nz-council/scripts/cli.py pool <name> [--council akl|wlg|chc|rot|npl|nsn|tdc|npr|has|ham|hutt|porirua|uhutt|kapiti|whg|pmn|tga|qldc|dud] [--json]
+python3 skills/nz-council/scripts/cli.py facilities [--council akl|wlg|chc|rot|npl|nsn|tdc|npr|has|ham|hutt|porirua|uhutt|kapiti|whg|pmn|tga|qldc|dud] [--type pool|gym|leisure-centre|library] [--region central|east|north|south|west] [--limit N] [--json]
 ```
 
 ## Examples
@@ -103,6 +104,8 @@ python3 skills/nz-council/scripts/cli.py pool "Baywave" --council tga --json
 python3 skills/nz-council/scripts/cli.py pools --council qldc --json
 python3 skills/nz-council/scripts/cli.py pool "Alpine Aqualand" --json
 python3 skills/nz-council/scripts/cli.py facilities --council qldc --type leisure-centre --json
+python3 skills/nz-council/scripts/cli.py pools --council nsn --json
+python3 skills/nz-council/scripts/cli.py facilities --council tdc --type leisure-centre --json
 ```
 
 ## Resources
@@ -120,6 +123,8 @@ python3 skills/nz-council/scripts/cli.py facilities --council qldc --type leisur
 - Wellington City pools and recreation centres use public `wellington.govt.nz` listing pages.
 - Rotorua Lakes pools and aquatic facilities use public `rotorualakescouncil.nz` recreation and park pages plus the CLM Rotorua Aquatic Centre operator pages.
 - New Plymouth pools use NPDC public pages for Todd Energy Aquatic Centre, Inglewood Pool, and Waitara Pool; Bell Block uses the public Methanex Bell Block Aquatic Centre site.
+- Nelson pools use the public Nelson City Council swimming pools page, which links to CLM detail pages for Riverside Pool and Nayland Park Pool.
+- Tasman facilities use public Tasman District Council swimming and sport/recreation pages for Richmond Aquatic Centre and Motueka Recreation Centre.
 - Hamilton pools use `hamiltonpools.co.nz`, a Hamilton City Council site, for Waterworld, Gallagher Aquatic Centre, and seasonal partner pool listings. The current Hamilton Pools source does not list Founders Memorial Theatre Pool as an active pool.
 - Hutt City pools use the Hutt City Pools and Fitness public site. Direct HTTP is Cloudflare-challenged in some environments, so the CLI probes direct HTTP first and can fall back to the local Chrome DevTools endpoint at `127.0.0.1:5100`.
 - Porirua Arena Aquatics uses the public Te Rauparaha Arena aquatic pages.

--- a/skills/nz-council/references/api-notes.md
+++ b/skills/nz-council/references/api-notes.md
@@ -21,6 +21,8 @@ Implemented as the primary event source.
 - List Wellington: `https://www.eventfinda.co.nz/whatson/events/wellington`
 - List Christchurch: `https://www.eventfinda.co.nz/whatson/events/christchurch`
 - List New Plymouth: `https://www.eventfinda.co.nz/whatson/events/new-plymouth`
+- List Nelson: `https://www.eventfinda.co.nz/whatson/events/nelson-region`
+- List Tasman: `https://www.eventfinda.co.nz/whatson/events/tasman-district`
 - List Whangarei: `https://www.eventfinda.co.nz/whatson/events/whangarei`
 - List Tauranga: `https://www.eventfinda.co.nz/whatson/events/tauranga`
 - List Queenstown Lakes: `https://www.eventfinda.co.nz/whatson/events/queenstown`
@@ -603,6 +605,43 @@ Useful fields observed:
 - QLDC pages link users to lane availability/bookings, but no anonymous public lane-availability payload is wired in v1.
 
 Freshness: source-linked snapshot from public QLDC pages. Users should follow the `source_url` before travel, especially for seasonal Arrowtown Memorial Pool and community pools.
+
+### Nelson City pools
+
+Implemented as council-sourced static facility records.
+
+- Council listing: `https://www.nelson.govt.nz/5community/2recreation/swimming-pools`
+- Operator detail pages linked by council:
+  - `https://www.clmnz.co.nz/riverside-swimming-pool/`
+  - `https://www.clmnz.co.nz/nayland-park-pool/`
+
+Observed pools:
+
+- Riverside Pool
+- Nayland Park Pool
+
+The Nelson council page states there are two council-owned pools. Riverside Pool is described as an indoor, all-year pool in central Nelson on Riverside Drive. Nayland Park Pool is described as a Stoke summer-season pool adjacent to Nayland College. CLM operator pages provide current opening hours, contact details, and facility features.
+
+Freshness: static records seeded from the council page and linked CLM detail pages. This avoids turning the CLI into a browser automation client while keeping links to current hours.
+
+### Tasman District recreation facilities
+
+Implemented as council-sourced static facility records.
+
+- Swimming listing: `https://www.tasman.govt.nz/my-region/recreation/beaches-and-swimming`
+- Sport/recreation listing: `https://www.tasman.govt.nz/my-region/recreation/sport-and-recreation-centres`
+- Richmond detail: `https://www.tasman.govt.nz/my-region/recreation/sport-and-recreation-centres/richmond-aquatic-centre`
+- Motueka detail: `https://www.tasman.govt.nz/my-region/recreation/sport-and-recreation-centres/motueka-recreation-centre`
+- Richmond operator page linked by council: `https://www.clmnz.co.nz/richmond/`
+
+Observed scoped facilities:
+
+- Richmond Aquatic Centre
+- Motueka Recreation Centre
+
+Direct `curl` fetches to `tasman.govt.nz` returned a Cloudflare interstitial during discovery. The content above was checked with the local CDP fallback browser at `127.0.0.1:5100`. The CLI intentionally does not depend on CDP or non-stdlib browser automation at runtime.
+
+Freshness: static records seeded from the council pages and linked operator page. Opening hours remain on linked detail/operator pages.
 
 ### Christchurch recreation and sport
 

--- a/skills/nz-council/scripts/cli.py
+++ b/skills/nz-council/scripts/cli.py
@@ -69,6 +69,9 @@ QLDC_SWIM_SOURCE = QLDC_BASE + "/recreation/swim/"
 DUD_BASE = "https://www.dunedin.govt.nz"
 DUD_POOLS_URL = DUD_BASE + "/community-facilities/swimming-pools"
 DUD_SPORTS_REVIEW_URL = DUD_BASE + "/community-facilities/parks-and-reserves/dunedin-sports-facilities-review"
+NSN_BASE = "https://www.nelson.govt.nz"
+TDC_BASE = "https://www.tasman.govt.nz"
+CLM_BASE = "https://www.clmnz.co.nz"
 
 UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146 Safari/537.36"
 
@@ -86,6 +89,8 @@ COUNCIL_LOCATIONS = {
     "tga": "tauranga",
     "qldc": "queenstown",
     "dud": "dunedin",
+    "nsn": "nelson-region",
+    "tdc": "tasman-district",
 }
 
 COUNCIL_NAMES = {
@@ -106,6 +111,8 @@ COUNCIL_NAMES = {
     "tga": "Tauranga",
     "qldc": "Queenstown Lakes",
     "dud": "Dunedin",
+    "nsn": "Nelson",
+    "tdc": "Tasman",
 }
 
 RECREATION_COUNCILS = (
@@ -114,6 +121,8 @@ RECREATION_COUNCILS = (
     "chc",
     "rot",
     "npl",
+    "nsn",
+    "tdc",
     "npr",
     "has",
     "ham",
@@ -332,6 +341,9 @@ NPL_POOL_FACILITIES = [
     },
 ]
 
+NSN_POOL_LISTING_URL = NSN_BASE + "/5community/2recreation/swimming-pools"
+TDC_SWIMMING_LISTING_URL = TDC_BASE + "/my-region/recreation/beaches-and-swimming"
+TDC_RECREATION_LISTING_URL = TDC_BASE + "/my-region/recreation/sport-and-recreation-centres"
 NPR_AQUATIC_SOURCE_URL = NPR_BASE + "/napier/facilities/napier-aquatic-centre/"
 HAS_SWIMMING_POOLS_URL = HAS_BASE + "/hastings/facilities/swimming-pools/"
 
@@ -535,6 +547,119 @@ STATIC_RECREATION_FACILITIES: dict[str, list[dict[str, Any]]] = {
                 "learn-to-swim pool",
                 "hydrotherapy pools",
                 "swim school",
+            ],
+        },
+    ],
+    "nsn": [
+        {
+            "name": "Riverside Pool",
+            "id": "riverside-pool",
+            "type": "pool",
+            "facility_types": ["pool", "gym", "leisure-centre"],
+            "council": "nsn",
+            "council_name": "Nelson",
+            "source": "nelson-city-council",
+            "source_url": CLM_BASE + "/riverside-swimming-pool/",
+            "listing_source_url": NSN_POOL_LISTING_URL,
+            "address": "25 Riverside Drive, Nelson",
+            "operator": "CLM",
+            "description": "Council-owned indoor pool and fitness facility in central Nelson with all-year access.",
+            "hours": None,
+            "hours_summary": "Open all year; current hours are published on the linked CLM page.",
+            "phone": "03 546 3221",
+            "email": "nelsonaquatics@clmnz.co.nz",
+            "features": [
+                "Lane swimming",
+                "Open swimming",
+                "Kids swimming",
+                "Spa pool",
+                "Swimming lessons",
+                "Fitness centre",
+                "Aquafitness classes",
+            ],
+        },
+        {
+            "name": "Nayland Park Pool",
+            "id": "nayland-park-pool",
+            "aliases": ["nayland-pool"],
+            "type": "pool",
+            "facility_types": ["pool"],
+            "council": "nsn",
+            "council_name": "Nelson",
+            "source": "nelson-city-council",
+            "source_url": CLM_BASE + "/nayland-park-pool/",
+            "listing_source_url": NSN_POOL_LISTING_URL,
+            "address": "192 Nayland Park, Nelson",
+            "operator": "CLM",
+            "description": "Council-owned community summer pool in Stoke, adjacent to Nayland College.",
+            "hours": None,
+            "hours_summary": "Open for the summer season; current hours are published on the linked CLM page.",
+            "phone": "03 547 0292",
+            "email": "naylandpark@clmnz.co.nz",
+            "features": [
+                "50 metre lane pool",
+                "Toddlers pool",
+                "Teaching pool",
+                "Diving boards",
+            ],
+        },
+    ],
+    "tdc": [
+        {
+            "name": "Richmond Aquatic Centre",
+            "id": "richmond-aquatic-centre",
+            "type": "pool",
+            "facility_types": ["pool", "gym", "leisure-centre"],
+            "council": "tdc",
+            "council_name": "Tasman",
+            "source": "tasman-district-council",
+            "source_url": TDC_RECREATION_LISTING_URL + "/richmond-aquatic-centre",
+            "listing_source_url": TDC_SWIMMING_LISTING_URL,
+            "address": "161 Salisbury Road, Richmond, Nelson",
+            "operator": "CLM",
+            "operator_url": CLM_BASE + "/richmond/",
+            "description": "Tasman public year-round aquatic and fitness centre with lane, wave, hydrotherapy, spa, tots, and learn-to-swim pools.",
+            "hours": None,
+            "hours_summary": "Open all year; current hours are published on the linked CLM page.",
+            "phone": "03 543 9755",
+            "email": "aru@clmnz.co.nz",
+            "features": [
+                "25m lane pool",
+                "Wave pool",
+                "Lazy river",
+                "Spa pools",
+                "Hydrotherapy pool",
+                "Sauna",
+                "Tots pool",
+                "Learn to swim pool",
+                "Fitness centre",
+            ],
+        },
+        {
+            "name": "Motueka Recreation Centre",
+            "id": "motueka-recreation-centre",
+            "type": "leisure-centre",
+            "facility_types": ["leisure-centre", "gym"],
+            "council": "tdc",
+            "council_name": "Tasman",
+            "source": "tasman-district-council",
+            "source_url": TDC_RECREATION_LISTING_URL + "/motueka-recreation-centre",
+            "listing_source_url": TDC_RECREATION_LISTING_URL,
+            "address": "40 Old Wharf Road, Motueka, Tasman",
+            "operator": "Sport Tasman",
+            "description": "Multi-purpose recreation facility with an office space, fitness lounge, theatre facility, stadium, games room, skating rink, netball courts, and climbing wall.",
+            "hours": None,
+            "hours_note": "Opening details are published by the linked Tasman District Council and operator pages.",
+            "phone": "03 528 8228",
+            "email": "MRC@sporttasman.org.nz",
+            "features": [
+                "Fitness lounge",
+                "Theatre facility",
+                "Stadium",
+                "Games room",
+                "Skating rink",
+                "Netball courts",
+                "Climbing wall",
             ],
         },
     ],
@@ -2103,15 +2228,22 @@ def fetch_npl_facilities(kind: str) -> tuple[list[dict[str, Any]], str]:
 
 
 def static_recreation_facilities(council: str, kind: str | None = None) -> tuple[list[dict[str, Any]], str]:
-    source_url = {"npr": NPR_AQUATIC_SOURCE_URL, "has": HAS_SWIMMING_POOLS_URL}.get(council, "")
+    source_url = {
+        "npr": NPR_AQUATIC_SOURCE_URL,
+        "has": HAS_SWIMMING_POOLS_URL,
+        "nsn": NSN_POOL_LISTING_URL,
+        "tdc": TDC_SWIMMING_LISTING_URL if kind == "pool" else TDC_RECREATION_LISTING_URL,
+    }.get(council, "")
     facilities: list[dict[str, Any]] = []
     for item in STATIC_RECREATION_FACILITIES.get(council, []):
-        item_type = item.get("type")
-        if kind == "pool" and item_type not in {"pool", "water-park", "aquatic-centre"}:
+        item_types = set(item.get("facility_types") or item.get("types") or [item.get("type")])
+        if kind == "pool" and not item_types.intersection({"pool", "water-park", "aquatic-centre"}):
             continue
-        if kind and kind != "pool" and item_type != kind:
+        if kind and kind != "pool" and kind not in item_types:
             continue
         facility = dict(item)
+        if council == "tdc" and kind != "pool":
+            facility["listing_source_url"] = TDC_RECREATION_LISTING_URL
         facility["id"] = facility.get("id") or slug_text(str(facility.get("name") or ""))
         facilities.append(facility)
     return facilities, source_url
@@ -3899,7 +4031,7 @@ def pool_detail_for_council(council: str, name: str) -> tuple[dict[str, Any] | N
             "facility": card,
             "lane_availability_today": None,
         }, listing_url, []
-    if council in {"npr", "has"}:
+    if council in {"npr", "has", "nsn", "tdc"}:
         cards, listing_url = static_recreation_facilities(council, "pool")
         card = find_facility(cards, name)
         if not card:
@@ -3989,7 +4121,7 @@ def cmd_pools(args: argparse.Namespace) -> None:
             die("--region is only supported for Auckland pools")
         pools, source_url = fetch_npl_facilities("pool")
         pools = pools[: args.limit]
-    elif args.council in {"npr", "has"}:
+    elif args.council in {"npr", "has", "nsn", "tdc"}:
         if args.region:
             die("--region is only supported for Auckland pools")
         pools, source_url = static_recreation_facilities(args.council, "pool")
@@ -4048,7 +4180,7 @@ def cmd_pools(args: argparse.Namespace) -> None:
 
 def cmd_pool(args: argparse.Namespace) -> None:
     started = time.perf_counter()
-    councils = [args.council] if args.council else ["dud", "qldc", "whg", "npr", "has", "npl", "rot", "akl", "tga", "wlg", "ham", "hutt", "porirua", "uhutt", "kapiti", "chc", "pmn"]
+    councils = [args.council] if args.council else ["dud", "qldc", "whg", "npr", "has", "npl", "nsn", "tdc", "rot", "akl", "tga", "wlg", "ham", "hutt", "porirua", "uhutt", "kapiti", "chc", "pmn"]
     suggestions_by_council: list[str] = []
     for council in councils:
         detail, listing_url, suggestions = pool_detail_for_council(council, args.name)
@@ -4114,12 +4246,14 @@ def cmd_facilities(args: argparse.Namespace) -> None:
             if args.type == "gym":
                 note = "Rotorua Aquatic Centre includes a gym; linked operator pages have current programme details."
         facilities = facilities[: args.limit]
-    elif args.council in {"npr", "has"}:
+    elif args.council in {"npr", "has", "nsn", "tdc"}:
         if args.region:
             die("--region is only supported for Auckland facilities")
         facilities, source_url = static_recreation_facilities(args.council, args.type)
         note = None
-        if args.type != "pool":
+        if args.type == "library":
+            note = "Libraries are outside this skill's recreation-focused data source."
+        elif args.council in {"npr", "has"} and args.type != "pool":
             note = f"{COUNCIL_NAMES[args.council]} recreation support currently covers aquatic facilities only."
         facilities = facilities[: args.limit]
     elif args.council == "npl":


### PR DESCRIPTION
## Sources

- Nelson City Council swimming pools: https://www.nelson.govt.nz/5community/2recreation/swimming-pools
- Riverside Pool CLM detail: https://www.clmnz.co.nz/riverside-swimming-pool/
- Nayland Park Pool CLM detail: https://www.clmnz.co.nz/nayland-park-pool/
- Tasman swimming listing: https://www.tasman.govt.nz/my-region/recreation/beaches-and-swimming
- Tasman sport/recreation listing: https://www.tasman.govt.nz/my-region/recreation/sport-and-recreation-centres
- Richmond Aquatic Centre detail: https://www.tasman.govt.nz/my-region/recreation/sport-and-recreation-centres/richmond-aquatic-centre
- Richmond Aquatic Centre CLM detail: https://www.clmnz.co.nz/richmond/
- Motueka Recreation Centre detail: https://www.tasman.govt.nz/my-region/recreation/sport-and-recreation-centres/motueka-recreation-centre

Tasman direct fetch returned a Cloudflare interstitial during discovery, so the Tasman council pages were verified through the requested local CDP fallback at `127.0.0.1:5100`. Runtime CLI data remains stdlib-only and does not require CDP.

## Sample Output

- `pools --council nsn --json`: returns Riverside Pool and Nayland Park Pool.
- `pools --council tdc --json`: returns Richmond Aquatic Centre.
- `facilities --council tdc --type leisure-centre --json`: returns Richmond Aquatic Centre and Motueka Recreation Centre.
- `pool "Riverside Pool" --json`: returns Nelson/Riverside detail with address `25 Riverside Drive, Nelson`, phone `03 546 3221`, and CLM source URL.

## Validation

- `python3 -m py_compile skills/nz-council/scripts/cli.py`
- `python3 skills/nz-council/scripts/cli.py pools --council nsn --json`
- `python3 skills/nz-council/scripts/cli.py pools --council tdc --json`
- `python3 skills/nz-council/scripts/cli.py pool 'Riverside Pool' --json`
- `python3 skills/nz-council/scripts/cli.py facilities --council tdc --type leisure-centre --json`
- `python3 skills/nz-council/scripts/cli.py pool 'No Such Pool' --council nsn --json`
- `python3 skills/nz-council/scripts/cli.py pools --council rot --limit 1 --json`
- `python3 skills/nz-council/scripts/cli.py pool 'Tepid Baths' --json`
- `python3 skills/nz-council/scripts/cli.py pools --council wlg --limit 1 --json`
