### PR TITLE
feat: add NZ pharmacy retail skills

### DIFF
--- a/skills/bargainchemist-nz/SKILL.md
+++ b/skills/bargainchemist-nz/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: bargainchemist-nz
+description: Query Bargain Chemist NZ public product search, suggestions, and Shopify product JSON through a lightweight no-login CLI. Use when the task involves Bargain Chemist NZ product lookup, current online prices, availability, product handles, or machine-readable public product data. Read-only; no cart, checkout, account, prescription, or order actions.
+---
+
+# Bargain Chemist NZ
+
+## Goal
+
+Query live Bargain Chemist NZ product data through a small deterministic CLI with human-readable and JSON output, without browser automation or account login.
+
+## Use this when
+
+- A user asks for Bargain Chemist NZ product prices or availability
+- A user wants to search Bargain Chemist products by keyword
+- A user has a Bargain Chemist product handle or URL and wants public product details
+- A workflow needs lightweight machine-readable Bargain Chemist public product data
+
+## Do not use this for
+
+- Non-Bargain Chemist retailers
+- Authenticated account, loyalty, personalised, cart, checkout, prescription, order, delivery, or payment actions
+- Redistributing scraped Bargain Chemist product data as a dataset
+- Medical advice, medicine suitability, or historical pricing claims
+
+## Preferred workflow
+
+1. Run `scripts/cli.py` with the narrowest subcommand that answers the task.
+2. Use `search` for keyword product lookup and `suggest` for typeahead-style discovery.
+3. Use `product` when a product handle or Bargain Chemist product URL is known.
+4. Use `--json` for agent chaining, comparisons, alerts, or structured reports.
+5. Mention that prices and availability are live public website snapshots from an unofficial read-only wrapper.
+
+## CLI
+
+Run with:
+
+```bash
+python3 skills/bargainchemist-nz/scripts/cli.py <command> [flags]
+```
+
+Commands:
+
+- `search <term> [--limit N] [--page N] [--json]` - Boost Commerce product search
+- `suggest <term> [--limit N] [--json]` - Boost Commerce search suggestions and product suggestions
+- `product <handle-or-url> [--json]` - Shopify product JSON for one product handle
+
+Examples:
+
+```bash
+python3 skills/bargainchemist-nz/scripts/cli.py search panadol --limit 5
+python3 skills/bargainchemist-nz/scripts/cli.py suggest vitamins --limit 5 --json
+python3 skills/bargainchemist-nz/scripts/cli.py product panadol-liquid-caps-16s --json
+```
+
+## Resources
+
+- CLI entrypoint: `scripts/cli.py`
+- Live smoke test: `scripts/smoke_test.py`
+- API and safety notes: `references/api-notes.md`
+
+## Notes
+
+- The implemented commands use only Python stdlib and unauthenticated public GET requests.
+- Search and suggest use Bargain Chemist's Boost Commerce endpoints; product detail uses Shopify `products/<handle>.js`.
+- Do not use this skill for cart, checkout, account, prescription, payment, or order mutations.

--- a/skills/bargainchemist-nz/references/api-notes.md
+++ b/skills/bargainchemist-nz/references/api-notes.md
@@ -1,0 +1,114 @@
+# Bargain Chemist NZ API notes
+
+This skill is an unofficial lightweight wrapper around public read-only endpoints used by `bargainchemist.co.nz`.
+
+## Source and auth
+
+- Website: `https://www.bargainchemist.co.nz/`
+- Boost Commerce search endpoint: `https://services.mybcapps.com/bc-sf-filter/search`
+- Boost Commerce suggest endpoint: `https://services.mybcapps.com/bc-sf-filter/search/suggest`
+- Shopify product JSON endpoint: `https://www.bargainchemist.co.nz/products/{handle}.js`
+- Shopify shop id in Boost requests: `bargain-chemist.myshopify.com`
+- Auth model for supported commands: none
+
+No username, password, account cookie, private token, cart id, prescription flow, or browser session is required for the implemented read-only operations.
+
+## Endpoint families used
+
+### Product search
+
+`GET https://services.mybcapps.com/bc-sf-filter/search`
+
+Observed query parameters:
+
+```text
+_=pf
+shop=bargain-chemist.myshopify.com
+page=1
+limit=12
+sort=relevance
+locale=en
+event_type=init
+pg=search_page
+build_filter_tree=true
+q=<term>
+product_available=true
+variant_available=true
+return_all_currency_fields=false
+currency=NZD
+country=NZ
+```
+
+Useful observed response fields:
+
+- `total_product`
+- `total_page`
+- `products[]`
+- product fields including `id`, `title`, `handle`, `price_min`, `price_max`, `available`, `vendor`, `product_type`, `body_html`, `images`, `images_info`, and `variants[]`
+
+Product page URL pattern:
+
+```text
+https://www.bargainchemist.co.nz/products/<handle>
+```
+
+### Suggestions
+
+`GET https://services.mybcapps.com/bc-sf-filter/search/suggest`
+
+Observed query parameters:
+
+```text
+shop=bargain-chemist.myshopify.com
+locale=en
+q=<term>
+re_run_if_typo=true
+event_type=suggest
+pg=search_page
+return_all_currency_fields=false
+recent_search=<term>
+enable_default_result=false
+```
+
+Observed response fields include `total_product`, `products[]`, `suggestions`, `collections`, `pages`, `did_you_mean`, and `all_empty`.
+
+### Product detail
+
+`product <handle-or-url>` uses Shopify's public product JSON route:
+
+```text
+GET https://www.bargainchemist.co.nz/products/{handle}.js
+```
+
+Live read-only checks confirmed this endpoint for handles returned by Boost search, such as `panadol-liquid-caps-16s`. The response includes Shopify product fields such as `id`, `title`, `handle`, `vendor`, `type`, `available`, `price`, `variants[]`, `images`, and `featured_image`. Prices from this route are integer cents and are normalized to NZD decimal values by the CLI.
+
+If Shopify product JSON is unavailable for a handle, the CLI attempts a read-only Boost search fallback and returns an exact handle match when present. The fallback is documented in the JSON response with `fallback`.
+
+## CLI output shape
+
+The CLI normalizes product records into:
+
+- `id`
+- `title`
+- `handle`
+- `url`
+- `source_url`
+- `price_min`
+- `price_max`
+- `available`
+- `vendor`
+- `product_type`
+- `body_html`
+- `variants`
+- `images`
+
+Top-level JSON includes `source`, `source_url`, `query` or `handle`, `total_product`, and `results`. Use `--raw` only when the caller needs the original API payload for debugging.
+
+## Safety boundary
+
+- Treat prices and availability as live public website snapshots, not historical facts.
+- Medicine availability is not medical advice and does not imply suitability, dosage, or safety for a person.
+- Endpoint shapes and public storefront behavior can change without notice because this is not a formal public API.
+- Keep requests narrow and human-scale; do not build high-volume scrapers or redistribute product data as a dataset.
+- Do not use this skill for cart mutation, checkout, order placement, prescription uploads, account actions, delivery actions, payment actions, or logged-in/personalised workflows.
+- Do not commit credentials, cookies, raw HAR captures, private screenshots, browser session data, or checkout/account/prescription payloads.

