### PR TITLE
ci: require skill validation on PRs

### DIFF
--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -1,0 +1,19 @@
+name: Validate Skills
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  validate-skills:
+    runs-on: [self-hosted, linux, x64, skills-smoke]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: '3.12'
+
+      - name: Validate all skills
+        run: python3 scripts/validate_skill.py --strict


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/validate-skills.yml` that runs on every PR targeting `main` (opened, synchronize, reopened)
- Executes `python3 scripts/validate_skill.py --strict` — fails if any skill has missing/invalid frontmatter, broken local links, scaffold placeholders, or forbidden files
- Uses the same self-hosted runner (`skills-smoke`) and setup pattern as the existing smoke-tests workflow
- Job is named `validate-skills` so it can be set as a required status check in branch protection

## Test plan

- [x] `python3 scripts/validate_skill.py --strict` runs clean locally (all 39 skills pass)
- [x] Workflow YAML is valid (verified with Python `yaml.safe_load`)
- [ ] Confirm `validate-skills` job appears in GitHub Actions on this PR
- [ ] Add `validate-skills` as a required status check under Settings → Branches → main

🤖 Generated with [Claude Code](https://claude.com/claude-code)