### PR TITLE
Add Wellington bin schedule skill

### DIFF
--- a/skills/wellington-bin-schedule/SKILL.md
+++ b/skills/wellington-bin-schedule/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: wellington-bin-schedule
+description: Query Wellington City Council rubbish and recycling collection days using a WCC street ID. Use when the task involves Wellington bin day, rubbish/recycling schedules, or kerbside collection for a Wellington address. Requires a WCC street ID (found by searching your address on the WCC collection-day page). No account login required.
+---
+
+# Wellington Bin Schedule
+
+## Goal
+
+Query live Wellington City Council household rubbish and recycling collection schedules through a deterministic CLI with human-readable and JSON output.
+
+Wellington combines **rubbish and recycling (glass crate) on the same collection day** — there is no separate recycling week.
+
+## Use this when
+
+- A user asks when Wellington bins go out
+- A user wants the next rubbish or recycling collection date for a Wellington street
+- A workflow needs machine-readable Wellington City Council collection schedule data
+
+## Do not use this for
+
+- Councils outside Wellington City (try Auckland, Christchurch, or other council skills)
+- Food scraps / organics collection (Wellington does not offer kerbside organics)
+- Commercial or private collection schedules not shown on WCC's page
+- Finding a street ID — the user must obtain this from the WCC website
+
+## Preferred workflow
+
+1. Ask the user for their WCC street ID if not provided (they can find it at `https://wellington.govt.nz/rubbish-recycling-and-waste/when-to-put-out-your-rubbish-and-recycling`)
+2. Run `scripts/cli.py --street-id <id>` with an optional street name for display
+3. Use `--json` for agent chaining, comparisons, alerts, or structured reports
+4. Note that **rubbish and recycling are collected together** in Wellington
+
+## CLI
+
+Run with:
+
+```bash
+python3 skills/wellington-bin-schedule/scripts/cli.py --street-id <id> [street name...] [flags]
+```
+
+### Arguments
+
+- `--street-id <id>` — **(required)** WCC street ID (numeric), e.g. `6317`
+- `street name` — optional display name, e.g. `Awa Road, Karaka Bays`
+- `--json` — emit JSON
+
+Examples:
+
+```bash
+python3 skills/wellington-bin-schedule/scripts/cli.py --street-id 6317
+python3 skills/wellington-bin-schedule/scripts/cli.py --street-id 6317 "Awa Road, Karaka Bays"
+python3 skills/wellington-bin-schedule/scripts/cli.py --street-id 6317 --json
+```
+
+## Finding your street ID
+
+1. Visit `https://wellington.govt.nz/rubbish-recycling-and-waste/when-to-put-out-your-rubbish-and-recycling`
+2. Search for your street name
+3. The street ID appears in the URL parameter `?streetId=` after selecting your street
+4. Use that ID with `--street-id`
+
+## Resources
+
+- CLI entrypoint: `scripts/cli.py`
+- API and stability notes: `references/api-notes.md`
+
+## Notes
+
+- No API key, username, password, or cookie is required
+- Rubbish and recycling are **always collected on the same day** in Wellington
+- Wellington does not have a kerbside food scraps / organics collection
+- Dates are current Council snapshots, not historical records
+- Public holidays may shift collection dates — the CLI reflects the current Council page
+- The street autocomplete API requires ASP.NET authentication and is not accessible programmatically
+- Treat dates as live current snapshots, not guaranteed future schedules

