### PR TITLE
ci: run smoke tests on every push to main

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -2,6 +2,8 @@ name: Smoke Tests
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
   schedule:
     # 06:00 NZST daily (UTC+12 → 18:00 UTC previous day)
     - cron: '0 18 * * *'


### PR DESCRIPTION
Adds `push` to `main` as a trigger so the smoke run kicks off on every merge, not just the daily cron and manual dispatch.