--- a/skills/bargainchemist-nz/scripts/cli.py
+++ b/skills/bargainchemist-nz/scripts/cli.py
@@ -1,0 +1,515 @@
+#!/usr/bin/env python3
+"""Bargain Chemist NZ lightweight read-only product CLI.
+
+Self-contained stdlib wrapper around public Boost Commerce search/suggest
+endpoints and Shopify product JSON. No login, cart mutation, browser
+automation, prescription flow, or third-party dependencies.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+BASE_WEB = "https://www.bargainchemist.co.nz"
+BOOST_SEARCH_BASE = "https://services.mybcapps.com/bc-sf-filter/search"
+BOOST_SUGGEST_BASE = "https://services.mybcapps.com/bc-sf-filter/search/suggest"
+SHOP = "bargain-chemist.myshopify.com"
+DEFAULT_LIMIT = 12
+MAX_LIMIT = 50
+UA = os.environ.get(
+    "BARGAINCHEMIST_NZ_USER_AGENT",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
+)
+
+
+class ApiError(Exception):
+    pass
+
+
+def die(message: str, code: int = 1) -> None:
+    print(f"bargainchemist-nz: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("must be >= 1")
+    return parsed
+
+
+def bounded_limit(value: str) -> int:
+    parsed = positive_int(value)
+    if parsed > MAX_LIMIT:
+        raise argparse.ArgumentTypeError(f"must be <= {MAX_LIMIT}")
+    return parsed
+
+
+def request_json(url: str, params: dict[str, Any] | None = None, timeout: int = 25) -> tuple[Any, str]:
+    if params:
+        clean = {k: str(v) for k, v in params.items() if v not in (None, "")}
+        url = url + "?" + urllib.parse.urlencode(clean)
+    headers = {
+        "Accept": "application/json, text/plain, */*",
+        "Accept-Language": "en-NZ,en;q=0.9",
+        "Origin": BASE_WEB,
+        "Referer": BASE_WEB + "/",
+        "User-Agent": UA,
+    }
+    req = urllib.request.Request(url, headers=headers, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", "replace")
+            return json.loads(raw), resp.geturl()
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8", "replace")
+        detail = raw[:300].strip().replace("\n", " ")
+        raise ApiError(f"HTTP {e.code} from {url}: {detail}") from e
+    except urllib.error.URLError as e:
+        raise ApiError(f"network error calling {url}: {e.reason}") from e
+    except json.JSONDecodeError as e:
+        raise ApiError(f"invalid JSON from {url}: {e}") from e
+
+
+def to_number(value: Any, *, cents: bool = False) -> float | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        amount = float(value)
+    else:
+        text = re.sub(r"[^0-9.]+", "", str(value))
+        if not text:
+            return None
+        try:
+            amount = float(text)
+        except ValueError:
+            return None
+    if cents:
+        amount = amount / 100.0
+    return round(amount, 2)
+
+
+def to_int(value: Any) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def bool_or_none(value: Any) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    if text in {"true", "1", "yes", "y"}:
+        return True
+    if text in {"false", "0", "no", "n"}:
+        return False
+    return None
+
+
+def money(value: Any) -> str:
+    amount = to_number(value)
+    if amount is None:
+        return "-"
+    return f"${amount:.2f}"
+
+
+def stock_label(value: Any) -> str:
+    available = bool_or_none(value)
+    if available is True:
+        return "in stock"
+    if available is False:
+        return "unavailable"
+    return "unknown"
+
+
+def product_url(handle: str) -> str:
+    return f"{BASE_WEB}/products/{urllib.parse.quote(handle, safe='')}"
+
+
+def absolute_url(value: Any) -> str | None:
+    if not value:
+        return None
+    text = str(value)
+    if text.startswith("//"):
+        return "https:" + text
+    if text.startswith("http://") or text.startswith("https://"):
+        return text
+    if text.startswith("/"):
+        return BASE_WEB + text
+    return text
+
+
+def normalize_image(entry: Any) -> str | None:
+    if isinstance(entry, str):
+        return absolute_url(entry)
+    if isinstance(entry, dict):
+        for key in ("src", "url", "image", "original_src"):
+            url = absolute_url(entry.get(key))
+            if url:
+                return url
+        preview = entry.get("preview_image")
+        if isinstance(preview, dict):
+            return normalize_image(preview)
+    return None
+
+
+def normalize_images(raw: dict[str, Any]) -> list[str]:
+    candidates: list[Any] = []
+    for key in ("images", "images_info", "media"):
+        value = raw.get(key)
+        if isinstance(value, list):
+            candidates.extend(value)
+    for key in ("featured_image", "image"):
+        value = raw.get(key)
+        if value:
+            candidates.append(value)
+    seen: set[str] = set()
+    images: list[str] = []
+    for entry in candidates:
+        url = normalize_image(entry)
+        if url and url not in seen:
+            seen.add(url)
+            images.append(url)
+    return images
+
+
+def normalize_variant(raw: dict[str, Any], *, cents: bool) -> dict[str, Any]:
+    return {
+        "id": raw.get("id"),
+        "title": raw.get("title") or raw.get("name") or "",
+        "sku": raw.get("sku") or "",
+        "barcode": raw.get("barcode") or "",
+        "available": bool_or_none(raw.get("available")),
+        "price": to_number(raw.get("price"), cents=cents),
+        "compare_at_price": to_number(raw.get("compare_at_price"), cents=cents),
+        "inventory_quantity": to_int(raw.get("inventory_quantity")),
+        "option1": raw.get("option1"),
+        "option2": raw.get("option2"),
+        "option3": raw.get("option3"),
+    }
+
+
+def min_max_variant_prices(variants: list[dict[str, Any]]) -> tuple[float | None, float | None]:
+    prices = [v.get("price") for v in variants if isinstance(v.get("price"), (int, float))]
+    if not prices:
+        return None, None
+    return min(prices), max(prices)
+
+
+def normalize_product(raw: dict[str, Any], *, source: str) -> dict[str, Any]:
+    cents = source == "shopify-product-json"
+    handle = str(raw.get("handle") or "").strip()
+    variants_raw = raw.get("variants") if isinstance(raw.get("variants"), list) else []
+    variants = [normalize_variant(v, cents=cents) for v in variants_raw if isinstance(v, dict)]
+    variant_min, variant_max = min_max_variant_prices(variants)
+    price_min = to_number(raw.get("price_min"), cents=cents)
+    price_max = to_number(raw.get("price_max"), cents=cents)
+    if price_min is None:
+        price_min = variant_min if variant_min is not None else to_number(raw.get("price"), cents=cents)
+    if price_max is None:
+        price_max = variant_max if variant_max is not None else price_min
+    url = product_url(handle) if handle else absolute_url(raw.get("url")) or ""
+    return {
+        "id": raw.get("id"),
+        "title": raw.get("title") or raw.get("name") or "",
+        "handle": handle,
+        "url": url,
+        "source_url": url,
+        "price_min": price_min,
+        "price_max": price_max,
+        "available": bool_or_none(raw.get("available")),
+        "vendor": raw.get("vendor") or "",
+        "product_type": raw.get("product_type") or raw.get("type") or "",
+        "body_html": raw.get("body_html") or raw.get("description"),
+        "variants": variants,
+        "images": normalize_images(raw),
+    }
+
+
+def search_params(term: str, *, limit: int, page: int) -> dict[str, Any]:
+    return {
+        "_": "pf",
+        "shop": SHOP,
+        "page": page,
+        "limit": limit,
+        "sort": "relevance",
+        "locale": "en",
+        "event_type": "init",
+        "pg": "search_page",
+        "build_filter_tree": "true",
+        "q": term,
+        "product_available": "true",
+        "variant_available": "true",
+        "return_all_currency_fields": "false",
+        "currency": "NZD",
+        "country": "NZ",
+    }
+
+
+def suggest_params(term: str) -> dict[str, Any]:
+    return {
+        "shop": SHOP,
+        "locale": "en",
+        "q": term,
+        "re_run_if_typo": "true",
+        "event_type": "suggest",
+        "pg": "search_page",
+        "return_all_currency_fields": "false",
+        "recent_search": term,
+        "enable_default_result": "false",
+    }
+
+
+def normalize_suggestions(raw: Any) -> list[dict[str, Any]]:
+    if not isinstance(raw, list):
+        return []
+    output: list[dict[str, Any]] = []
+    for item in raw:
+        if isinstance(item, str):
+            output.append({"text": item})
+        elif isinstance(item, dict):
+            text = item.get("q") or item.get("query") or item.get("term") or item.get("title") or item.get("text")
+            output.append({"text": text or "", "raw": item})
+    return output
+
+
+def search_products(term: str, *, limit: int, page: int, raw: bool = False) -> dict[str, Any]:
+    started = time.perf_counter()
+    data, source_url = request_json(BOOST_SEARCH_BASE, search_params(term, limit=limit, page=page))
+    products = data.get("products") if isinstance(data, dict) else []
+    results = [normalize_product(p, source="boost-commerce-search") for p in products or [] if isinstance(p, dict)]
+    output = {
+        "source": "boost-commerce-search",
+        "source_url": source_url,
+        "query": term,
+        "page": page,
+        "limit": limit,
+        "total_product": data.get("total_product") if isinstance(data, dict) else None,
+        "total_page": data.get("total_page") if isinstance(data, dict) else None,
+        "results": results,
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+    }
+    if raw:
+        output["raw"] = data
+    return output
+
+
+def suggest_products(term: str, *, limit: int, raw: bool = False) -> dict[str, Any]:
+    started = time.perf_counter()
+    data, source_url = request_json(BOOST_SUGGEST_BASE, suggest_params(term))
+    products = data.get("products") if isinstance(data, dict) else []
+    results = [normalize_product(p, source="boost-commerce-suggest") for p in products or [] if isinstance(p, dict)]
+    output = {
+        "source": "boost-commerce-suggest",
+        "source_url": source_url,
+        "query": term,
+        "limit": limit,
+        "total_product": data.get("total_product") if isinstance(data, dict) else None,
+        "suggestions": normalize_suggestions(data.get("suggestions") if isinstance(data, dict) else None),
+        "results": results[:limit],
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+    }
+    if raw:
+        output["raw"] = data
+    return output
+
+
+def extract_handle(value: str) -> str:
+    text = value.strip()
+    if not text:
+        die("product handle or URL is required")
+    if "://" in text or text.startswith("www.") or "/products/" in text:
+        parse_target = text if "://" in text else "https://" + text.lstrip("/")
+        parsed = urllib.parse.urlparse(parse_target)
+        path = parsed.path
+        if "/products/" in path:
+            text = path.split("/products/", 1)[1]
+        else:
+            text = path.rsplit("/", 1)[-1]
+    text = text.split("?", 1)[0].split("#", 1)[0].strip("/")
+    if text.endswith(".js"):
+        text = text[:-3]
+    handle = urllib.parse.unquote(text).strip()
+    if not handle or "/" in handle:
+        die(f"could not parse product handle from {value!r}")
+    return handle
+
+
+def product_from_boost(handle: str, *, raw: bool = False) -> dict[str, Any] | None:
+    data = search_products(handle, limit=12, page=1, raw=raw)
+    match = None
+    for product in data.get("results") or []:
+        if product.get("handle") == handle:
+            match = product
+            break
+    if not match:
+        return None
+    output = {
+        "source": "boost-commerce-search",
+        "source_url": data.get("source_url"),
+        "handle": handle,
+        "total_product": 1,
+        "results": [match],
+        "product": match,
+        "fallback": "Shopify product JSON was unavailable; matched exact handle in Boost search.",
+    }
+    if raw and data.get("raw") is not None:
+        output["raw"] = data["raw"]
+    return output
+
+
+def product_detail(value: str, *, raw: bool = False) -> dict[str, Any]:
+    started = time.perf_counter()
+    handle = extract_handle(value)
+    endpoint = product_url(handle) + ".js"
+    try:
+        data, source_url = request_json(endpoint)
+    except ApiError as e:
+        fallback = product_from_boost(handle, raw=raw)
+        if fallback is not None:
+            fallback["elapsed_ms"] = round((time.perf_counter() - started) * 1000)
+            return fallback
+        raise ApiError(f"{e}; Boost fallback did not find handle {handle!r}") from e
+    product = normalize_product(data, source="shopify-product-json") if isinstance(data, dict) else {}
+    output = {
+        "source": "shopify-product-json",
+        "source_url": source_url,
+        "handle": handle,
+        "total_product": 1 if product else 0,
+        "results": [product] if product else [],
+        "product": product,
+        "elapsed_ms": round((time.perf_counter() - started) * 1000),
+    }
+    if raw:
+        output["raw"] = data
+    return output
+
+
+def print_product_rows(result: dict[str, Any]) -> None:
+    total = result.get("total_product")
+    query = result.get("query")
+    shown = len(result.get("results") or [])
+    if query:
+        print(f"{total if total is not None else '?'} product matches for {query!r} (showing {shown})")
+    else:
+        print(f"{shown} product result(s)")
+    for product in result.get("results") or []:
+        title = product.get("title") or "(untitled)"
+        price = money(product.get("price_min"))
+        available = stock_label(product.get("available"))
+        vendor = product.get("vendor") or ""
+        url = product.get("url") or ""
+        extra = f" | {vendor}" if vendor else ""
+        print(f"{price:>8}  {available:<11}  {title}{extra}")
+        if url:
+            print(f"          {url}")
+
+
+def print_suggest(result: dict[str, Any]) -> None:
+    suggestions = [s.get("text") for s in result.get("suggestions") or [] if s.get("text")]
+    if suggestions:
+        print("Suggestions: " + ", ".join(suggestions[:8]))
+    print_product_rows(result)
+
+
+def print_product_detail(result: dict[str, Any]) -> None:
+    product = result.get("product") or {}
+    if not product:
+        print("No product found.")
+        return
+    title = product.get("title") or "(untitled)"
+    price_min = product.get("price_min")
+    price_max = product.get("price_max")
+    price_text = money(price_min) if price_min == price_max else f"{money(price_min)}-{money(price_max)}"
+    bits = [price_text, stock_label(product.get("available"))]
+    if product.get("vendor"):
+        bits.append(str(product["vendor"]))
+    if product.get("product_type"):
+        bits.append(str(product["product_type"]))
+    print(title)
+    print(" | ".join(bits))
+    if product.get("url"):
+        print(product["url"])
+    print(f"Variants: {len(product.get('variants') or [])} | Images: {len(product.get('images') or [])}")
+
+
+def emit(result: dict[str, Any], *, json_output: bool, mode: str) -> None:
+    if json_output:
+        print(json.dumps(result, indent=2, ensure_ascii=False))
+        return
+    if mode == "suggest":
+        print_suggest(result)
+    elif mode == "product":
+        print_product_detail(result)
+    else:
+        print_product_rows(result)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="bargainchemist-nz",
+        description="Read-only Bargain Chemist NZ product search and product detail CLI.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    search = sub.add_parser("search", help="search Bargain Chemist products")
+    search.add_argument("term", help="search term")
+    search.add_argument("--limit", type=bounded_limit, default=DEFAULT_LIMIT, help=f"results per page, 1-{MAX_LIMIT}")
+    search.add_argument("--page", type=positive_int, default=1, help="1-based search page")
+    search.add_argument("--json", dest="json_output", action="store_true", help="print normalized JSON")
+    search.add_argument("--raw", action="store_true", help="include raw API response in JSON output")
+
+    suggest = sub.add_parser("suggest", help="fetch suggestions and suggested products")
+    suggest.add_argument("term", help="suggestion term")
+    suggest.add_argument("--limit", type=bounded_limit, default=8, help=f"maximum suggested products, 1-{MAX_LIMIT}")
+    suggest.add_argument("--json", dest="json_output", action="store_true", help="print normalized JSON")
+    suggest.add_argument("--raw", action="store_true", help="include raw API response in JSON output")
+
+    product = sub.add_parser("product", help="fetch one product by handle or product URL")
+    product.add_argument("handle_or_url", help="product handle or https://www.bargainchemist.co.nz/products/<handle> URL")
+    product.add_argument("--json", dest="json_output", action="store_true", help="print normalized JSON")
+    product.add_argument("--raw", action="store_true", help="include raw API response in JSON output")
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "search":
+            result = search_products(args.term, limit=args.limit, page=args.page, raw=args.raw)
+            emit(result, json_output=args.json_output, mode="search")
+        elif args.command == "suggest":
+            result = suggest_products(args.term, limit=args.limit, raw=args.raw)
+            emit(result, json_output=args.json_output, mode="suggest")
+        elif args.command == "product":
+            result = product_detail(args.handle_or_url, raw=args.raw)
+            emit(result, json_output=args.json_output, mode="product")
+        else:
+            parser.error("unknown command")
+    except ApiError as e:
+        die(str(e))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/bargainchemist-nz/scripts/smoke_test.py
+++ b/skills/bargainchemist-nz/scripts/smoke_test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Live read-only smoke tests for the Bargain Chemist NZ skill."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).parent.parent
+CLI = SKILL_DIR / "scripts" / "cli.py"
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CLI)] + args,
+        capture_output=True,
+        text=True,
+        cwd=str(SKILL_DIR),
+        timeout=45,
+    )
+
+
+def test(name: str, fn) -> bool:
+    try:
+        ok = fn()
+        status = "PASS" if ok else "FAIL"
+        print(f"[{status}] {name}")
+        return ok
+    except Exception as e:
+        print(f"[FAIL] {name}")
+        print(f"  error: {e}")
+        return False
+
+
+results: list[bool] = []
+search_handle = ""
+
+
+def test_help() -> bool:
+    result = run(["--help"])
+    if result.returncode != 0:
+        print(f"  stderr: {result.stderr[:300]}")
+    return result.returncode == 0
+
+
+results.append(test("--help exits 0", test_help))
+
+
+def test_search() -> bool:
+    global search_handle
+    result = run(["search", "panadol", "--limit", "3", "--json"])
+    if result.returncode != 0:
+        print(f"  stderr: {result.stderr[:300]}")
+        return False
+    data = json.loads(result.stdout)
+    products = data.get("results")
+    if not isinstance(products, list) or not products:
+        print(f"  stdout: {result.stdout[:300]}")
+        print("  Expected search JSON to include non-empty results[]")
+        return False
+    if not isinstance(data.get("total_product"), int) or data["total_product"] < 1:
+        print("  Expected total_product > 0")
+        return False
+    first = products[0]
+    required = ("title", "handle", "url", "price_min", "price_max", "available", "variants", "images")
+    missing = [key for key in required if key not in first]
+    if missing:
+        print(f"  Missing normalized product keys: {missing}")
+        return False
+    search_handle = str(first.get("handle") or "")
+    return bool(search_handle)
+
+
+results.append(test("search panadol returns normalized products", test_search))
+
+
+def test_suggest() -> bool:
+    result = run(["suggest", "panadol", "--limit", "3", "--json"])
+    if result.returncode != 0:
+        print(f"  stderr: {result.stderr[:300]}")
+        return False
+    data = json.loads(result.stdout)
+    if data.get("source") != "boost-commerce-suggest":
+        print(f"  stdout: {result.stdout[:300]}")
+        print("  Expected source=boost-commerce-suggest")
+        return False
+    products = data.get("results")
+    if not isinstance(products, list) or not products:
+        print(f"  stdout: {result.stdout[:300]}")
+        print("  Expected suggest JSON to include non-empty results[]")
+        return False
+    return isinstance(data.get("total_product"), int)
+
+
+results.append(test("suggest panadol returns suggested products", test_suggest))
+
+
+def test_product() -> bool:
+    if not search_handle:
+        print("  No handle captured from search")
+        return False
+    result = run(["product", search_handle, "--json"])
+    if result.returncode != 0:
+        print(f"  stderr: {result.stderr[:300]}")
+        return False
+    data = json.loads(result.stdout)
+    product = data.get("product")
+    if not isinstance(product, dict):
+        print(f"  stdout: {result.stdout[:300]}")
+        print("  Expected product object")
+        return False
+    if product.get("handle") != search_handle:
+        print(f"  Expected handle {search_handle!r}, got {product.get('handle')!r}")
+        return False
+    if data.get("source") != "shopify-product-json":
+        print(f"  Expected source=shopify-product-json, got {data.get('source')!r}")
+        return False
+    if not isinstance(product.get("variants"), list) or not product["variants"]:
+        print("  Expected product variants[]")
+        return False
+    if not isinstance(product.get("images"), list):
+        print("  Expected product images[]")
+        return False
+    return bool(product.get("url")) and product.get("price_min") is not None
+
+
+results.append(test("product <handle> returns Shopify product JSON", test_product))
+
+if all(results):
+    print("All tests passed.")
+    sys.exit(0)
+
+print(f"{results.count(False)} test(s) failed.")
+sys.exit(1)

--- a/skills/chemistwarehouse-nz/SKILL.md
+++ b/skills/chemistwarehouse-nz/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: chemistwarehouse-nz
+description: Query Chemist Warehouse NZ public searchapiv2 suggestion, product search, category listing, and product detail endpoints through a lightweight no-login CLI. Use for live NZ pharmacy product names, prices, categories, product IDs, ratings, and machine-readable Chemist Warehouse NZ data. Read-only; no cart, checkout, account, prescription, order, or payment mutations.
+---
+
+# Chemist Warehouse NZ
+
+## Goal
+
+Query live Chemist Warehouse NZ product data through a small deterministic CLI with concise human output and normalized JSON, without browser automation, login, or write actions.
+
+## Use this when
+
+- A user asks for Chemist Warehouse NZ product prices, IDs, ratings, or product URLs
+- A user wants keyword suggestions, product search, category listings, or product detail
+- A workflow needs lightweight machine-readable Chemist Warehouse NZ product data
+
+## Do not use this for
+
+- Chemist Warehouse Australia or unrelated pharmacies
+- Cart, checkout, payment, account, order, wishlist, stock reservation, prescription upload, prescription management, or other mutations
+- Authenticated, personalised, medical-record, or prescription-only workflows
+- Historical price claims unless another source provides history
+
+## Preferred workflow
+
+1. Run `scripts/cli.py` with the narrowest command that answers the task.
+2. Use `suggest` to discover terms, product IDs, and category IDs.
+3. Use `search` for keyword price/product lookup; use `category` when a category ID is known.
+4. Use `product` for exact detail by product ID or Chemist Warehouse `/buy/<id>/...` URL.
+5. Use `--json` for comparisons, reports, or agent chaining.
+6. State that prices are live online snapshots from an unofficial read-only wrapper.
+
+## CLI
+
+Run with:
+
+```bash
+python3 skills/chemistwarehouse-nz/scripts/cli.py <command> [flags]
+```
+
+Commands:
+
+- `suggest TERM [--limit N] [--json]`
+- `search TERM [--limit N] [--page N] [--json]`
+- `category ID [--limit N] [--page N] [--json]`
+- `product PRODUCT_ID_OR_URL [--json]`
+
+Examples:
+
+```bash
+python3 skills/chemistwarehouse-nz/scripts/cli.py suggest panadol --limit 5
+python3 skills/chemistwarehouse-nz/scripts/cli.py search "vitamin c" --limit 10 --json
+python3 skills/chemistwarehouse-nz/scripts/cli.py category 256 --limit 10
+python3 skills/chemistwarehouse-nz/scripts/cli.py product 6973 --json
+```
+
+## Resources
+
+- CLI entrypoint: `scripts/cli.py`
+- Live read-only smoke test: `scripts/smoke_test.py`
+- API and safety notes: `references/api-notes.md`
+
+## Notes
+
+- The CLI uses public unauthenticated `searchapiv2` endpoints with browser-compatible headers.
+- Product detail supports numeric product IDs directly; product URLs are parsed for `/buy/<id>/`.
+- Search can redirect for some brand-exact terms; use more general terms such as `vitamin c` for smoke tests.
+- Endpoint shapes can change; verify with a small live query before relying on broader workflows.

--- a/skills/chemistwarehouse-nz/references/api-notes.md
+++ b/skills/chemistwarehouse-nz/references/api-notes.md
@@ -1,0 +1,99 @@
+# Chemist Warehouse NZ API notes
+
+Observed live on 2026-05-24. This skill is an unofficial read-only wrapper around public endpoints used by `www.chemistwarehouse.co.nz`.
+
+## Source and auth boundary
+
+- Website: `https://www.chemistwarehouse.co.nz/`
+- API base: `https://www.chemistwarehouse.co.nz/searchapiv2`
+- Auth model for implemented commands: none
+- Required headers in live tests:
+  - `User-Agent: Mozilla/5.0`
+  - `Accept: application/json,text/plain,*/*`
+  - `Referer: https://www.chemistwarehouse.co.nz/`
+
+No username, password, account cookie, bearer token, private API key, or browser session is required for the implemented read-only operations.
+
+Do not call or automate cart, checkout, payment, account, order, wishlist, stock reservation, prescription upload, prescription management, or any other mutating endpoint. Do not submit patient, prescription, or account data through this skill.
+
+## Suggest endpoint
+
+Request:
+
+```text
+GET /suggest?identifier=nz&search=panadol
+```
+
+Response shape:
+
+- Top-level `suggestionGroups`
+- `indexName: 1keywords` suggestions include `searchterm`, `nrResults`
+- `indexName: 2categories` suggestions include `mlValue`, `fhLocation`, `catid`, `nrResults`
+- `indexName: 3products` suggestions include `secondId`, `name`, `_thumburl`, `producturl`, `brand`, `price`, `rrp`, `ams_schedule`, `is_prescription`, `bv_star_rating`, `bv_total_votes`, `splat`
+
+The CLI normalizes product suggestions into `items[]` and keeps grouped keyword/category/product suggestions under `groups`.
+
+## Search endpoint
+
+Request pattern:
+
+```text
+GET /search?identifier=nz&fh_location=//catalog01/en_AU/categories<{catalog01_chemnz}/$s=<term>&fh_start_index=<offset>&fh_view_size=<limit>
+```
+
+Response shape:
+
+- Product listing items are under `universes.universe[0].items-section.items.item`
+- Total item count is under `universes.universe[0].items-section.results.total-items`
+- Product attributes are a list at `item.attribute`
+- Common attribute names: `secondid`, `name`, `producturl`, `price_cw_nz`, `rrp_cw_nz`, `_thumburl`, `ams_schedule`, `is_prescription`, `bv_star_rating`, `bv_total_votes`, `l1_category`, `l2_category`, `l3_category`
+- `item.link[0].url-params` usually contains a reusable detail query with `fh_secondid`
+
+Some brand-exact or heavily merchandised terms can redirect and return no normal listing items. `vitamin c` was robust in live smoke tests.
+
+## Category endpoint
+
+Request pattern:
+
+```text
+GET /search?identifier=nz&fh_location=//catalog01/en_AU/categories<{catalog01_chemnz}/categories<{chemnz<ID>}&fh_start_index=<offset>&fh_view_size=<limit>
+```
+
+Category `256` returned `3376` total items in a prior live test. The CLI accepts `256`, `chemnz256`, or a full category token and normalizes digit-only IDs to `chemnz<ID>`.
+
+## Detail endpoint
+
+Preferred detail lookup is another `/search` request with a product second ID:
+
+```text
+GET /search?identifier=nz&site=cw_nz&channel=desktop&fh_location=//catalog01/en_AU/categories<{catalog01_chemnz}&fh_start_index=0&fh_refview=search&fh_secondid=<product_id>&fh_lister_pos=1&fh_modification=
+```
+
+The detail query can also be made by taking a search/category product item's `link[0].url-params`, appending it to `/search`, and adding `identifier=nz`.
+
+Observed detail response notes:
+
+- `info.view` is the string `detail`
+- The detail product remains under `universes.universe[0].items-section.items.item`
+- Detail attributes include `description`, `_imageurl`, `price_cw_nz`, `rrp_cw_nz`, `bv_star_rating`, `bv_total_votes`, plus the normal product fields
+
+## CLI normalization
+
+JSON commands include:
+
+- `source`: `chemistwarehouse-nz-searchapiv2`
+- `source_url`: exact URL called
+- `query`, `category_id`, or `product_id` as applicable
+- `total`: upstream total when available
+- `results`: number of returned normalized items, or grouped suggestion counts for `suggest`
+- `items`: normalized product records
+
+Product records include product ID, name, brand when supplied, price, RRP, currency, URL, image/thumbnail, prescription flag, AMS schedule, Bazaarvoice rating/votes, categories, and detail URL params when provided.
+
+## Stability and safety
+
+- Treat prices, ratings, and product availability signals as live online snapshots.
+- Store, account, prescription, or logged-in state may change what a real customer sees.
+- Endpoint fields and Fredhopper query parameters are not an official public API contract and can change.
+- Keep queries narrow and limits small; avoid high-volume scraping.
+- Do not commit cookies, credentials, HAR files, private account data, patient data, or raw browser captures.

--- a/skills/chemistwarehouse-nz/scripts/cli.py
+++ b/skills/chemistwarehouse-nz/scripts/cli.py
@@ -1,0 +1,572 @@
+#!/usr/bin/env python3
+"""Chemist Warehouse NZ read-only product lookup CLI.
+
+Stdlib wrapper around the public searchapiv2 endpoints used by
+chemistwarehouse.co.nz. No login, cart, checkout, account, or prescription
+mutations.
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from html.parser import HTMLParser
+from typing import Any
+
+BASE_API = "https://www.chemistwarehouse.co.nz/searchapiv2"
+BASE_WEB = "https://www.chemistwarehouse.co.nz"
+SOURCE = "chemistwarehouse-nz-searchapiv2"
+ROOT_LOCATION = "//catalog01/en_AU/categories<{catalog01_chemnz}"
+UA = os.environ.get("CHEMISTWAREHOUSE_NZ_USER_AGENT", "Mozilla/5.0")
+
+
+class HTMLText(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.parts: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() in {"br", "p", "div", "li"}:
+            self.parts.append(" ")
+
+    def handle_data(self, data: str) -> None:
+        if data:
+            self.parts.append(data)
+
+    def text(self) -> str:
+        return " ".join(html.unescape(" ".join(self.parts)).split())
+
+
+def die(message: str, code: int = 1) -> None:
+    print(f"chemistwarehouse-nz: {message}", file=sys.stderr)
+    raise SystemExit(code)
+
+
+def api_url(path: str, params: dict[str, Any]) -> str:
+    clean = {k: v for k, v in params.items() if v is not None}
+    return BASE_API + path + "?" + urllib.parse.urlencode(clean, doseq=True)
+
+
+def request_json(path: str, params: dict[str, Any], timeout: int = 25) -> tuple[Any, str]:
+    url = api_url(path, params)
+    headers = {
+        "User-Agent": UA,
+        "Accept": "application/json,text/plain,*/*",
+        "Referer": BASE_WEB + "/",
+    }
+    req = urllib.request.Request(url, headers=headers)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read().decode("utf-8", "replace")
+            return json.loads(raw), url
+    except urllib.error.HTTPError as e:
+        raw = e.read().decode("utf-8", "replace")
+        detail = raw[:300].strip() or e.reason
+        die(f"HTTP {e.code} from {url}: {detail}")
+    except urllib.error.URLError as e:
+        die(f"network error calling {url}: {e.reason}")
+    except json.JSONDecodeError as e:
+        die(f"invalid JSON from {url}: {e}")
+
+
+def as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def first_dict(value: Any) -> dict[str, Any]:
+    for item in as_list(value):
+        if isinstance(item, dict):
+            return item
+    return {}
+
+
+def to_float(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    try:
+        return float(str(value).replace("$", "").replace(",", ""))
+    except (TypeError, ValueError):
+        return None
+
+
+def to_int(value: Any) -> int | None:
+    if value is None or value == "":
+        return None
+    try:
+        return int(float(str(value).replace(",", "")))
+    except (TypeError, ValueError):
+        return None
+
+
+def to_bool(value: Any) -> bool | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return value
+    text = str(value).strip().lower()
+    if text in {"1", "true", "yes", "y"}:
+        return True
+    if text in {"0", "false", "no", "n"}:
+        return False
+    return None
+
+
+def html_to_text(value: Any) -> str:
+    if not isinstance(value, str) or not value:
+        return ""
+    parser = HTMLText()
+    try:
+        parser.feed(value)
+        parser.close()
+        return parser.text()
+    except Exception:
+        return " ".join(html.unescape(value).split())
+
+
+def item_attributes(item: dict[str, Any]) -> dict[str, Any]:
+    attrs: dict[str, Any] = {}
+    for attr in as_list(item.get("attribute")):
+        if not isinstance(attr, dict):
+            continue
+        name = attr.get("name")
+        if not name:
+            continue
+        values = []
+        for value in as_list(attr.get("value")):
+            if isinstance(value, dict):
+                values.append(value.get("value"))
+            else:
+                values.append(value)
+        values = [v for v in values if v not in (None, "")]
+        if values:
+            attrs[str(name)] = values[0] if len(values) == 1 else values
+    return attrs
+
+
+def attr_value(attrs: dict[str, Any], *names: str) -> Any:
+    for name in names:
+        value = attrs.get(name)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def detail_params(item: dict[str, Any]) -> str | None:
+    for link in as_list(item.get("link")):
+        if isinstance(link, dict) and link.get("type") == "detail" and link.get("url-params"):
+            return str(link["url-params"])
+    for link in as_list(item.get("link")):
+        if isinstance(link, dict) and link.get("url-params"):
+            return str(link["url-params"])
+    return None
+
+
+def normalize_product(source_item: dict[str, Any], *, include_description: bool = False) -> dict[str, Any]:
+    attrs = item_attributes(source_item) if "attribute" in source_item else dict(source_item)
+    product_id = str(attr_value(attrs, "secondid", "secondId") or source_item.get("id") or "")
+    product = {
+        "product_id": product_id,
+        "name": attr_value(attrs, "name") or "",
+        "brand": attr_value(attrs, "brand") or "",
+        "price": to_float(attr_value(attrs, "price_cw_nz", "price")),
+        "rrp": to_float(attr_value(attrs, "rrp_cw_nz", "rrp")),
+        "currency": "NZD",
+        "url": attr_value(attrs, "producturl"),
+        "image": attr_value(attrs, "_imageurl", "_thumburl"),
+        "thumbnail": attr_value(attrs, "_thumburl"),
+        "is_prescription": to_bool(attr_value(attrs, "is_prescription")),
+        "ams_schedule": to_int(attr_value(attrs, "ams_schedule")),
+        "rating": {
+            "stars": to_float(attr_value(attrs, "bv_star_rating")),
+            "votes": to_int(attr_value(attrs, "bv_total_votes")),
+        },
+        "categories": {
+            "l1": attr_value(attrs, "l1_category"),
+            "l2": attr_value(attrs, "l2_category"),
+            "l3": attr_value(attrs, "l3_category"),
+            "name": attr_value(attrs, "categories"),
+        },
+        "splat": attr_value(attrs, "splat"),
+    }
+    params = detail_params(source_item)
+    if params:
+        product["detail_url_params"] = params
+    description_html = attr_value(attrs, "description")
+    if include_description and description_html:
+        product["description"] = html_to_text(description_html)
+        product["description_html"] = description_html
+    return product
+
+
+def search_items(payload: Any) -> tuple[int | None, list[dict[str, Any]]]:
+    if not isinstance(payload, dict):
+        return None, []
+    universes = payload.get("universes") if isinstance(payload.get("universes"), dict) else {}
+    universe = first_dict(universes.get("universe"))
+    section = universe.get("items-section") if isinstance(universe.get("items-section"), dict) else {}
+    results = section.get("results") if isinstance(section.get("results"), dict) else {}
+    total = to_int(results.get("total-items"))
+    items = []
+    item_block = section.get("items") if isinstance(section.get("items"), dict) else {}
+    for item in as_list(item_block.get("item")):
+        if isinstance(item, dict):
+            items.append(item)
+    return total, items
+
+
+def elapsed_ms(started: float) -> int:
+    return round((time.perf_counter() - started) * 1000)
+
+
+def page_offset(page: int, limit: int) -> int:
+    return (max(1, page) - 1) * max(1, limit)
+
+
+def clamp_limit(limit: int) -> int:
+    return min(max(1, limit), 100)
+
+
+def category_token(category_id: str) -> str:
+    text = str(category_id).strip().strip("{}")
+    if not text:
+        die("category ID is required")
+    if text.isdigit():
+        return "chemnz" + text
+    return text
+
+
+def short_category_id(catid: Any) -> str:
+    if not catid:
+        return ""
+    matches = re.findall(r"chemnz(\d+)", str(catid))
+    return matches[-1] if matches else str(catid)
+
+
+def product_id_from_ref(ref: str) -> str:
+    text = str(ref).strip()
+    parsed = urllib.parse.urlparse(text)
+    query = urllib.parse.parse_qs(parsed.query if parsed.scheme else text)
+    if query.get("fh_secondid"):
+        return query["fh_secondid"][0]
+    if parsed.scheme:
+        match = re.search(r"/buy/(\d+)(?:/|$)", parsed.path)
+        if match:
+            return match.group(1)
+    if text.isdigit():
+        return text
+    match = re.search(r"\b(\d{3,})\b", text)
+    if match:
+        return match.group(1)
+    die("product must be a numeric product ID or /buy/<id>/ product URL")
+
+
+def cmd_suggest(args: argparse.Namespace) -> None:
+    started = time.perf_counter()
+    limit = clamp_limit(args.limit)
+    payload, url = request_json("/suggest", {"identifier": "nz", "search": args.term})
+    keywords: list[dict[str, Any]] = []
+    categories: list[dict[str, Any]] = []
+    products: list[dict[str, Any]] = []
+    groups = payload.get("suggestionGroups") if isinstance(payload, dict) else []
+    for group in as_list(groups):
+        if not isinstance(group, dict):
+            continue
+        index_name = group.get("indexName")
+        suggestions = [s for s in as_list(group.get("suggestions")) if isinstance(s, dict)]
+        if index_name == "1keywords":
+            for item in suggestions[:limit]:
+                keywords.append({"term": item.get("searchterm") or "", "total": to_int(item.get("nrResults"))})
+        elif index_name == "2categories":
+            for item in suggestions[:limit]:
+                catid = item.get("catid")
+                categories.append(
+                    {
+                        "name": item.get("mlValue") or "",
+                        "category_id": short_category_id(catid),
+                        "catid": catid,
+                        "total": to_int(item.get("nrResults")),
+                        "fh_location": item.get("fhLocation"),
+                    }
+                )
+        elif index_name == "3products":
+            for item in suggestions[:limit]:
+                products.append(normalize_product(item))
+    data = {
+        "kind": "suggest",
+        "source": SOURCE,
+        "source_url": url,
+        "query": args.term,
+        "total": len(keywords) + len(categories) + len(products),
+        "results": {
+            "keywords": len(keywords),
+            "categories": len(categories),
+            "products": len(products),
+        },
+        "items": products,
+        "groups": {
+            "keywords": keywords,
+            "categories": categories,
+            "products": products,
+        },
+        "elapsed_ms": elapsed_ms(started),
+    }
+    emit(data, args.json)
+
+
+def cmd_search(args: argparse.Namespace) -> None:
+    started = time.perf_counter()
+    limit = clamp_limit(args.limit)
+    page = max(1, args.page)
+    location = ROOT_LOCATION + "/$s=" + args.term
+    payload, url = request_json(
+        "/search",
+        {
+            "identifier": "nz",
+            "fh_location": location,
+            "fh_start_index": page_offset(page, limit),
+            "fh_view_size": limit,
+        },
+    )
+    total, raw_items = search_items(payload)
+    items = [normalize_product(item) for item in raw_items[:limit]]
+    data = {
+        "kind": "search",
+        "source": SOURCE,
+        "source_url": url,
+        "query": args.term,
+        "page": page,
+        "limit": limit,
+        "offset": page_offset(page, limit),
+        "total": total,
+        "results": len(items),
+        "items": items,
+        "elapsed_ms": elapsed_ms(started),
+    }
+    emit(data, args.json)
+
+
+def cmd_category(args: argparse.Namespace) -> None:
+    started = time.perf_counter()
+    limit = clamp_limit(args.limit)
+    page = max(1, args.page)
+    token = category_token(args.category_id)
+    location = ROOT_LOCATION + f"/categories<{{{token}}}"
+    payload, url = request_json(
+        "/search",
+        {
+            "identifier": "nz",
+            "fh_location": location,
+            "fh_start_index": page_offset(page, limit),
+            "fh_view_size": limit,
+        },
+    )
+    total, raw_items = search_items(payload)
+    items = [normalize_product(item) for item in raw_items[:limit]]
+    data = {
+        "kind": "category",
+        "source": SOURCE,
+        "source_url": url,
+        "category_id": args.category_id,
+        "category_token": token,
+        "page": page,
+        "limit": limit,
+        "offset": page_offset(page, limit),
+        "total": total,
+        "results": len(items),
+        "items": items,
+        "elapsed_ms": elapsed_ms(started),
+    }
+    emit(data, args.json)
+
+
+def cmd_product(args: argparse.Namespace) -> None:
+    started = time.perf_counter()
+    product_id = product_id_from_ref(args.product)
+    payload, url = request_json(
+        "/search",
+        {
+            "identifier": "nz",
+            "site": "cw_nz",
+            "channel": "desktop",
+            "fh_location": ROOT_LOCATION,
+            "fh_start_index": 0,
+            "fh_refview": "search",
+            "fh_secondid": product_id,
+            "fh_lister_pos": 1,
+            "fh_modification": "",
+        },
+    )
+    total, raw_items = search_items(payload)
+    items = [normalize_product(item, include_description=True) for item in raw_items]
+    if not items:
+        die(f"product not found: {product_id}")
+    data = {
+        "kind": "product",
+        "source": SOURCE,
+        "source_url": url,
+        "product_id": product_id,
+        "total": total if total is not None else len(items),
+        "results": len(items),
+        "items": items,
+        "elapsed_ms": elapsed_ms(started),
+    }
+    emit(data, args.json)
+
+
+def money(value: Any) -> str:
+    if value is None:
+        return "-"
+    try:
+        return f"${float(value):.2f}"
+    except (TypeError, ValueError):
+        return str(value)
+
+
+def price_label(item: dict[str, Any]) -> str:
+    price = item.get("price")
+    label = money(price)
+    rrp = item.get("rrp")
+    if rrp is not None and rrp != price:
+        label += f" (RRP {money(rrp)})"
+    return label
+
+
+def product_status(item: dict[str, Any]) -> str:
+    bits = []
+    if item.get("is_prescription") is True:
+        bits.append("prescription")
+    elif item.get("is_prescription") is False:
+        bits.append("non-prescription")
+    if item.get("ams_schedule") is not None:
+        bits.append(f"schedule {item['ams_schedule']}")
+    rating = item.get("rating") if isinstance(item.get("rating"), dict) else {}
+    if rating.get("stars") is not None:
+        votes = rating.get("votes")
+        bits.append(f"{rating['stars']:.1f} stars" + (f" ({votes})" if votes is not None else ""))
+    return " | ".join(bits)
+
+
+def print_product_line(item: dict[str, Any]) -> None:
+    product_id = item.get("product_id") or ""
+    name = item.get("name") or ""
+    print(f"{product_id:>8}  {price_label(item):<22}  {name}".rstrip())
+    status = product_status(item)
+    if status:
+        print(f"          {status}")
+    if item.get("url"):
+        print(f"          {item['url']}")
+
+
+def print_suggest(data: dict[str, Any]) -> None:
+    print(f"suggestions for {data.get('query')!r}: {data.get('total', 0)} ({data.get('elapsed_ms')} ms)")
+    groups = data.get("groups") if isinstance(data.get("groups"), dict) else {}
+    keywords = groups.get("keywords") if isinstance(groups.get("keywords"), list) else []
+    categories = groups.get("categories") if isinstance(groups.get("categories"), list) else []
+    products = groups.get("products") if isinstance(groups.get("products"), list) else []
+    if keywords:
+        print("Keywords:")
+        for item in keywords:
+            suffix = f" ({item.get('total')})" if item.get("total") is not None else ""
+            print(f"  {item.get('term', '')}{suffix}")
+    if categories:
+        print("Categories:")
+        for item in categories:
+            suffix = f" ({item.get('total')})" if item.get("total") is not None else ""
+            category_id = item.get("category_id") or item.get("catid") or ""
+            print(f"  {category_id}  {item.get('name', '')}{suffix}")
+    if products:
+        print("Products:")
+        for item in products:
+            print_product_line(item)
+
+
+def print_items(data: dict[str, Any]) -> None:
+    label = data.get("query") or data.get("category_id") or data.get("product_id") or "items"
+    total = data.get("total")
+    total_label = "unknown total" if total is None else f"{total} total"
+    print(f"{data.get('kind')}: {label!r}, {data.get('results', 0)} shown, {total_label} ({data.get('elapsed_ms')} ms)")
+    for item in data.get("items") or []:
+        print_product_line(item)
+
+
+def print_detail(data: dict[str, Any]) -> None:
+    item = (data.get("items") or [{}])[0]
+    print_product_line(item)
+    categories = item.get("categories") if isinstance(item.get("categories"), dict) else {}
+    category_name = categories.get("name")
+    if category_name:
+        print(f"Category: {category_name}")
+    description = item.get("description")
+    if description:
+        clipped = description[:360] + "..." if len(description) > 360 else description
+        print(f"Description: {clipped}")
+    if item.get("image"):
+        print(f"Image: {item['image']}")
+
+
+def emit(data: dict[str, Any], as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2, ensure_ascii=False))
+        return
+    if data.get("kind") == "suggest":
+        print_suggest(data)
+    elif data.get("kind") == "product":
+        print_detail(data)
+    else:
+        print_items(data)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Chemist Warehouse NZ live product lookup CLI (public read-only endpoints, no login)."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    sp = sub.add_parser("suggest", help="query keyword, category, and product suggestions")
+    sp.add_argument("term")
+    sp.add_argument("--limit", type=int, default=5)
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_suggest)
+
+    sp = sub.add_parser("search", help="search live product listings by term")
+    sp.add_argument("term")
+    sp.add_argument("--limit", type=int, default=10)
+    sp.add_argument("--page", type=int, default=1, help="one-based results page")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_search)
+
+    sp = sub.add_parser("category", help="list products in a Chemist Warehouse NZ category ID")
+    sp.add_argument("category_id")
+    sp.add_argument("--limit", type=int, default=10)
+    sp.add_argument("--page", type=int, default=1, help="one-based results page")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_category)
+
+    sp = sub.add_parser("product", help="fetch product detail by product ID or /buy/<id>/ URL")
+    sp.add_argument("product")
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_product)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    args.func(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/chemistwarehouse-nz/scripts/smoke_test.py
+++ b/skills/chemistwarehouse-nz/scripts/smoke_test.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Live read-only smoke tests for the Chemist Warehouse NZ skill."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).parent.parent
+CLI = SKILL_DIR / "scripts" / "cli.py"
+
+
+def run(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CLI)] + args,
+        capture_output=True,
+        text=True,
+        cwd=str(SKILL_DIR),
+        timeout=45,
+    )
+
+
+def test(name: str, fn) -> bool:
+    try:
+        ok = fn()
+        print(f"[{'PASS' if ok else 'FAIL'}] {name}")
+        return ok
+    except Exception as e:
+        print(f"[FAIL] {name}")
+        print(f"  error: {e}")
+        return False
+
+
+def load_json(result: subprocess.CompletedProcess[str]) -> dict:
+    if result.returncode != 0:
+        raise AssertionError(f"command failed: {result.stderr[:300]}")
+    try:
+        data = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise AssertionError(f"invalid JSON: {e}; stdout={result.stdout[:300]!r}")
+    if not isinstance(data, dict):
+        raise AssertionError("expected JSON object")
+    return data
+
+
+def test_help() -> bool:
+    result = run(["--help"])
+    return result.returncode == 0 and "Chemist Warehouse NZ" in result.stdout
+
+
+def test_suggest() -> bool:
+    data = load_json(run(["suggest", "panadol", "--limit", "2", "--json"]))
+    groups = data.get("groups") if isinstance(data.get("groups"), dict) else {}
+    products = groups.get("products")
+    keywords = groups.get("keywords")
+    if not isinstance(products, list) or not products:
+        raise AssertionError("expected product suggestions")
+    if not isinstance(keywords, list) or not keywords:
+        raise AssertionError("expected keyword suggestions")
+    return bool(products[0].get("product_id") and products[0].get("name"))
+
+
+def test_search() -> str:
+    data = load_json(run(["search", "vitamin c", "--limit", "3", "--json"]))
+    items = data.get("items")
+    if not isinstance(items, list) or not items:
+        raise AssertionError("expected search items")
+    if not data.get("total") or data.get("total") < len(items):
+        raise AssertionError("expected total >= returned items")
+    product_id = str(items[0].get("product_id") or "")
+    if not product_id:
+        raise AssertionError("expected product_id in first search result")
+    return product_id
+
+
+def test_category() -> bool:
+    data = load_json(run(["category", "256", "--limit", "3", "--json"]))
+    items = data.get("items")
+    if not isinstance(items, list) or not items:
+        raise AssertionError("expected category items")
+    if not data.get("total") or data.get("total") < len(items):
+        raise AssertionError("expected category total >= returned items")
+    return True
+
+
+def test_product(product_id: str) -> bool:
+    data = load_json(run(["product", product_id, "--json"]))
+    items = data.get("items")
+    if not isinstance(items, list) or len(items) != 1:
+        raise AssertionError("expected one product detail item")
+    item = items[0]
+    if item.get("product_id") != product_id:
+        raise AssertionError(f"expected product_id {product_id}, got {item.get('product_id')}")
+    if not item.get("name") or not item.get("url"):
+        raise AssertionError("expected detail name and URL")
+    return True
+
+
+results: list[bool] = []
+results.append(test("--help exits 0", test_help))
+results.append(test("suggest panadol returns keyword and product suggestions", test_suggest))
+
+search_product_id = ""
+
+
+def capture_search() -> bool:
+    global search_product_id
+    search_product_id = test_search()
+    return bool(search_product_id)
+
+
+results.append(test("search vitamin c returns products", capture_search))
+results.append(test("category 256 returns products", test_category))
+
+if search_product_id:
+    results.append(test("product detail returns a live item", lambda: test_product(search_product_id)))
+else:
+    results.append(False)
+    print("[FAIL] product detail returns a live item")
+    print("  error: skipped because search did not produce a product ID")
+
+if all(results):
+    print("All tests passed.")
+    raise SystemExit(0)
+
+print(f"{results.count(False)} test(s) failed.")
+raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Add Chemist Warehouse NZ public searchapiv2 skill with suggest/search/category/product commands
- Add Bargain Chemist NZ public Boost Commerce + Shopify product JSON skill with search/suggest/product commands
- Document no-auth read-only API surfaces and boundaries for both skills

## Test Plan
- python3 scripts/validate_skill.py skills/chemistwarehouse-nz
- python3 scripts/validate_skill.py skills/bargainchemist-nz
- python3 skills/chemistwarehouse-nz/scripts/smoke_test.py
- python3 skills/bargainchemist-nz/scripts/smoke_test.py
- python3 scripts/validate_skill.py skills
- bash scripts/run_all_smoke.sh

Latest local result: validator clean; smoke PASS 35, SKIP 4, FAIL 0.