--- a/skills/wellington-bin-schedule/references/api-notes.md
+++ b/skills/wellington-bin-schedule/references/api-notes.md
@@ -1,0 +1,48 @@
+# Wellington Bin Schedule API notes
+
+This skill is an unofficial wrapper around the public Wellington City Council collection-day component used by the website.
+
+## Source and auth
+
+- Collection-day search page: `https://wellington.govt.nz/rubbish-recycling-and-waste/when-to-put-out-your-rubbish-and-recycling`
+- Collection results component: `https://wellington.govt.nz/rubbish-recycling-and-waste/when-to-put-out-your-rubbish-and-recycling/components/collection-search-results`
+- Street autocomplete endpoint: `https://wellington.govt.nz/layouts/wcc/GeneralLayout.aspx/GetRubbishCollectionStreets`
+- Auth model: **no credentials required** for the collection results endpoint
+
+## Endpoint details
+
+### Collection results (`components/collection-search-results`)
+
+- **Method:** POST
+- **Content-Type:** `application/x-www-form-urlencoded`
+- **Body:** `streetId=<id>&streetName=<name>`
+- **Response:** HTML fragment with collection schedule
+- **Required headers:**
+  - `Origin: https://wellington.govt.nz`
+  - `Referer: https://wellington.govt.nz/rubbish-recycling-and-waste/when-to-put-out-your-rubbish-and-recycling`
+
+The response HTML contains:
+- Street name in an `<h3>` heading
+- Collection date in `<p class="collection-date h2 mt-2">` — format: "Friday, 29 May"
+- Put-out time in `<span class="nowrap">` — preceded by "out before"
+- Collected items as `<li>` elements with CSS classes `recycling-icon-rubbish` and `recycling-icon-glass`
+
+### Street autocomplete (`GetRubbishCollectionStreets`)
+
+This ASP.NET ASMX endpoint requires server-side authentication (returns HTTP 401 for all programmatic requests) and **cannot be used**. Users must obtain their street ID from the WCC website directly.
+
+## Wellington collection model
+
+Unlike Auckland, Wellington collects **rubbish and recycling on the same day**:
+- Rubbish (red-lid wheelie bin or official bags)
+- Recycling (glass crate only — no mixed recycling bin)
+
+There is **no kerbside food scraps / organics collection** in Wellington.
+
+## Stability and safety
+
+- Treat dates as live current snapshots from WCC, not historical or guaranteed data
+- Public holidays can shift collection dates
+- The component endpoint is a Sitecore rendering — its path and response shape could change
+- Avoid high-volume scraping; rate-limit requests
+- Do not use this skill for account changes or service requests

