### PR TITLE
fix(nzpost-tracking): smoke_test.py skip stub

### DIFF
--- a/skills/nzpost-tracking/SKILL.md
+++ b/skills/nzpost-tracking/SKILL.md
@@ -8,3 +8,5 @@ description: DEPRECATED, renamed to nzpost. Use the nzpost skill instead.
 This skill has been renamed to **nzpost**. Install that instead.
 
 The old name will be removed in a future release.
+
+The `scripts/` directory contains only a no-op smoke test stub that exits 0 with a `[SKIP]` marker so CI does not fail on this deprecation alias. No tools live here.

--- a/skills/nzpost-tracking/scripts/smoke_test.py
+++ b/skills/nzpost-tracking/scripts/smoke_test.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+"""Deprecation stub. Real skill renamed to nzpost."""
+print("[SKIP] nzpost-tracking is a deprecation stub; see skills/nzpost")


### PR DESCRIPTION
## Why

Main-branch smoke job failed immediately after #78 merged: the new \`nzpost-tracking\` deprecation alias has no \`scripts/smoke_test.py\`, and \`scripts/run_all_smoke.sh\` runs every skill dir unconditionally.

\`\`\`
FAIL: nzpost-tracking
python3: can't open file '.../skills/nzpost-tracking/scripts/smoke_test.py': [Errno 2] No such file or directory
\`\`\`

## Fix

One-line skip stub that exits 0 and prints \`[SKIP]\`, so the runner classifies it as skipped rather than failed.

## Why a stub rather than runner change

Smaller blast radius. Touching \`run_all_smoke.sh\` to special-case missing files affects 50 other skills. A stub keeps the contract intact.