### PR TITLE
ci: add daily smoke test workflow for all skills

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,0 +1,144 @@
+name: Smoke Tests
+
+on:
+  workflow_dispatch:
+  schedule:
+    # 06:00 NZST daily (UTC+12 → 18:00 UTC previous day)
+    - cron: '0 18 * * *'
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      skills: ${{ steps.list.outputs.skills }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - id: list
+        name: List skill directories
+        run: |
+          skills=$(ls skills/ | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().split()))")
+          echo "skills=$skills" >> "$GITHUB_OUTPUT"
+
+  smoke:
+    needs: discover
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        skill: ${{ fromJson(needs.discover.outputs.skills) }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run smoke test — ${{ matrix.skill }}
+        id: test
+        run: |
+          set +e
+          output=$(uv run --no-project python "skills/${{ matrix.skill }}/scripts/smoke_test.py" 2>&1)
+          exit_code=$?
+          echo "$output"
+
+          skip_count=$(echo "$output" | grep -c '\[SKIP\]' || echo 0)
+
+          if [ "$exit_code" -ne 0 ]; then
+            result=FAIL
+          elif [ "$skip_count" -gt 0 ]; then
+            result=SKIP
+          else
+            result=PASS
+          fi
+
+          mkdir -p /tmp/smoke-results
+          echo "$result" > "/tmp/smoke-results/${{ matrix.skill }}.txt"
+
+          {
+            if [ "$result" = FAIL ]; then
+              printf "## ❌ %s\n\n\`\`\`\n%s\n\`\`\`\n\n" "${{ matrix.skill }}" "$output"
+            elif [ "$result" = SKIP ]; then
+              printf "## ⏭️ %s (skipped — missing API key)\n\n" "${{ matrix.skill }}"
+            else
+              printf "## ✅ %s\n\n" "${{ matrix.skill }}"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          exit "$exit_code"
+
+      - name: Upload result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-result-${{ matrix.skill }}
+          path: /tmp/smoke-results/${{ matrix.skill }}.txt
+          if-no-files-found: warn
+
+  report:
+    needs: smoke
+    runs-on: ubuntu-latest
+    if: always()
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: smoke-result-*
+          path: /tmp/results
+          merge-multiple: true
+
+      - name: Summarise results
+        run: |
+          pass=0; skip=0; fail=0
+          failed_skills=(); skip_skills=()
+
+          shopt -s nullglob
+          for f in /tmp/results/*.txt; do
+            skill=$(basename "$f" .txt)
+            result=$(cat "$f")
+            case "$result" in
+              PASS) pass=$((pass+1)) ;;
+              SKIP) skip=$((skip+1)); skip_skills+=("$skill") ;;
+              FAIL) fail=$((fail+1)); failed_skills+=("$skill") ;;
+            esac
+          done
+
+          total=$((pass+skip+fail))
+
+          {
+            echo "## 🥝 Smoke Test Summary"
+            echo ""
+            echo "| Status | Count |"
+            echo "|--------|-------|"
+            echo "| ✅ Passed | $pass |"
+            echo "| ⏭️ Skipped (missing API key) | $skip |"
+            echo "| ❌ Failed | $fail |"
+            echo "| **Total** | **$total** |"
+
+            if [ ${#skip_skills[@]} -gt 0 ]; then
+              echo ""
+              echo "### Skipped (missing API key)"
+              for s in "${skip_skills[@]}"; do
+                echo "- \`$s\`"
+              done
+            fi
+
+            if [ ${#failed_skills[@]} -gt 0 ]; then
+              echo ""
+              echo "### Failed"
+              for s in "${failed_skills[@]}"; do
+                echo "- \`$s\`"
+              done
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          echo "Pass: $pass | Skip: $skip | Fail: $fail"
+          if [ "$total" -eq 0 ]; then
+            echo "WARNING: no result files found — artifacts may not have uploaded"
+            exit 1
+          fi
+          if [ ${#failed_skills[@]} -gt 0 ]; then
+            echo "FAILED: ${failed_skills[*]}"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/smoke-tests.yml` that runs every skill's `smoke_test.py` daily at 06:00 NZST (18:00 UTC) and on `workflow_dispatch`
- Dynamic matrix — each of the 35 skills gets its own job with `continue-on-error: true` so one failure doesn't block visibility into others
- Skills missing API keys (`AT_API_KEY`, `METLINK_API_KEY`, `METOCEAN_API_KEY`) are reported as **SKIP** rather than FAIL — the smoke tests already handle this internally
- A final `report` job aggregates pass/skip/fail counts and lists failing skills in the GitHub Step Summary

## Trigger notes

- ✅ `workflow_dispatch` — manual trigger
- ✅ `schedule` — daily cron `0 18 * * *`
- ❌ No push trigger (intentional)

## Test plan

- [ ] Merge to main
- [ ] Run `gh workflow run smoke-tests.yml` and verify all 35 skill jobs appear
- [ ] Check Step Summary shows pass/skip/fail counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)