### PR TITLE
ci: run smoke tests on self-hosted residential runner

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   discover:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, skills-smoke]
     outputs:
       skills: ${{ steps.list.outputs.skills }}
     steps:
@@ -22,7 +22,7 @@ jobs:
 
   smoke:
     needs: discover
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, skills-smoke]
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -79,7 +79,7 @@ jobs:
 
   report:
     needs: smoke
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64, skills-smoke]
     if: always()
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
## Why

GitHub Actions hosted runners run from known Microsoft/GitHub datacenter IP ranges. Cloudflare blocks these IPs with anti-bot challenges (403/429/CAPTCHA) for several NZ retail and utility sites:

- `bunnings`
- `mitre10-nz`
- `the-warehouse-nz`
- `woolworths-nz`
- `eventfinda-nz`
- `auckland-bin-schedule`

By routing requests through a residential IP, these sites respond normally and smoke tests can run to completion.

## Where the runner lives

- **Host:** dreamteam (Ubuntu, residential IP)
- **Service:** systemd user service — `actions-runner-skills.service` (runs as `adam`, survives reboots via `loginctl linger`)
- **Install path:** `/home/adam/actions-runner-skills`
- **Label:** `skills-smoke` (used to pin only this workflow to this runner)
- **Runner name:** `dreamteam-skills`

## What changed

All three jobs (`discover`, `smoke`, `report`) now use:

```yaml
runs-on: [self-hosted, linux, x64, skills-smoke]
```

Everything else is identical — same triggers (schedule, dispatch), same matrix, same steps, same `setup-uv` action, same status checks.

## If the runner dies

Re-register with a fresh token:

```bash
cd /home/adam/actions-runner-skills
TOKEN=$(gh api -X POST /repos/thecolab-ai/.skills/actions/runners/registration-token --jq .token)
./config.sh --url https://github.com/thecolab-ai/.skills --token "$TOKEN" --name dreamteam-skills --labels skills-smoke --unattended --replace
systemctl --user restart actions-runner-skills.service
```

To deregister entirely: `./config.sh remove --token <token>` then `systemctl --user disable --now actions-runner-skills.service`.