### PR TITLE
ci: add smoke-test workflow with matrix per skill

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,86 @@
+name: Smoke Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+  schedule:
+    - cron: "0 19 * * *"  # 07:00 NZST (UTC+12)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare:
+    name: Discover skills
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.discover.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Discover skills with smoke tests
+        id: discover
+        run: |
+          matrix=$(find skills -path "*/scripts/smoke_test.py" -type f \
+            | sed 's|skills/||;s|/scripts/smoke_test.py||' \
+            | sort \
+            | jq -R . \
+            | jq -cs .)
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+          echo "Found skills: $matrix"
+
+  smoke:
+    name: smoke (${{ matrix.skill }})
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        skill: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Run smoke test
+        run: python3 skills/${{ matrix.skill }}/scripts/smoke_test.py
+
+  summary:
+    name: Summary
+    needs: [prepare, smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write job summary
+        run: |
+          echo "## Smoke Test Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Skill | Status |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|--------|" >> "$GITHUB_STEP_SUMMARY"
+
+          matrix='${{ needs.prepare.outputs.matrix }}'
+          overall='${{ needs.smoke.result }}'
+
+          # Emit one row per skill — individual job outcomes are not
+          # available in the summary context, so we report the aggregate
+          # smoke result for each skill and note the limitation.
+          echo "$matrix" | jq -r '.[]' | while read -r skill; do
+            case "$overall" in
+              success)  status="✅ pass" ;;
+              failure)  status="❌ fail" ;;
+              cancelled) status="⏹ cancelled" ;;
+              *)        status="⚠️ $overall" ;;
+            esac
+            echo "| \`$skill\` | $status |" >> "$GITHUB_STEP_SUMMARY"
+          done
+
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "> **Note:** Individual per-skill outcomes are not accessible" >> "$GITHUB_STEP_SUMMARY"
+          echo "> from the summary job in GitHub Actions — the status above" >> "$GITHUB_STEP_SUMMARY"
+          echo "> reflects the overall matrix result (\`$overall\`)." >> "$GITHUB_STEP_SUMMARY"
+          echo "> Expand the individual \`smoke (<skill>)\` jobs in the sidebar" >> "$GITHUB_STEP_SUMMARY"
+          echo "> for per-skill pass/fail detail." >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # thecolab-ai/.skills
 
+![Smoke Tests](https://github.com/thecolab-ai/.skills/actions/workflows/smoke-tests.yml/badge.svg)
+
 Community-contributed AI skills for useful New Zealand-specific data and workflows.
 
 Point your agent at real NZ infrastructure, public datasets, market data, industry feeds, transport APIs, pricing sources, weather services, and other useful local information.


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/smoke-tests.yml` with a three-job CI pipeline that discovers and runs every skill's `smoke_test.py` in parallel
- Adds a workflow status badge to `README.md`

## Triggers

- `workflow_dispatch` — run manually from the GitHub Actions UI at any time
- `pull_request` — runs on every PR to catch regressions before merge
- `schedule: "0 19 * * *"` — daily at 19:00 UTC (07:00 NZST) to catch upstream API drift
- **No `push: branches: [main]`** — avoids double-runs on merged PRs

## How it works

### Job 1 — `prepare` (dynamic matrix discovery)
```bash
find skills -path "*/scripts/smoke_test.py" -type f \
  | sed 's|skills/||;s|/scripts/smoke_test.py||' \
  | sort \
  | jq -R . | jq -cs .
```
Outputs a JSON array of skill names (currently 35) as the `matrix` job output.

### Job 2 — `smoke` (parallel matrix)
- One job per skill: `smoke (<skill-name>)` — failures show the skill name directly in the GH Actions sidebar
- `strategy.fail-fast: false` — all skills run even if one fails
- `timeout-minutes: 5` per skill
- Python 3.12, stdlib only — no extra deps needed; smoke tests skip cleanly when API keys are absent

### Job 3 — `summary` (`if: always()`)
Writes a markdown table to `$GITHUB_STEP_SUMMARY` listing every skill and its status.

> **Limitation:** GitHub Actions does not expose per-matrix-job outcomes to downstream jobs — only the aggregate `needs.smoke.result` is available. The summary table therefore shows the overall matrix result for each skill. Per-skill pass/fail is visible by expanding individual `smoke (<skill>)` jobs in the sidebar.

## Concurrency
```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```
Redundant runs on the same ref are cancelled automatically.

## How to run manually

1. Go to **Actions → Smoke Tests → Run workflow**
2. Select branch and click **Run workflow**
3. Watch the `smoke (<skill>)` matrix expand — failed skills appear in red immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)