### PR TITLE
fix(homes-nz): restore suburb command after upstream endpoint regression

### DIFF
--- a/skills/homes-nz/references/api-notes.md
+++ b/skills/homes-nz/references/api-notes.md
@@ -35,6 +35,7 @@ The CLI sends browser-like `Accept`, `Referer`, `Origin`, and `User-Agent` heade
 - `GET /map/radius/addresses` was present in the bundle but returned `could not parse request body` for direct no-login reproduction, so `nearby` uses `GET /map/items` with a bounding box instead.
 - `GET /suburb/estimate_history/{id}` was present in the bundle and returned JSON, but direct live checks produced inconsistent values for known suburbs. The CLI uses the query form, which matched the expected suburb market levels in live verification.
 - No no-login suburb sales-volume aggregate was verified. The `suburb` command reports the available suburb property count from typeahead, HomesEstimate trend, and median rent estimate.
+- **API drift (observed ~mid-2025, suburb resolution):** `GET /address/search` returns only `Type: 1` (city-level) rows when the query combines a suburb name with a city name (e.g. "Ponsonby Auckland", "Kelburn Wellington"). This broke `resolve_suburb`, which could not find a `SuburbID` in results. The fix applies the same trailing-word-stripping fallback already used by the `address` command: if the full query yields no result with a `SuburbID`, progressively strip trailing words and retry until a `Type: 2` suburb row is returned or a single word remains. `GET /median_suburb_rent_estimate?id={suburb_id}` was also reported as intermittently returning HTTP 500 around the same period but has since recovered; it remains the live rent-estimate endpoint and is verified working as of May 2026.
 
 ## Stability and safety
 

--- a/skills/homes-nz/scripts/cli.py
+++ b/skills/homes-nz/scripts/cli.py
@@ -465,16 +465,42 @@ def cmd_property(args: argparse.Namespace) -> None:
 
 
 def resolve_suburb(value: str) -> dict[str, Any]:
+    """Resolve a suburb name (or numeric id) to its search result dict.
+
+    When the query includes a city qualifier (e.g. "Ponsonby Auckland") the
+    address/search endpoint often returns only Type=1 city-level rows.  We
+    apply the same trailing-word-stripping fallback used by the address command:
+    strip the last word iteratively until we get a Type=2 suburb row, or until
+    only a single word remains.
+    """
     if value.isdigit():
         return {"SuburbID": int(value), "Title": value}
-    payload = request_json(BASE_GATEWAY, "/address/search", {"Address": value})
-    results = [x for x in (payload or {}).get("Results") or [] if isinstance(x, dict)]
-    for item in results:
-        if item.get("Type") == 2 and item.get("SuburbID"):
-            return item
-    for item in results:
-        if item.get("SuburbID"):
-            return item
+
+    def _search_for_suburb(query: str) -> dict[str, Any] | None:
+        payload = request_json(BASE_GATEWAY, "/address/search", {"Address": query})
+        results = [x for x in (payload or {}).get("Results") or [] if isinstance(x, dict)]
+        for item in results:
+            if item.get("Type") == 2 and item.get("SuburbID"):
+                return item
+        for item in results:
+            if item.get("SuburbID"):
+                return item
+        return None
+
+    # First attempt with the full query.
+    result = _search_for_suburb(value)
+    if result:
+        return result
+
+    # If that failed (e.g. all results were Type=1 city rows), progressively
+    # strip trailing words and retry — same strategy as address command.
+    words = value.split()
+    while len(words) > 1:
+        words = words[:-1]
+        result = _search_for_suburb(" ".join(words))
+        if result:
+            return result
+
     die(f"no suburb id found for {value!r}")
 
 

--- a/skills/homes-nz/scripts/smoke_test.py
+++ b/skills/homes-nz/scripts/smoke_test.py
@@ -11,6 +11,14 @@ CLI = SKILL_DIR / "scripts" / "cli.py"
 REGRESSION_ADDRESS = "65 Riverside Drive Whangarei"
 REGRESSION_PROPERTY_ID = "c1bf1078-9c44-4f03-b9e0-b2ada7a4f992"
 
