### PR TITLE
fix: cap Akahu transaction exports client-side

### DIFF
--- a/skills/akahu-personal/references/api-notes.md
+++ b/skills/akahu-personal/references/api-notes.md
@@ -32,10 +32,10 @@ Implemented endpoints:
 
 - `GET /me` - identity/access-grant metadata for the authorised user
 - `GET /accounts` - account names, masked/formatted account identifiers, status, type, attributes, balances, refresh timestamps
-- `GET /transactions` - recent transactions; supports date range and limit query parameters in the CLI
-- `endpoint PATH` - escape hatch for the full Akahu Personal App API surface, including account-specific transactions, pending transactions, parties, payments, webhooks, refresh, categories, connections, and other documented paths
+- `GET /transactions` - recent transactions; supports date range query parameters and client-side `--limit` capping in the CLI
+- `endpoint PATH` - escape hatch for Akahu API paths using Personal App authentication, including account-specific transactions, pending transactions, parties, payments, webhooks, refresh, and other documented paths when the token has permission
 
-The named commands cover common read-only analysis. Use `endpoint` when Akahu adds new endpoints or the task needs a path not represented by a first-class subcommand.
+The named commands cover common read-only analysis. Use `endpoint` when Akahu adds new endpoints or the task needs a path not represented by a first-class subcommand. Some documented Akahu endpoints are app-scoped or require permissions/scopes that a Personal App token may not have; those correctly return Akahu `401`/`403` errors.
 
 ## Data boundaries
 

--- a/skills/akahu-personal/scripts/cli.py
+++ b/skills/akahu-personal/scripts/cli.py
@@ -148,6 +148,14 @@ def maybe_redact(data, raw):
     return data if raw else redact_obj(data)
 
 
+def limit_items_response(data, limit):
+    if isinstance(data, dict) and isinstance(data.get("items"), list):
+        clone = dict(data)
+        clone["items"] = data["items"][:limit]
+        return clone
+    return data
+
+
 def cmd_me(args):
     data = get_client(args).get("/me")
     emit(data, args.json)
@@ -165,6 +173,7 @@ def cmd_transactions(args):
     if args.end:
         params.append(("end", args.end))
     data = get_client(args).get("/transactions", params=params)
+    data = limit_items_response(data, args.limit)
     emit(maybe_redact(data, args.raw_account_numbers), args.json)
 
 
@@ -211,7 +220,7 @@ def cmd_export(args):
     datasets = {
         "me.json": client.get("/me"),
         "accounts.json": maybe_redact(client.get("/accounts"), args.raw_account_numbers),
-        "transactions_recent.json": maybe_redact(client.get("/transactions", [("limit", str(args.limit))]), args.raw_account_numbers),
+        "transactions_recent.json": maybe_redact(limit_items_response(client.get("/transactions", [("limit", str(args.limit))]), args.limit), args.raw_account_numbers),
     }
     for filename, data in datasets.items():
         path = out_dir / filename


### PR DESCRIPTION
## Summary
- Caps `transactions --limit N` and `export --limit N` client-side because the Akahu API can return more rows than requested
- Clarifies that generic `endpoint` calls use Personal App authentication and may receive Akahu `401`/`403` for app-scoped or unpermitted endpoints

## Test Plan
- [x] `python3 scripts/validate_skill.py skills/akahu-personal --strict`
- [x] `python3 scripts/check_readme_skills.py`
- [x] Live local spin confirmed `transactions --limit 10` and export needed client-side capping