--- a/skills/wellington-bin-schedule/scripts/cli.py
+++ b/skills/wellington-bin-schedule/scripts/cli.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Check Wellington City Council rubbish and recycling collection schedules."""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.parse
+import urllib.request
+from html.parser import HTMLParser
+from typing import Any
+
+COLLECTION_URL = "https://wellington.govt.nz/rubbish-recycling-and-waste/when-to-put-out-your-rubbish-and-recycling/components/collection-search-results"
+MAIN_PAGE = "https://wellington.govt.nz/rubbish-recycling-and-waste/when-to-put-out-your-rubbish-and-recycling"
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
+
+def fetch_text(
+    url: str, headers: dict[str, str] | None = None,
+    data: bytes | None = None, timeout: int = 30
+) -> str:
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": UA, **(headers or {})},
+        data=data,
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read().decode("utf-8", "replace")
+
+
+def get_collection(street_id: str, street_name: str) -> dict[str, Any]:
+    """Fetch and parse Wellington collection schedule for a street."""
+    form_data = urllib.parse.urlencode({
+        "streetId": street_id,
+        "streetName": street_name,
+    }).encode("utf-8")
+
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded",
+        "Accept": "text/html,application/xhtml+xml",
+        "Origin": "https://wellington.govt.nz",
+        "Referer": MAIN_PAGE,
+    }
+
+    html = fetch_text(COLLECTION_URL, headers=headers, data=form_data)
+
+    # Extract street name from the response heading
+    title_m = re.search(r"<h3[^>]*>\s*([^<]+)\s*</h3>", html)
+    resolved_name = title_m.group(1).strip() if title_m else street_name
+
+    # Extract collection date: "Friday, 29 May"
+    date_m = re.search(
+        r'class="collection-date[^"]*">\s*([A-Za-z]+),?\s*(\d+\s+[A-Za-z]+)',
+        html,
+    )
+    collection_day = date_m.group(1) if date_m else None
+    collection_date = f"{date_m.group(1)}, {date_m.group(2)}" if date_m else None
+
+    # Extract "out before" time
+    time_m = re.search(r"out before\s*<span[^>]*>([^<]+)</span>", html)
+    put_out_time = f"before {time_m.group(1)}" if time_m else None
+
+    # Check which items are collected
+    has_rubbish = "recycling-icon-rubbish" in html
+    has_glass = "recycling-icon-glass" in html  # Glass crate = recycling in Wellington
+
+    if not collection_date:
+        raise RuntimeError(
+            "Could not parse collection date from WCC response — "
+            "the page structure may have changed"
+        )
+
+    next_dates: dict[str, str] = {}
+    if has_rubbish:
+        next_dates["rubbish"] = collection_date
+    if has_glass:
+        next_dates["recycling"] = collection_date
+
+    return {
+        "street_id": street_id,
+        "street_name": resolved_name,
+        "next_dates": next_dates,
+        "collection_day": collection_day,
+        "put_out_time": put_out_time,
+        "url": f"{MAIN_PAGE}?streetId={street_id}",
+        "source": "Wellington City Council collection-day page",
+    }
+
+
+def print_human(result: dict[str, Any]) -> None:
+    print(result["street_name"])
+    print(f"Source: {result['url']}")
+    if result.get("put_out_time"):
+        print(f"  Put out: {result['put_out_time']}")
+    print("  Next collection:")
+    dates = result.get("next_dates", {})
+    date_str = dates.get("rubbish") or dates.get("recycling") or "—"
+    print(f"    {date_str}")
+    print("  Items:")
+    for svc in ["rubbish", "recycling"]:
+        if svc in result.get("next_dates", {}):
+            label = "Rubbish" if svc == "rubbish" else "Recycling (glass crate)"
+            print(f"    {label}: collected")
+    print("  Note: Wellington combines rubbish and recycling on the same collection day.")
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(
+        description="Check Wellington City Council rubbish and recycling collection schedules."
+    )
+    ap.add_argument(
+        "street_name", nargs="*",
+        help="Wellington street name (for display/lookup reference)",
+    )
+    ap.add_argument(
+        "--street-id", required=True,
+        help="Wellington City Council street ID (find yours by searching on the WCC collection-day page)",
+    )
+    ap.add_argument("--json", action="store_true", help="Emit JSON")
+    args = ap.parse_args(argv)
+
+    street_name = " ".join(args.street_name).strip() or f"Street {args.street_id}"
+
+    try:
+        result = get_collection(args.street_id, street_name)
+        if args.json:
+            print(json.dumps(result, indent=2, ensure_ascii=False))
+        else:
+            print_human(result)
+        return 0
+    except Exception as e:
+        if args.json:
+            print(json.dumps({"error": str(e)}, indent=2), file=sys.stderr)
+        else:
+            print(f"wellington-bin-schedule: {e}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/wellington-bin-schedule/scripts/cli.py
+++ b/skills/wellington-bin-schedule/scripts/cli.py
@@ -8,12 +8,11 @@ import re
 import sys
 import urllib.parse
 import urllib.request
-from html.parser import HTMLParser
 from typing import Any
 
 COLLECTION_URL = "https://wellington.govt.nz/rubbish-recycling-and-waste/when-to-put-out-your-rubbish-and-recycling/components/collection-search-results"
 MAIN_PAGE = "https://wellington.govt.nz/rubbish-recycling-and-waste/when-to-put-out-your-rubbish-and-recycling"
-UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
 
 
 def fetch_text(

--- a/skills/wellington-bin-schedule/scripts/smoke_test.py
+++ b/skills/wellington-bin-schedule/scripts/smoke_test.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Smoke test: hit the live WCC API and assert a valid response."""
+import json
+import subprocess
+import sys
+
+STREET_ID = "6317"
+STREET_NAME = "Awa Road, Karaka Bays"
+
+result = subprocess.run(
+    [sys.executable, "skills/wellington-bin-schedule/scripts/cli.py",
+     "--street-id", STREET_ID, "--json"],
+    capture_output=True, text=True
+)
+
+if result.returncode != 0:
+    print("FAIL: non-zero exit")
+    print(result.stderr)
+    sys.exit(1)
+
+data = json.loads(result.stdout)
+
+assert data.get("street_id") == STREET_ID, f"wrong street_id: {data}"
+assert data.get("next_dates"), f"no next_dates in response: {data}"
+assert data.get("collection_day"), f"no collection_day: {data}"
+assert data.get("put_out_time"), f"no put_out_time: {data}"
+assert "rubbish" in data["next_dates"] or "recycling" in data["next_dates"], \
+    f"expected at least one collection stream: {data}"
+
+print(f"PASS  street={data['street_name']}  next={data['next_dates']}  day={data['collection_day']}  time={data['put_out_time']}")


### PR DESCRIPTION
## Wellington Bin Schedule

Adds a new skill for querying Wellington City Council rubbish and recycling collection schedules.

### What it does
- Queries the WCC collection-day component endpoint using a street ID
- Returns next collection date, put-out time, and collected items (rubbish + recycling/glass crate)
- Supports both human-readable and JSON output
- Python stdlib only — zero dependencies

### Wellington collection model
Unlike Auckland, Wellington collects **rubbish and recycling on the same day**. There is no kerbside food scraps/organics collection in Wellington. The recycling stream is glass crate only (no mixed recycling bin).

### How to use
```bash
python3 skills/wellington-bin-schedule/scripts/cli.py --street-id 6317 "Awa Road, Karaka Bays"
python3 skills/wellington-bin-schedule/scripts/cli.py --street-id 6317 --json
```

### Files
- `skills/wellington-bin-schedule/SKILL.md` — skill definition and workflow
- `skills/wellington-bin-schedule/scripts/cli.py` — stdlib CLI (no deps)
- `skills/wellington-bin-schedule/references/api-notes.md` — API reference

### Notes
- Users find their street ID by searching on the WCC collection-day page
- The WCC street autocomplete ASMX endpoint requires server-side auth — street IDs must be obtained manually
- Tested working against live WCC data