+# Suburb regression tests: these use "SuburbName CityName" format which
+# previously triggered a bug where resolve_suburb returned no results.
+SUBURB_TESTS = [
+    ("Riverside Whangarei", 1413),
+    ("Ponsonby Auckland", 1279),
+    ("Kelburn Wellington", 670),
+]
+
 
 def run(args: list) -> subprocess.CompletedProcess:
     return subprocess.run(
@@ -111,6 +119,44 @@ def test_nearby():
 
 
 results.append(test(f"nearby {REGRESSION_PROPERTY_ID} returns comparables[]", test_nearby))
+
+
+def make_suburb_test(name_or_id: str, expected_suburb_id: int):
+    def _test():
+        result = run(["suburb", name_or_id, "--json"])
+        if result.returncode != 0:
+            print(f"  stderr: {result.stderr[:200]}")
+            return False
+        data = json.loads(result.stdout)
+        sub = data.get("suburb")
+        if not isinstance(sub, dict):
+            print(f"  stdout: {result.stdout[:200]}")
+            print("  Expected suburb{} in response")
+            return False
+        got_id = sub.get("suburb_id")
+        if got_id != expected_suburb_id:
+            print(f"  Expected suburb_id {expected_suburb_id}, got {got_id}")
+            return False
+        if not sub.get("title"):
+            print("  Missing suburb title")
+            return False
+        latest = data.get("latest_median_estimate") or {}
+        if latest.get("estimate") is None:
+            print("  Missing latest_median_estimate.estimate")
+            return False
+        rent = data.get("median_rent_estimate") or {}
+        if rent.get("estimate") is None:
+            print("  Missing median_rent_estimate.estimate")
+            return False
+        return True
+    return _test
+
+
+for suburb_name, suburb_id in SUBURB_TESTS:
+    results.append(test(
+        f"suburb '{suburb_name}' returns suburb_id={suburb_id} with estimate and rent",
+        make_suburb_test(suburb_name, suburb_id),
+    ))
 
 if all(results):
     print("All tests passed.")


### PR DESCRIPTION
## Summary
- The `suburb` command was broken: `python3 cli.py suburb "Riverside Whangarei" --json` exited with `no suburb id found for 'Riverside Whangarei'`
- Root cause was in `resolve_suburb`, not in `median_suburb_rent_estimate` — though that endpoint was also reported as intermittently returning HTTP 500
- Fixed `resolve_suburb` to apply the same trailing-word-stripping fallback already present in the `address` command
- Updated `smoke_test.py` to properly test the `suburb` command (3 suburbs, city-qualified names)
- Updated `api-notes.md` to document the regression and the fix

## Root cause
`GET /address/search` (the typeahead endpoint used to resolve a suburb name to its SuburbID) now returns **only `Type: 1` city-level rows** when the query combines a suburb name with a city name (e.g. `"Ponsonby Auckland"`, `"Kelburn Wellington"`, `"Riverside Whangarei"`). The `address` command already had a fix for this behaviour (trailing-word-stripping), but `resolve_suburb` — used exclusively by the `suburb` command — did not. So any city-qualified suburb query failed with `no suburb id found`.

The `median_suburb_rent_estimate` endpoint (`GET https://gateway.homes.co.nz/median_suburb_rent_estimate?id=<id>`) was reportedly returning HTTP 500 but is verified working as of May 2026 (returns `{"estimate":573.5,"date":"2026-05-02T00:00:00Z"}` for Riverside). No change to that endpoint was needed.

## Fix
Added a `_search_for_suburb(query)` helper inside `resolve_suburb`. If the full query returns no result with a `SuburbID`, the function progressively strips trailing words and retries (same strategy as `address`). This resolves all three city-qualified suburb names correctly:
- `"Riverside Whangarei"` → SuburbID 1413 (strips "Whangarei", retries with "Riverside")
- `"Ponsonby Auckland"` → SuburbID 1279
- `"Kelburn Wellington"` → SuburbID 670

## Smoke test outcomes
All 7 smoke tests pass:
- **Riverside Whangarei**: suburb_id=1413, median estimate 685K (2026-05-14), median rent $573.50/wk
- **Ponsonby Auckland**: suburb_id=1279, median estimate 2.21M (2026-05-14), median rent $1050/wk
- **Kelburn Wellington**: suburb_id=670, median estimate 1.27M (2026-05-14), median rent $820/wk

## Residual risk
- If the upstream `GET /address/search` further tightens its behaviour so that even a bare suburb name returns only city rows, the stripping loop would exhaust all words and still fail. This seems unlikely but is the same risk already accepted for the `address` command.
- `median_suburb_rent_estimate` has shown intermittent 500s; if it starts failing again the `median_rent_estimate` field will be `{"date": null, "estimate": null}` rather than crashing (the `suburb()` function tolerates a null `rent_payload`).
- No new dependencies added; stdlib only.

🤖 Generated with Claude Code