### PR TITLE
fix: accept json flag on Akahu endpoint command

### DIFF
--- a/skills/akahu-personal/scripts/cli.py
+++ b/skills/akahu-personal/scripts/cli.py
@@ -279,6 +279,7 @@ def main(argv=None):
     p.add_argument("--data-json", help="JSON request body for POST/PUT/PATCH")
     p.add_argument("--data-file", help="path to JSON request body for POST/PUT/PATCH")
     p.add_argument("--raw-account-numbers", action="store_true", help="do not redact account numbers")
+    p.add_argument("--json", action="store_true", help="accepted for consistency; endpoint output is always JSON")
     p.add_argument("--i-understand-this-can-mutate", action="store_true", help="required for POST/PUT/PATCH/DELETE")
     p.set_defaults(func=cmd_endpoint)
 


### PR DESCRIPTION
## Summary
- Accepts `--json` on `akahu-personal endpoint` for consistency with the documented examples
- Endpoint output was already JSON; this fixes the CLI argument parser so the docs and command agree

## Test Plan
- [x] `python3 skills/akahu-personal/scripts/cli.py endpoint /accounts --json --help`
- [x] `python3 scripts/validate_skill.py skills/akahu-personal --strict`
- [x] `python3 scripts/check_readme_skills.py`
