### PR TITLE
feat: add Air NZ and Jetstar flight skills

### DIFF
--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -18,9 +18,23 @@ jobs:
         with:
           python-version: '3.12'
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install CloakBrowser for browser-assisted smoke tests
+        run: |
+          uv run --no-project --with cloakbrowser python -m cloakbrowser install
+          uv run --no-project --with cloakbrowser python - <<'PY'
+          from cloakbrowser import launch
+          print("CloakBrowser import OK", launch)
+          PY
+
       - name: Run smoke tests (parallel)
         env:
           AT_API_KEY: ${{ secrets.AT_API_KEY }}
           METOCEAN_API_KEY: ${{ secrets.METOCEAN_API_KEY }}
           METLINK_API_KEY: ${{ secrets.METLINK_API_KEY }}
+          HERMES_SMOKE_WITH_CLOAKBROWSER: "1"
+          HERMES_SMOKE_USE_BROWSER: "1"
         run: bash scripts/run_all_smoke.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ skills/<name>/          # each skill — kebab-case dir, one clear job
   scripts/cli.py        #   the tool (main entry point)
   scripts/smoke_test.py #   end-to-end test, exits non-zero on failure
   references/*.md       #   heavy detail (API schemas, tables) loaded on demand
+docs/                   # repo-wide conventions, including optional browser-assisted mode
 scripts/                # repo tooling (see below)
 templates/              # skill-minimal, skill-tool-wrapper, skill-cli-workflow
 template/SKILL.md       # base template new_skill.py copies from
@@ -64,6 +65,11 @@ These come from `CONTRIBUTING.md` and are enforced by validation/CI:
   (machine-readable for Claude) and otherwise prints clean human-readable text.
 - **Timeout every network call** (10s default) and fail with a clear human message — not a stack
   trace — when an upstream API is down or rate-limited.
+- **Optional browser-assisted mode:** direct HTTP/API stays preferred. If a public read-only site
+  needs a real browser context, expose an explicit `--browser` flag using
+  [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) when installed. Keep it optional, return
+  machine-readable `cloakbrowser_not_installed` when unavailable, and treat CAPTCHA/request-auth as
+  blocked states rather than bypass targets. See `docs/browser-assisted-skills.md`.
 - **NZ English** in user-facing strings ("organisation", "colour"); American spelling in code.
 - `smoke_test.py` exercises happy path + at least one edge case, is safe to re-run, and tolerates
   upstream flakiness (skip vs hard-fail on network errors).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,6 +28,24 @@ python3 skills/<name>/scripts/smoke_test.py
 - TypeScript/Node skill helpers are **not accepted** — all scripts must be Python
 - Avoid per-skill doc clutter
 
+## Optional browser-assisted mode
+
+Direct public HTTP/API calls are still the default. Only add a `--browser` mode when a public,
+read-only website exposes useful data more reliably inside a real browser context than from a bare
+HTTP client.
+
+Use [CloakBrowser](https://github.com/CloakHQ/CloakBrowser) for browser-assisted skills when it is
+installed. Keep the dependency optional: import it only when `--browser` is requested, keep normal
+validation and non-browser smoke tests working on clean hosts, and return a clear machine-readable
+`cloakbrowser_not_installed` error if the user requested browser mode on a machine without it.
+
+Browser-assisted mode is not CAPTCHA bypass tooling. If the site returns CAPTCHA, request-auth, bot
+challenge, login, checkout, payment, booking, cart mutation, or protected account flows, stop and
+return a blocked state or use a public fallback. Do not forge tokens, hold bookings, operate accounts,
+or complete transactions.
+
+Full convention: [`docs/browser-assisted-skills.md`](docs/browser-assisted-skills.md).
+
 ## Definition of done
 
 A contribution is only ready when it passes all of these:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,20 @@ python3 skills/at-transport/scripts/cli.py alerts
 
 No auth needed for `fuelclock-nz`, `metservice-nz`, or `nz-news`. `at-transport` requires a free API key from [dev-portal.at.govt.nz](https://dev-portal.at.govt.nz).
 
+## Optional browser-assisted mode
+
+Most skills use direct public HTTP/API calls. Some modern sites only expose useful public data reliably inside a real browser context, especially on headless servers. Those skills may offer an explicit `--browser` flag.
+
+Recommended runtime: [CloakBrowser](https://github.com/CloakHQ/CloakBrowser). Full convention: [docs/browser-assisted-skills.md](docs/browser-assisted-skills.md).
+
+Recommended convention:
+
+- `--browser` should use CloakBrowser when it is installed.
+- CloakBrowser must be optional: normal validation and non-browser smoke tests should still run on clean hosts.
+- If CloakBrowser is missing, the CLI should return a clear `cloakbrowser_not_installed` error so the agent can recommend installing it instead of silently pretending browser mode ran.
+- Browser-assisted skills must stay read-only and stop before login, checkout, payment, booking, cart mutation, or protected account actions.
+- CAPTCHA, request-auth, and bot challenges are blocked states, not puzzles to defeat; return an explicit blocked flag or clear error and use a public fallback when one exists.
+
 ## About this repository
 
 This repo is intentionally structured like a proper skills library.
@@ -58,6 +72,7 @@ If you're a business looking at this and thinking "how do we actually want AI ag
 | Skill | Description |
 |-------|-------------|
 | [akahu-personal](skills/akahu-personal/SKILL.md) | Query personal transactional bank-account data — account lists, balances, settled/pending transactions, account-specific transaction history, and private JSON/CSV exports — from Akahu, a New Zealand open-banking provider. Use when the task involves personal bank data exports, NZ account balances, transaction analysis, cashflow/spending categorisation, or inspecting authenticated Personal App banking data. Requires user-provided AKAHU_APP_TOKEN and AKAHU_USER_TOKEN; never smoke-test against real personal data in CI. |
+| [airnz-flights](skills/airnz-flights/SKILL.md) | Search public Air New Zealand fare snapshots and timetable fallback data through a lightweight no-login CLI. Use when the task involves Air NZ route/date fare snapshots, fare products, flight numbers, departure/arrival times, duration, stops, or machine-readable current flight data. Optional --browser mode uses CloakBrowser when installed and returns cloakbrowser_not_installed when unavailable. Read-only; no login, Airpoints, seat holds, booking, payment, manage-booking, or checkout actions. |
 | [at-transport](skills/at-transport/SKILL.md) | Query live Auckland Transport (AT) public transport data — stops, departures, service alerts, vehicle positions, routes, and network status. Use when the task involves Auckland buses, trains, ferries, or real-time transit information. |
 | [auckland-bin-schedule](skills/auckland-bin-schedule/SKILL.md) | Query Auckland Council rubbish, recycling, and food scraps collection days for Auckland properties using the public collection-day website flow. Use when the task involves Auckland bin day, rubbish/recycling schedules, food scraps collection, address lookup, or property-id based collection checks. No account login required. |
 | [bargainchemist-nz](skills/bargainchemist-nz/SKILL.md) | Query Bargain Chemist NZ public product search, suggestions, and Shopify product JSON through a lightweight no-login CLI. Use when the task involves Bargain Chemist NZ product lookup, current online prices, availability, product handles, or machine-readable public product data. Read-only; no cart, checkout, account, prescription, or order actions. |
@@ -76,6 +91,7 @@ If you're a business looking at this and thinking "how do we actually want AI ag
 | [geonet-nz](skills/geonet-nz/SKILL.md) | Query GeoNet New Zealand public earthquake, volcano alert, and GeoNet news endpoints through a lightweight no-login CLI. Use when the task involves recent NZ earthquakes, felt/MMI-filtered quakes, earthquake detail by publicID, volcanic alert levels, volcanic activity bulletins, or GeoNet public geohazard updates. Read-only; no authentication required. |
 | [homes-nz](skills/homes-nz/SKILL.md) | Query homes.co.nz NZ residential property estimates (HomesEstimate/HEV), sales history, suburb trends, and nearby comparable properties. No login required. |
 | [interest-co-nz](skills/interest-co-nz/SKILL.md) | Query interest.co.nz public mortgage-rate tables through a lightweight no-login HTML parser. Use when the task involves current New Zealand mortgage rates, bank home-loan rates, variable/floating rates, fixed terms from 6 months to 5 years, special LVR rows, or comparing advertised mortgage rates across NZ lenders. Read-only; no application, lead, login, or quote submission. |
+| [jetstar-flights](skills/jetstar-flights/SKILL.md) | Search public Jetstar New Zealand one-way fare-cache flight availability through a no-login Node CLI. Use when the task involves Jetstar route/date fare snapshots, low-fare availability, flight IDs, prices, or machine-readable current Jetstar availability. Read-only; no login, Club Jetstar account, booking, seat hold, payment, manage-booking, or checkout actions. |
 | [kmart](skills/kmart/SKILL.md) | Query Kmart NZ and AU product search, prices, SKU lookup, clearance/promotional snapshots, and store-location data. Read-only; no login, cart, checkout, or account actions. |
 | [lawa-nz](skills/lawa-nz/SKILL.md) | Query Land Air Water Aotearoa (LAWA) public river-quality sites, swimming sites, and river indicator summaries through no-login Umbraco JSON endpoints. Use when the task involves NZ river quality, macroinvertebrate/community index data, E. coli/nutrient indicator bands, swim-site listings, or LAWA environmental monitoring site discovery. Read-only. |
 | [linz-data-service](skills/linz-data-service/SKILL.md) | Search and inspect LINZ Data Service public Koordinates catalogue layers, tables, services, licences, tags, and download/view capabilities through no-login JSON endpoints. Use when the task involves Toitū Te Whenua LINZ datasets such as addresses, parcels, imagery, hydrography, roads, property, or geospatial layers. Read-only; no API key needed for catalogue metadata. |

--- a/docs/browser-assisted-skills.md
+++ b/docs/browser-assisted-skills.md
@@ -1,0 +1,102 @@
+# Browser-assisted skills
+
+Most skills in this repository should stay as simple direct HTTP/API CLIs. Use browser assistance only when a public, read-only website exposes useful data more reliably from a real browser context than from a bare HTTP client.
+
+Recommended browser runtime: [CloakBrowser](https://github.com/CloakHQ/CloakBrowser).
+
+## When to add `--browser`
+
+Add an explicit `--browser` flag when all of these are true:
+
+- the data is public and no-login;
+- direct HTTP/API calls are unreliable, incomplete, or frequently challenged;
+- a real browser context materially improves access to the same public read-only workflow;
+- the skill still has a useful non-browser fallback or a clear failure mode;
+- the workflow stops before login, checkout, payment, booking, cart mutation, account actions, or protected user data.
+
+Do not add `--browser` just because automation is possible. If the direct public endpoint works cleanly, prefer the simpler CLI.
+
+## Required behaviour
+
+Browser-assisted mode must be opt-in and honest:
+
+- expose it as `--browser`, not as the default path;
+- import/use CloakBrowser only when `--browser` is requested;
+- keep normal validation and non-browser smoke tests working on clean hosts;
+- if CloakBrowser is missing, return a clear machine-readable error named `cloakbrowser_not_installed`;
+- include a human recommendation to install CloakBrowser or rerun without `--browser`;
+- treat CAPTCHA, request-auth, bot challenges, or protected flows as blocked states, not puzzles to defeat;
+- if the browser path is blocked but a public fallback exists, return the fallback data and include an explicit blocked flag such as `fare_search_blocked: true`.
+
+Example JSON error:
+
+```json
+{
+  "error": "cloakbrowser_not_installed",
+  "message": "Install CloakBrowser to use --browser.",
+  "recommendation": "Recommend that the user installs CloakBrowser or reruns without --browser for the fallback path."
+}
+```
+
+## Implementation sketch
+
+Use this shape for Python CLIs:
+
+```python
+class CloakBrowserNotInstalled(RuntimeError):
+    pass
+
+
+def fetch_with_browser(...):
+    try:
+        from cloakbrowser import launch
+    except ImportError as exc:
+        raise CloakBrowserNotInstalled(
+            "cloakbrowser_not_installed: install CloakBrowser to use --browser"
+        ) from exc
+
+    with launch(
+        headless=True,
+        timezone="Pacific/Auckland",
+        locale="en-NZ",
+        args=["--no-sandbox", "--disable-dev-shm-usage"],
+    ) as browser:
+        page = browser.new_page()
+        # Navigate public pages and read public data only.
+```
+
+For headless Linux servers, include safe Chromium flags where supported:
+
+```text
+--no-sandbox
+--disable-dev-shm-usage
+```
+
+## Documentation requirements
+
+When a skill offers `--browser`, document it in:
+
+- `SKILL.md` usage/flags;
+- `references/api-notes.md`, including the direct source, browser-assisted source, and blocked-state behaviour;
+- smoke/validation notes, making clear that browser mode is optional for local clean-host validation but installed in GitHub Actions smoke runs.
+
+Include the CloakBrowser repo link where useful: <https://github.com/CloakHQ/CloakBrowser>.
+
+## CI and smoke tests
+
+GitHub Actions smoke runs should install CloakBrowser and set:
+
+```text
+HERMES_SMOKE_WITH_CLOAKBROWSER=1
+HERMES_SMOKE_USE_BROWSER=1
+```
+
+`scripts/run_all_smoke.sh` uses `uv run --with cloakbrowser` when `HERMES_SMOKE_WITH_CLOAKBROWSER=1`, so browser-assisted smoke tests can import CloakBrowser without making it a repo-wide static dependency.
+
+For skills where `--browser` is the richer or more realistic path, the smoke test should prefer `--browser` when CloakBrowser is available or when `HERMES_SMOKE_USE_BROWSER=1` is set. It may still accept a clearly marked blocked/fallback state, for example `fare_search_blocked: true`, when the upstream site returns request-auth/CAPTCHA. A missing CloakBrowser install in CI should fail loudly rather than silently testing only the fallback.
+
+## Security and ethics boundary
+
+Browser-assisted mode is not CAPTCHA bypass tooling. Do not ship code whose purpose is to evade technical access controls, forge protected tokens, operate accounts, place orders, hold bookings, or complete transactions.
+
+The acceptable use case is narrow: use a real browser context to read the same public information a normal visitor can see, then convert that information into deterministic, agent-readable output.

--- a/scripts/run_all_smoke.sh
+++ b/scripts/run_all_smoke.sh
@@ -8,7 +8,11 @@ mkdir -p "$RESULTS_DIR"
 
 _smoke_one() {
     local skill="$1"
-    uv run --no-project python "$REPO_ROOT/skills/$skill/scripts/smoke_test.py" \
+    local uv_args=(run --no-project)
+    if [[ "${HERMES_SMOKE_WITH_CLOAKBROWSER:-}" == "1" ]]; then
+        uv_args+=(--with cloakbrowser)
+    fi
+    uv "${uv_args[@]}" python "$REPO_ROOT/skills/$skill/scripts/smoke_test.py" \
         > "$RESULTS_DIR/${skill}.log" 2>&1
     printf '%d\n' $? > "$RESULTS_DIR/${skill}.exit"
 }

--- a/skills/airnz-flights/SKILL.md
+++ b/skills/airnz-flights/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: airnz-flights
+description: Search public Air New Zealand fare snapshots and timetable fallback data through a lightweight no-login CLI. Use when the task involves Air NZ route/date fare snapshots, fare products, flight numbers, departure/arrival times, duration, stops, or machine-readable current flight data. Optional --browser mode uses CloakBrowser when installed and returns cloakbrowser_not_installed when unavailable. Read-only; no login, Airpoints, seat holds, booking, payment, manage-booking, or checkout actions.
+---
+
+# Air New Zealand Flights
+
+## Goal
+
+Query live public Air New Zealand fare snapshots when the anonymous browser-style search is accepted, with a public timetable fallback when Air NZ returns request-auth/CAPTCHA.
+
+## Use this when
+
+- A user asks to search current Air New Zealand flights by origin, destination, and date
+- A user wants a public timetable snapshot for NZ domestic or Air NZ-served routes
+- A workflow needs flight times, flight numbers, duration, stops, or booking-search handoff URLs
+- An agent is comparing public airline availability without logging in or holding seats
+
+## Do not use this for
+
+- Booking, payment, seat selection, fare holds, checkout, Airpoints login, manage-booking, refund/change actions, or passenger details
+- Private/authenticated booking data
+- High-volume scraping, fare-history warehousing, or bypassing Air NZ controls
+- Claims about final payable totals; prices, when returned, are pre-checkout fare snapshots only
+
+## Preferred workflow
+
+1. Ask for or infer IATA airport codes and a specific departure date.
+2. Run `scripts/cli.py ORIGIN DESTINATION YYYY-MM-DD` with the narrowest useful query.
+3. Prefer `--browser` on headless servers or anti-bot-sensitive workflows when CloakBrowser is installed; if it is not installed, the CLI returns `cloakbrowser_not_installed` so the agent can recommend installation.
+4. Use `--direct` if only direct services are useful.
+5. Use `--limit` for concise human output or `--json` for agent chaining.
+6. Treat results as live snapshots: fares/schedules can change without notice.
+7. If JSON includes `fare_search_blocked: true`, Air NZ returned request-auth/CAPTCHA and the CLI has fallen back to schedules only.
+8. Send users to the returned booking search URL if they want to complete a booking themselves.
+
+## CLI
+
+Run from the repository root:
+
+```bash
+python3 skills/airnz-flights/scripts/cli.py <origin> <destination> <date> [flags]
+```
+
+Examples:
+
+```bash
+python3 skills/airnz-flights/scripts/cli.py AKL WLG 2026-07-13 --limit 5
+python3 skills/airnz-flights/scripts/cli.py AKL WLG 2026-07-13 --browser --limit 5
+python3 skills/airnz-flights/scripts/cli.py AKL CHC 2026-07-13 --browser --json
+python3 skills/airnz-flights/scripts/cli.py WLG ZQN 2026-08-04 --direct
+```
+
+### Flags
+
+- `--direct` — direct flights only
+- `--adults N` — adult passenger count for the fare-search attempt
+- `--browser` — use optional CloakBrowser headless mode; if unavailable, returns `cloakbrowser_not_installed` for agents to surface as an installation recommendation
+- `--limit N` — max rows in human output
+- `--json` — emit machine-readable JSON
+
+## Resources
+
+- CLI entrypoint: `scripts/cli.py`
+- Live smoke test: `scripts/smoke_test.sh`
+- API/source notes: `references/api-notes.md`
+
+## Notes
+
+- Python Playwright is required for the timetable fallback because Air NZ's same public timetable feed can return empty results to bare non-browser clients while returning the public schedule in a normal browser context.
+- The CLI first attempts the browser-sniffed anonymous fare-search flow (`/vbook/ajax/bui/flights/search` → `selectitinerary`) and parses embedded `legOptions` prices when Air NZ accepts the request.
+- If Air NZ returns request-auth/CAPTCHA, the CLI falls back to `/feeds/flight-timetables` and marks `fare_search_blocked: true`.
+- `--browser` is optional, not mandatory. It imports CloakBrowser only when requested, so normal validation/smoke runs still work on clean hosts.
+- If `--browser --json` is requested and CloakBrowser is missing, the CLI returns a machine-readable `cloakbrowser_not_installed` error plus an installation recommendation instead of pretending the browser path ran.
+- The CLI deliberately stops before fare selection; it does not create a booking session, hold seats, or progress to checkout.
+- Keep usage narrow and respectful.

--- a/skills/airnz-flights/references/api-notes.md
+++ b/skills/airnz-flights/references/api-notes.md
@@ -1,0 +1,95 @@
+# Source notes
+
+## Browser-sniffed fare search
+
+A browser capture of Air New Zealand's public booking search found this anonymous no-login flow:
+
+```text
+GET  https://flightbookings.airnewzealand.co.nz/vbook/actions/ext-search?...route/date/passenger params...
+POST https://flightbookings.airnewzealand.co.nz/vbook/ajax/bui/flights/search
+GET  https://flightbookings.airnewzealand.co.nz/vbook/actions/selectitinerary
+```
+
+When the POST is accepted, the `selectitinerary` HTML contains embedded `legOptions` JSON with fare products such as `Seat`, `Seat + Bag`, `flexi change`, and `flexi refund`, including adult price, currency, booking class, flight number, aircraft, departure/arrival, and selling-out markers.
+
+The CLI now attempts this sniffed read-only fare path first and parses `legOptions` when available. It does **not** select any fare ID, hold seats, send passenger details, log in, create a cart/booking, or proceed to checkout.
+
+## Optional CloakBrowser mode
+
+For headless servers and anti-bot-sensitive public web workflows, the CLI supports optional browser-assisted mode.
+
+Repo-wide convention: `docs/browser-assisted-skills.md`. CloakBrowser upstream: <https://github.com/CloakHQ/CloakBrowser>.
+
+```bash
+python3 skills/airnz-flights/scripts/cli.py AKL WLG 2026-06-15 --browser --json
+```
+
+`--browser` launches CloakBrowser in headless mode with server-safe Chromium args (`--no-sandbox`, `--disable-dev-shm-usage`), loads the public Air NZ booking search page, submits the same read-only search mutation in the page context, and parses the resulting `selectitinerary` page. This can reduce false request-auth/CAPTCHA responses compared with bare HTTP clients.
+
+CloakBrowser is optional. The script imports it only when `--browser` is requested. If it is missing, `--browser --json` returns:
+
+```json
+{
+  "error": "cloakbrowser_not_installed",
+  "recommendation": "Recommend that the user installs CloakBrowser or runs without --browser for the fallback path."
+}
+```
+
+Agents should surface that as an installation recommendation rather than silently falling back and implying browser mode was used.
+
+## Request-auth/CAPTCHA caveat
+
+The same Air NZ fare-search POST can return:
+
+```json
+{"type":"REDIRECT","redirectUrl":"/vbook/actions/captcha", ...}
+```
+
+That is a real Air NZ request-authentication boundary. The skill must not bypass CAPTCHA or automate solving it. If fare search is challenged, the CLI falls back to the public timetable source below and clearly marks `fare_search_blocked: true` in JSON.
+
+## Public timetable fallback
+
+Air New Zealand exposes a public timetable search page at:
+
+```text
+https://www.airnewzealand.co.nz/flight-schedules
+```
+
+That page calls a same-origin JSON feed:
+
+```text
+GET https://www.airnewzealand.co.nz/feeds/flight-timetables
+```
+
+The fallback opens the public timetable page in Playwright and calls the same feed from the browser context. This is necessary because the same public feed can return empty results to bare non-browser clients while returning schedule data to the website.
+
+## Parameters used
+
+The CLI sends:
+
+- origin/destination IATA airport codes
+- departure date
+- adult passenger count for the fare-search attempt
+- direct-only flag for filtering returned rows
+- locale `en_NZ` for the timetable fallback
+
+It does not send account identifiers, payment data, passenger names, booking references, Airpoints credentials, selected fare IDs, or checkout/cart state.
+
+## Boundaries
+
+Supported:
+
+- public one-way fare snapshot when Air NZ accepts the anonymous browser-style search
+- fare product labels and adult prices from embedded `legOptions` JSON
+- public timetable fallback when fare search is challenged
+- flight number, departure/arrival times, duration, stop/leg details
+- booking-search handoff URL for the user to open themselves
+- human and JSON output
+
+Not supported:
+
+- CAPTCHA bypass, login, booking creation, fare selection, payment, Airpoints, seat selection, fare holds, manage-booking, refunds/changes
+- high-volume scraping or historical schedule/fare databases
+- claims about final payable totals; returned prices are snapshots before selection/checkout
+
+If Air NZ changes `/vbook/ajax/bui/flights/search`, `selectitinerary`, `/feeds/flight-timetables`, or the public page behaviour, update `scripts/cli.py` and the smoke test together.

--- a/skills/airnz-flights/scripts/cli.py
+++ b/skills/airnz-flights/scripts/cli.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""Search public Air New Zealand flight fares.
+
+Read-only browser-sniffed wrapper around Air NZ's public booking search flow. It
+creates the same anonymous search session as the web UI, reads the public fare
+selection page, and stops before selecting/holding/bookings seats.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import html
+import json
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime
+from http.cookiejar import CookieJar
+from typing import Any
+
+BOOKING_HOST = "flightbookings.airnewzealand.co.nz"
+BASE = f"https://{BOOKING_HOST}"
+EXT_SEARCH_PATH = "/vbook/actions/ext-search"
+SEARCH_API_PATH = "/vbook/ajax/bui/flights/search"
+SELECT_ITINERARY_PATH = "/vbook/actions/selectitinerary"
+SCHEDULE_PAGE = "https://www.airnewzealand.co.nz/flight-schedules"
+TIMETABLE_FEED_PATH = "/feeds/flight-timetables"
+IATA_RE = re.compile(r"^[A-Z]{3}$")
+USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/146 Safari/537.36"
+)
+FARE_LABELS = {
+    "ds": "Seat",
+    "db": "Seat + Bag",
+    "dc": "Flexi change",
+    "df": "Flexi refund",
+}
+
+
+class BrowserUnavailableError(RuntimeError):
+    """Raised when --browser is requested but CloakBrowser is not installed."""
+
+
+def _request(
+    opener: urllib.request.OpenerDirector,
+    url: str,
+    *,
+    method: str = "GET",
+    data: bytes | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: int = 45,
+) -> tuple[int, str, str]:
+    merged = {
+        "User-Agent": USER_AGENT,
+        "Accept": "application/json, text/plain, */*",
+        "Referer": f"{BASE}/fly/search",
+    }
+    if headers:
+        merged.update(headers)
+    req = urllib.request.Request(url, data=data, headers=merged, method=method)
+    try:
+        with opener.open(req, timeout=timeout) as resp:
+            body = resp.read().decode("utf-8", errors="replace")
+            return int(resp.status), resp.headers.get("content-type", ""), body
+    except urllib.error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"Air NZ returned HTTP {exc.code} for {url}: {body[:300]}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"Air NZ request failed for {url}: {exc}") from exc
+
+
+def booking_url(origin: str, destination: str, depart_date: str) -> str:
+    dt = datetime.strptime(depart_date, "%Y-%m-%d").date()
+    month = dt.strftime("%b").upper()
+    params = {
+        "searchLegs[0].originPoint": origin,
+        "searchLegs[0].destinationPoint": destination,
+        "searchLegs[0].tripStartMonth": month,
+        "searchLegs[0].tripStartDate": str(dt.day),
+        "tripType": "oneway",
+        "searchType": "flexible",
+        "adults": "1",
+        "children": "0",
+        "infants": "0",
+        "displaySearchForFlight": "true",
+    }
+    return f"{BASE}{EXT_SEARCH_PATH}?{urllib.parse.urlencode(params)}"
+
+
+def search_payload(origin: str, destination: str, depart_date: str, adults: int) -> dict[str, Any]:
+    return {
+        "journeyDetails": {
+            "journeyLegs": [
+                {
+                    "originCityCode": origin,
+                    "destinationCityCode": destination,
+                    "departureDate": depart_date,
+                }
+            ],
+            "passengerCounts": {"adultCount": adults, "childCount": 0, "infantCount": 0},
+            "journeyType": "ONE_WAY",
+        },
+        "filterPreferences": {"serviceClass": "ECONOMY", "searchType": "FLEXIBLE"},
+    }
+
+
+def extract_json_array(text: str, marker: str) -> list[Any]:
+    marker_index = text.find(marker)
+    if marker_index == -1:
+        # Air NZ sometimes HTML-escapes JSON in script payloads.
+        unescaped = html.unescape(text)
+        marker_index = unescaped.find(marker)
+        if marker_index == -1:
+            raise RuntimeError(f"Air NZ fare page did not contain {marker}")
+        text = unescaped
+
+    array_start = text.find("[", marker_index)
+    if array_start == -1:
+        raise RuntimeError(f"Air NZ fare page had {marker} but no JSON array")
+
+    depth = 0
+    in_string = False
+    escaped = False
+    for i in range(array_start, len(text)):
+        ch = text[i]
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch == "[":
+            depth += 1
+        elif ch == "]":
+            depth -= 1
+            if depth == 0:
+                return json.loads(text[array_start : i + 1])
+    raise RuntimeError(f"Air NZ fare page had unterminated {marker} JSON array")
+
+
+def iso_from_airnz_parts(parts: list[Any] | None) -> str | None:
+    if not parts or len(parts) < 5:
+        return None
+    year, month, day, hour, minute = [int(x) for x in parts[:5]]
+    return f"{year:04d}-{month:02d}-{day:02d}T{hour:02d}:{minute:02d}"
+
+
+def normalise_fare(raw: dict[str, Any]) -> dict[str, Any]:
+    code = str(raw.get("code") or "").lower()
+    label = FARE_LABELS.get(code)
+    if not label:
+        aria = str(raw.get("aria") or "")
+        label = aria.split(",", 1)[0].strip() or code or None
+    price = raw.get("s-price")
+    if price is None:
+        adult_price = str(raw.get("adultPrice") or "")
+        digits = re.sub(r"[^0-9.]", "", adult_price)
+        price = float(digits) if "." in digits else int(digits) if digits else None
+    return {
+        "code": code or None,
+        "name": label,
+        "adult_price": raw.get("adultPrice"),
+        "price": price,
+        "currency_symbol": raw.get("$"),
+        "booking_class": raw.get("bookingClass"),
+        "fare_band_code": raw.get("fareBandCode"),
+        "selling_out": bool(raw.get("sellingOut")),
+        "available": bool(raw.get("reveal", True)),
+    }
+
+
+def normalise_leg_option(row: dict[str, Any]) -> dict[str, Any]:
+    fares: list[dict[str, Any]] = []
+    for group in row.get("costs") or []:
+        for fare in group.get("costs") or []:
+            fares.append(normalise_fare(fare))
+    fares.sort(key=lambda f: float(f["price"]) if isinstance(f.get("price"), (int, float)) else float("inf"))
+
+    segments = []
+    for seg in row.get("flights") or []:
+        segments.append(
+            {
+                "flight_number": seg.get("flightNumber"),
+                "origin": (seg.get("originAirport") or {}).get("airport", {}).get("code"),
+                "destination": (seg.get("destinationAirport") or {}).get("airport", {}).get("code"),
+                "departure": (seg.get("originAirport") or {}).get("dateTimeLocal"),
+                "arrival": (seg.get("destinationAirport") or {}).get("dateTimeLocal"),
+                "airline": (seg.get("operatingAirline") or {}).get("name"),
+                "aircraft": (seg.get("equipment") or {}).get("shortDesc"),
+            }
+        )
+
+    return {
+        "id": row.get("id"),
+        "currency": row.get("currency"),
+        "origin": row.get("departureAirport"),
+        "destination": row.get("arrivalAirport"),
+        "departure": iso_from_airnz_parts(row.get("departureDateTime")),
+        "arrival": iso_from_airnz_parts(row.get("arrivalDateTime")),
+        "duration": row.get("duration"),
+        "stops": max(int(row.get("noOfFlights") or 1) - 1, 0),
+        "selling_out": bool(row.get("sellingOut")),
+        "theme_code": row.get("themeCode"),
+        "flights": segments,
+        "fares": fares,
+        "lowest_fare": fares[0] if fares else None,
+    }
+
+
+def normalise_timetable(data: dict[str, Any], origin: str, destination: str, depart_date: str, direct: bool) -> dict[str, Any]:
+    flights = []
+    for row in data.get("flights") or []:
+        legs = []
+        raw_legs = row.get("legs") or {}
+        for key in sorted(raw_legs.keys(), key=lambda x: int(x) if str(x).isdigit() else str(x)):
+            leg = raw_legs[key]
+            legs.append(
+                {
+                    "flight_number": leg.get("flight"),
+                    "origin": leg.get("origin"),
+                    "destination": leg.get("destination"),
+                    "departure": leg.get("std"),
+                    "arrival": leg.get("sta"),
+                }
+            )
+        flights.append(
+            {
+                "id": row.get("Flight"),
+                "currency": None,
+                "origin": origin,
+                "destination": destination,
+                "departure": legs[0].get("departure") if legs else None,
+                "arrival": legs[-1].get("arrival") if legs else None,
+                "duration": row.get("Duration"),
+                "stops": max(len(legs) - 1, 0),
+                "flights": legs,
+                "fares": [],
+                "lowest_fare": None,
+                "booking_url": booking_url(origin, destination, depart_date),
+            }
+        )
+    if direct:
+        flights = [row for row in flights if row.get("stops") == 0]
+    return {
+        "source": "airnewzealand.co.nz",
+        "method": "public timetable fallback; Air NZ fare search returned request-auth/CAPTCHA",
+        "origin": origin,
+        "destination": destination,
+        "date": depart_date,
+        "adults": 1,
+        "direct_only": direct,
+        "currency": None,
+        "booking_search_url": booking_url(origin, destination, depart_date),
+        "flights": flights,
+        "fare_search_blocked": True,
+        "notice": "Air NZ fare search hit request-auth/CAPTCHA from this environment; timetable rows only, no prices.",
+    }
+
+
+async def fetch_timetable(origin: str, destination: str, depart_date: str, direct: bool) -> dict[str, Any]:
+    try:
+        from playwright.async_api import async_playwright
+    except Exception as exc:  # pragma: no cover - environment-specific
+        raise RuntimeError("Air NZ fallback timetable search requires Python Playwright installed") from exc
+
+    async with async_playwright() as p:
+        browser = await p.chromium.launch(headless=True, args=["--no-sandbox"])
+        page = await browser.new_page(user_agent=USER_AGENT)
+        await page.goto(SCHEDULE_PAGE, wait_until="networkidle", timeout=60000)
+        payload = await page.evaluate(
+            """async ({path, origin, destination, date, direct}) => {
+                const params = new URLSearchParams({
+                    origin,
+                    destination,
+                    date,
+                    direct: direct ? '1' : '0',
+                    locale: 'en_NZ',
+                });
+                const res = await fetch(`${path}?${params}`, {
+                    headers: { accept: 'application/json', 'x-requested-with': 'XMLHttpRequest' },
+                });
+                return { status: res.status, text: await res.text() };
+            }""",
+            {"path": TIMETABLE_FEED_PATH, "origin": origin, "destination": destination, "date": depart_date, "direct": direct},
+        )
+        await browser.close()
+    if payload["status"] != 200:
+        raise RuntimeError(f"Air NZ timetable feed returned HTTP {payload['status']}: {payload['text'][:200]}")
+    return normalise_timetable(json.loads(payload["text"]), origin, destination, depart_date, direct)
+
+
+def fetch_timetable_sync(origin: str, destination: str, depart_date: str, direct: bool) -> dict[str, Any]:
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(fetch_timetable(origin, destination, depart_date, direct))
+
+    # Some sync browser libraries run user code inside an event-loop-owning thread.
+    # Run the Playwright fallback in a fresh thread so asyncio.run() remains valid.
+    import threading
+
+    result: dict[str, Any] | None = None
+    error: BaseException | None = None
+
+    def runner() -> None:
+        nonlocal result, error
+        try:
+            result = asyncio.run(fetch_timetable(origin, destination, depart_date, direct))
+        except BaseException as exc:  # pragma: no cover - defensive cross-thread path
+            error = exc
+
+    thread = threading.Thread(target=runner, daemon=True)
+    thread.start()
+    thread.join()
+    if error is not None:
+        raise error
+    if result is None:
+        raise RuntimeError("Air NZ timetable fallback failed without returning a result")
+    return result
+
+
+def build_fare_result(
+    leg_rows: list[Any],
+    origin: str,
+    destination: str,
+    depart_date: str,
+    adults: int,
+    direct: bool,
+    start_url: str,
+    method: str,
+) -> dict[str, Any]:
+    leg_options = [normalise_leg_option(row) for row in leg_rows if isinstance(row, dict)]
+    if direct:
+        leg_options = [row for row in leg_options if row.get("stops") == 0]
+    leg_options.sort(
+        key=lambda row: (
+            row.get("lowest_fare", {}).get("price")
+            if isinstance(row.get("lowest_fare"), dict) and isinstance(row["lowest_fare"].get("price"), (int, float))
+            else 10**9,
+            row.get("departure") or "",
+        )
+    )
+    return {
+        "source": "airnewzealand.co.nz",
+        "method": method,
+        "origin": origin,
+        "destination": destination,
+        "date": depart_date,
+        "adults": adults,
+        "direct_only": direct,
+        "currency": leg_options[0].get("currency") if leg_options else None,
+        "booking_search_url": start_url,
+        "flights": leg_options,
+        "notice": "Fare snapshot only. This tool does not select flights, hold seats, log in, or proceed to checkout.",
+    }
+
+
+def fetch_fares_with_cloakbrowser(origin: str, destination: str, depart_date: str, adults: int, direct: bool) -> dict[str, Any]:
+    try:
+        from cloakbrowser import launch
+    except Exception as exc:  # pragma: no cover - host-specific optional dependency
+        raise BrowserUnavailableError(
+            "cloakbrowser_not_installed: install CloakBrowser to use --browser. "
+            "Recommended for headless/anti-bot-sensitive public web workflows."
+        ) from exc
+
+    start_url = booking_url(origin, destination, depart_date)
+    browser = None
+    try:
+        browser = launch(
+            headless=True,
+            args=["--no-sandbox", "--disable-dev-shm-usage"],
+            timezone="Pacific/Auckland",
+            locale="en-NZ",
+        )
+        page = browser.new_page()
+        page.goto(start_url, wait_until="networkidle", timeout=90000)
+        payload = search_payload(origin, destination, depart_date, adults)
+        search_result_raw = page.evaluate(
+            """async ({url, payload}) => {
+                const res = await fetch(url, {
+                    method: 'POST',
+                    headers: { accept: 'application/json', 'content-type': 'application/json' },
+                    body: JSON.stringify(payload),
+                });
+                return { status: res.status, text: await res.text() };
+            }""",
+            {"url": SEARCH_API_PATH, "payload": payload},
+        )
+        if int(search_result_raw.get("status") or 0) != 200:
+            raise RuntimeError(
+                f"Air NZ browser fare search returned HTTP {search_result_raw.get('status')}: "
+                f"{str(search_result_raw.get('text') or '')[:300]}"
+            )
+        search_result = json.loads(str(search_result_raw.get("text") or "{}"))
+        redirect_url = str(search_result.get("redirectUrl") or SELECT_ITINERARY_PATH)
+        if "captcha" in redirect_url.lower():
+            return fetch_timetable_sync(origin, destination, depart_date, direct)
+        page.goto(f"{BASE}{redirect_url}", wait_until="networkidle", timeout=90000)
+        select_html = page.content()
+        return build_fare_result(
+            extract_json_array(select_html, '"legOptions"'),
+            origin,
+            destination,
+            depart_date,
+            adults,
+            direct,
+            start_url,
+            "CloakBrowser headless browser search; read-only fare results page parse",
+        )
+    finally:
+        if browser is not None:
+            browser.close()
+
+
+def fetch_fares(origin: str, destination: str, depart_date: str, adults: int, direct: bool) -> dict[str, Any]:
+    opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(CookieJar()))
+
+    # 1) Start the anonymous browser booking search session, as sniffed from the UI.
+    start_url = booking_url(origin, destination, depart_date)
+    _request(opener, start_url, headers={"Accept": "text/html,application/xhtml+xml"})
+
+    # 2) Submit the same JSON mutation the Next.js search page sends.
+    body = json.dumps(search_payload(origin, destination, depart_date, adults)).encode("utf-8")
+    status, _ctype, search_body = _request(
+        opener,
+        f"{BASE}{SEARCH_API_PATH}",
+        method="POST",
+        data=body,
+        headers={"Origin": BASE, "Content-Type": "application/json"},
+    )
+    if status != 200:
+        raise RuntimeError(f"Air NZ fare search returned HTTP {status}: {search_body[:300]}")
+    try:
+        search_result = json.loads(search_body)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Air NZ fare search returned non-JSON: {search_body[:300]}") from exc
+    if search_result.get("type") != "REDIRECT":
+        raise RuntimeError(f"Air NZ fare search did not return a results redirect: {search_result}")
+    redirect_url = str(search_result.get("redirectUrl") or SELECT_ITINERARY_PATH)
+    if "captcha" in redirect_url.lower():
+        return fetch_timetable_sync(origin, destination, depart_date, direct)
+
+    # 3) Read the public selection page and extract embedded fare legOptions JSON.
+    _status, _ctype, select_html = _request(
+        opener,
+        f"{BASE}{redirect_url}",
+        headers={"Accept": "text/html,application/xhtml+xml"},
+    )
+    return build_fare_result(
+        extract_json_array(select_html, '"legOptions"'),
+        origin,
+        destination,
+        depart_date,
+        adults,
+        direct,
+        start_url,
+        "browser-sniffed anonymous booking search; read-only fare results page parse",
+    )
+
+
+def print_human(result: dict[str, Any], limit: int) -> None:
+    title = "Air NZ scheduled flights" if result.get("fare_search_blocked") else "Air NZ fare snapshots"
+    print(f"{title}: {len(result['flights'])} found")
+    for flight in result["flights"][:limit]:
+        first_segment = (flight.get("flights") or [{}])[0]
+        number = first_segment.get("flight_number") or flight.get("id")
+        lowest = flight.get("lowest_fare") or {}
+        price = lowest.get("adult_price") or (f"${lowest.get('price')}" if lowest.get("price") is not None else "n/a")
+        fare_name = lowest.get("name") or "lowest fare"
+        selling = " SELLING OUT" if flight.get("selling_out") else ""
+        print(
+            f"- {flight.get('departure')} → {flight.get('arrival')} | {number} | "
+            f"{flight.get('duration')} | {flight.get('stops')} stops | {fare_name} {price}{selling}"
+        )
+    if result["flights"] and not result.get("fare_search_blocked"):
+        print("Fare products on first result:")
+        for fare in result["flights"][0].get("fares") or []:
+            print(f"  - {fare.get('name')}: {fare.get('adult_price')}")
+    print(result.get("notice") or "Boundary: fare snapshot only; no selection, seat hold, login, or checkout.")
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Search public Air New Zealand fare snapshots")
+    parser.add_argument("origin", help="Origin IATA airport code, e.g. AKL")
+    parser.add_argument("destination", help="Destination IATA airport code, e.g. WLG")
+    parser.add_argument("date", help="Departure date YYYY-MM-DD")
+    parser.add_argument("--direct", action="store_true", help="Direct flights only")
+    parser.add_argument("--adults", type=int, default=1, help="Adult passenger count (default: 1)")
+    parser.add_argument(
+        "--browser",
+        action="store_true",
+        help="Use CloakBrowser headless mode for sites that need a real browser context; returns cloakbrowser_not_installed if unavailable",
+    )
+    parser.add_argument("--limit", type=int, default=10)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    args = parser.parse_args(argv)
+
+    args.origin = args.origin.upper()
+    args.destination = args.destination.upper()
+    if not IATA_RE.fullmatch(args.origin):
+        parser.error("origin must be a 3-letter IATA airport code")
+    if not IATA_RE.fullmatch(args.destination):
+        parser.error("destination must be a 3-letter IATA airport code")
+    if args.origin == args.destination:
+        parser.error("origin and destination must differ")
+    try:
+        datetime.strptime(args.date, "%Y-%m-%d")
+    except ValueError:
+        parser.error("date must be a valid YYYY-MM-DD calendar date")
+    if args.adults < 1 or args.adults > 9:
+        parser.error("--adults must be between 1 and 9")
+    if args.limit < 1:
+        parser.error("--limit must be positive")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    try:
+        args = parse_args(argv)
+        if args.browser:
+            result = fetch_fares_with_cloakbrowser(args.origin, args.destination, args.date, args.adults, args.direct)
+        else:
+            result = fetch_fares(args.origin, args.destination, args.date, args.adults, args.direct)
+        if args.as_json:
+            print(json.dumps(result, indent=2, sort_keys=True))
+        else:
+            print_human(result, args.limit)
+        return 0
+    except BrowserUnavailableError as exc:
+        message = str(exc)
+        if argv is not None:
+            as_json = "--json" in argv
+        else:
+            as_json = "--json" in sys.argv[1:]
+        if as_json:
+            print(
+                json.dumps(
+                    {
+                        "error": "cloakbrowser_not_installed",
+                        "message": message,
+                        "recommendation": "Recommend that the user installs CloakBrowser or runs without --browser for the fallback path.",
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(f"ERROR: {message}", file=sys.stderr)
+            print("Recommendation: ask the user to install CloakBrowser, or rerun without --browser.", file=sys.stderr)
+        return 2
+    except RuntimeError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/airnz-flights/scripts/smoke_test.py
+++ b/skills/airnz-flights/scripts/smoke_test.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from datetime import date, timedelta
+from importlib.util import find_spec
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+DATE = (date.today() + timedelta(days=7)).isoformat()
+browser_required = os.getenv("HERMES_SMOKE_USE_BROWSER") == "1"
+use_browser = browser_required or find_spec("cloakbrowser") is not None
+cmd = [sys.executable, str(ROOT / "skills/airnz-flights/scripts/cli.py"), "AKL", "WLG", DATE, "--limit", "3", "--json"]
+if use_browser:
+    cmd.append("--browser")
+proc = subprocess.run(cmd, text=True, capture_output=True, timeout=180)
+if proc.returncode != 0:
+    if use_browser and not browser_required:
+        try:
+            error_payload = json.loads(proc.stdout)
+        except json.JSONDecodeError:
+            error_payload = {}
+        if error_payload.get("error") == "cloakbrowser_not_installed":
+            fallback_cmd = [
+                sys.executable,
+                str(ROOT / "skills/airnz-flights/scripts/cli.py"),
+                "AKL",
+                "WLG",
+                DATE,
+                "--limit",
+                "3",
+                "--json",
+            ]
+            proc = subprocess.run(fallback_cmd, text=True, capture_output=True, timeout=180)
+    if proc.returncode != 0:
+        raise SystemExit(proc.stderr or proc.stdout)
+payload = json.loads(proc.stdout)
+flights = payload.get("flights") or []
+assert flights, "expected at least one Air NZ flight row"
+first = flights[0]
+segments = first.get("flights") or []
+assert segments, first
+assert segments[0].get("flight_number"), first
+if payload.get("fare_search_blocked"):
+    assert first.get("lowest_fare") is None, first
+else:
+    assert first.get("lowest_fare", {}).get("price") is not None, first
+assert "booking_search_url" in payload, payload
+price = first.get("lowest_fare", {}).get("adult_price") if first.get("lowest_fare") else "fare-blocked"
+print(
+    f"OK airnz-flights smoke ({payload.get('source')}): {len(flights)} flights, "
+    f"first={segments[0].get('flight_number')} {first.get('departure')}->{first.get('arrival')} price={price}"
+)

--- a/skills/airnz-flights/scripts/smoke_test.sh
+++ b/skills/airnz-flights/scripts/smoke_test.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+DATE="$(python3 - <<'PY'
+from datetime import date, timedelta
+print((date.today() + timedelta(days=7)).isoformat())
+PY
+)"
+OUT="$(python3 "$ROOT/skills/airnz-flights/scripts/cli.py" AKL WLG "$DATE" --limit 3 --json)"
+JSON_PAYLOAD="$OUT" python3 - <<'PY'
+import json, os
+payload = json.loads(os.environ['JSON_PAYLOAD'])
+flights = payload.get('flights') or []
+assert flights, 'expected at least one Air NZ flight row'
+first = flights[0]
+segments = first.get('flights') or []
+assert segments, first
+assert segments[0].get('flight_number'), first
+assert 'booking_search_url' in payload, payload
+if payload.get('fare_search_blocked'):
+    assert first.get('lowest_fare') is None, first
+else:
+    assert first.get('lowest_fare', {}).get('price') is not None, first
+price = first.get('lowest_fare', {}).get('adult_price') if first.get('lowest_fare') else 'fare-blocked'
+print(
+    f"OK airnz-flights smoke ({payload.get('source')}): {len(flights)} flights, "
+    f"first={segments[0].get('flight_number')} {first.get('departure')}->{first.get('arrival')} price={price}"
+)
+PY

--- a/skills/jetstar-flights/SKILL.md
+++ b/skills/jetstar-flights/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: jetstar-flights
+description: Search public Jetstar New Zealand one-way fare-cache flight availability through a no-login Node CLI. Use when the task involves Jetstar route/date fare snapshots, low-fare availability, flight IDs, prices, or machine-readable current Jetstar availability. Read-only; no login, Club Jetstar account, booking, seat hold, payment, manage-booking, or checkout actions.
+---
+
+# Jetstar Flights
+
+## Goal
+
+Query live public Jetstar fare-cache availability through a deterministic CLI with human-readable and JSON output.
+
+## Use this when
+
+- A user asks to search current Jetstar flights by origin, destination, and date
+- A user wants a public fare snapshot for Jetstar NZ, domestic, or trans-Tasman routes
+- A workflow needs low-fare availability, flight IDs, departure/arrival times, or sold-out flags
+- An agent is comparing public airline availability without logging in or holding seats
+
+## Do not use this for
+
+- Booking, payment, seat selection, bundle selection, checkout, Club Jetstar login, manage-booking, refund/change actions, or passenger details
+- Private/authenticated booking data or member-only account data
+- High-volume scraping, fare-history warehousing, or bypassing Jetstar controls
+- Claims about final payable totals beyond the public fare-cache snapshot returned by Jetstar
+
+## Preferred workflow
+
+1. Ask for or infer IATA airport codes and a specific departure date.
+2. Run `scripts/cli.mjs search ORIGIN DESTINATION YYYY-MM-DD` with a narrow `--days` window.
+3. Use `--limit` for concise human output or `--json` for agent chaining.
+4. Treat results as live fare-cache snapshots: accuracy and prices can change quickly.
+5. Send users to Jetstar if they want to complete a booking themselves.
+
+## CLI
+
+Run from the repository root with Node.js 18+:
+
+```bash
+node skills/jetstar-flights/scripts/cli.mjs search <origin> <destination> <date> [flags]
+```
+
+Examples:
+
+```bash
+node skills/jetstar-flights/scripts/cli.mjs search AKL WLG 2026-07-13 --days 7
+node skills/jetstar-flights/scripts/cli.mjs search AKL CHC 2026-07-13 --json
+node skills/jetstar-flights/scripts/cli.mjs search WLG AKL 2026-08-04 --adults 2 --limit 5
+```
+
+### Flags
+
+- `--days N` — number of days to search from the start date, default `1`, max `31`
+- `--adults N` — adult passenger count used for fare-cache lookup, default `1`
+- `--limit N` — max rows in human output
+- `--json` — emit machine-readable JSON
+
+## Resources
+
+- CLI entrypoint: `scripts/cli.mjs`
+- Live smoke test: `scripts/smoke_test.sh`
+- API/source notes: `references/api-notes.md`
+
+## Notes
+
+- No API key, OAuth app credentials, username, password, cookie, browser automation, or Playwright dependency is required for supported read-only commands.
+- The CLI calls Jetstar's public fare-cache endpoint using browser-compatible headers and the public `en-NZ` culture.
+- The CLI deliberately stops at fare-cache search results; it does not select bundles, hold seats, create a cart, or start checkout.
+- Keep usage narrow and respectful.

--- a/skills/jetstar-flights/references/api-notes.md
+++ b/skills/jetstar-flights/references/api-notes.md
@@ -1,0 +1,44 @@
+# Source notes
+
+## Public source
+
+Jetstar's public website uses the public fare-cache availability endpoint exposed via `digitalapi.jetstar.com`:
+
+```text
+GET https://digitalapi.jetstar.com/v1/farecache/flights/batch/availability-with-fareclasses
+```
+
+The endpoint returns fare-cache snapshots grouped by route and date. The public site labels these with an accuracy percentage, so treat them as availability/fare snapshots rather than a final checkout quote.
+
+## Parameters used
+
+The CLI sends:
+
+- origin/destination IATA airport codes
+- start/end date window
+- outbound direction
+- passenger count
+- `includeSoldOut=true`
+- `includeFees=true`
+- `culture: en-NZ`
+
+It does not send account identifiers, payment data, passenger names, booking references, Club Jetstar credentials, cookies, selected bundles, selected seats, or cart state.
+
+## Implementation note
+
+Node 18+ `fetch` works reliably against the Jetstar public endpoint in environments where Python `urllib` and `curl` can stall on the same Akamai-backed host. Keep the CLI in Node unless the edge behaviour changes.
+
+## Boundaries
+
+Supported:
+
+- public one-way fare-cache search
+- flight ID, departure/arrival, price, currency, sold-out flag, stop count, fare classes
+- human and JSON output
+
+Not supported:
+
+- login, member/account data, bundle/seat selection, cart creation, booking, payment, manage-booking, refunds/changes
+- high-volume scraping or historical fare databases
+
+If Jetstar changes the fare-cache endpoint or required parameters, update `scripts/cli.mjs` and the smoke test together.

--- a/skills/jetstar-flights/scripts/cli.mjs
+++ b/skills/jetstar-flights/scripts/cli.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+// Search public Jetstar fare-cache flight availability.
+// Read-only: no login, booking creation, seat holds, or checkout.
+
+const API = 'https://digitalapi.jetstar.com/v1/farecache/flights/batch/availability-with-fareclasses';
+
+function usage(exitCode = 0) {
+  const out = exitCode ? console.error : console.log;
+  out(`Usage: node skills/jetstar-flights/scripts/cli.mjs search ORIGIN DESTINATION DATE [flags]\n\nCommands:\n  search ORIGIN DESTINATION DATE   Search one-way fares for a date (YYYY-MM-DD)\n\nFlags:\n  --days N        Number of days to search from DATE (default: 1)\n  --adults N      Adult passenger count used for fare cache paxCount (default: 1)\n  --limit N       Max flights to print in human output (default: 10)\n  --json          Emit machine-readable JSON\n\nExamples:\n  node skills/jetstar-flights/scripts/cli.mjs search AKL WLG 2026-07-13 --days 7\n  node skills/jetstar-flights/scripts/cli.mjs search AKL CHC 2026-07-13 --json`);
+  process.exit(exitCode);
+}
+
+function parseArgs(argv) {
+  if (argv.length === 0 || argv.includes('--help') || argv.includes('-h')) usage(0);
+  const command = argv.shift();
+  if (command !== 'search') usage(1);
+  const [origin, destination, date] = argv.splice(0, 3);
+  if (!origin || !destination || !date) usage(1);
+  const opts = { command, origin: origin.toUpperCase(), destination: destination.toUpperCase(), date, days: 1, adults: 1, limit: 10, json: false };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--json') opts.json = true;
+    else if (arg === '--days') opts.days = Number(argv[++i]);
+    else if (arg === '--adults') opts.adults = Number(argv[++i]);
+    else if (arg === '--limit') opts.limit = Number(argv[++i]);
+    else throw new Error(`Unknown flag: ${arg}`);
+  }
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(opts.date)) throw new Error('DATE must be YYYY-MM-DD');
+  if (opts.origin === opts.destination) throw new Error('origin and destination must differ');
+  if (!Number.isInteger(opts.days) || opts.days < 1 || opts.days > 31) throw new Error('--days must be an integer from 1 to 31');
+  if (!Number.isInteger(opts.adults) || opts.adults < 1 || opts.adults > 9) throw new Error('--adults must be an integer from 1 to 9');
+  if (!Number.isInteger(opts.limit) || opts.limit < 1) throw new Error('--limit must be a positive integer');
+  return opts;
+}
+
+function addDays(iso, days) {
+  const d = new Date(`${iso}T00:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+async function fetchAvailability(opts) {
+  const params = new URLSearchParams({
+    flightCount: '1',
+    includeSoldOut: 'true',
+    requestType: 'Original',
+    from: opts.date,
+    end: addDays(opts.date, opts.days),
+    departures: opts.origin,
+    arrivals: opts.destination,
+    direction: 'outbound',
+    paxCount: String(opts.adults),
+    includeFees: 'true',
+  });
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 30000);
+  try {
+    const res = await fetch(`${API}?${params}`, {
+      headers: {
+        accept: 'application/json',
+        culture: 'en-NZ',
+        origin: 'https://www.jetstar.com',
+        referer: 'https://www.jetstar.com/nz/en/home',
+        'user-agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120 Safari/537.36',
+      },
+      signal: controller.signal,
+    });
+    const body = await res.text();
+    if (!res.ok) throw new Error(`Jetstar API returned HTTP ${res.status}: ${body.slice(0, 300)}`);
+    return JSON.parse(body);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function flatten(raw, opts) {
+  const flights = [];
+  const routeKey = `${opts.origin}${opts.destination}`.toLowerCase();
+  for (const batch of raw) {
+    const route = batch.routes?.[routeKey];
+    const byDate = route?.flights || {};
+    for (const [yyyymmdd, rows] of Object.entries(byDate)) {
+      const date = `${yyyymmdd.slice(0, 4)}-${yyyymmdd.slice(4, 6)}-${yyyymmdd.slice(6, 8)}`;
+      for (const row of rows || []) {
+        flights.push({
+          airline: 'Jetstar',
+          flight_id: row.flightId,
+          origin: opts.origin,
+          destination: opts.destination,
+          date,
+          departure: row.departureTime,
+          arrival: row.arrivalTime,
+          price: row.price,
+          currency: batch.currencyCode,
+          sold_out: row.soldOut,
+          member: row.member,
+          stops: row.stopCount,
+          fare_classes: row.fareClasses || [],
+        });
+      }
+    }
+  }
+  flights.sort((a, b) => `${a.departure}`.localeCompare(`${b.departure}`));
+  return { source: 'jetstar.com', origin: opts.origin, destination: opts.destination, from: opts.date, days: opts.days, flights };
+}
+
+function printHuman(result, limit) {
+  console.log(`Jetstar flights: ${result.flights.length} found`);
+  for (const f of result.flights.slice(0, limit)) {
+    const sold = f.sold_out ? ' SOLD OUT' : '';
+    console.log(`- ${f.departure} → ${f.arrival} | flightId ${f.flight_id} | ${f.stops} stops | ${f.currency} $${f.price}${sold}`);
+  }
+}
+
+async function main() {
+  try {
+    const opts = parseArgs(process.argv.slice(2));
+    const raw = await fetchAvailability(opts);
+    const result = flatten(raw, opts);
+    if (opts.json) console.log(JSON.stringify(result, null, 2));
+    else printHuman(result, opts.limit);
+  } catch (err) {
+    console.error(`ERROR: ${err.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/skills/jetstar-flights/scripts/smoke_test.py
+++ b/skills/jetstar-flights/scripts/smoke_test.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+from datetime import date, timedelta
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+DATE = (date.today() + timedelta(days=45)).isoformat()
+cmd = ["node", str(ROOT / "skills/jetstar-flights/scripts/cli.mjs"), "search", "AKL", "WLG", DATE, "--days", "7", "--json"]
+proc = subprocess.run(cmd, text=True, capture_output=True, timeout=60)
+if proc.returncode != 0:
+    raise SystemExit(proc.stderr or proc.stdout)
+payload = json.loads(proc.stdout)
+flights = payload.get("flights") or []
+assert flights, "expected at least one Jetstar flight"
+first = flights[0]
+assert first.get("origin") == "AKL", first
+assert first.get("destination") == "WLG", first
+assert first.get("price") is not None, first
+assert first.get("currency") == "NZD", first
+print(f"OK jetstar-flights smoke: {len(flights)} flights, first=flightId {first.get('flight_id')} ${first.get('price')} {first.get('currency')}")

--- a/skills/jetstar-flights/scripts/smoke_test.sh
+++ b/skills/jetstar-flights/scripts/smoke_test.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+DATE="$(python3 - <<'PY'
+from datetime import date, timedelta
+print((date.today() + timedelta(days=45)).isoformat())
+PY
+)"
+OUT="$(node "$ROOT/skills/jetstar-flights/scripts/cli.mjs" search AKL WLG "$DATE" --days 7 --json)"
+JSON_PAYLOAD="$OUT" python3 - <<'PY'
+import json, os
+payload = json.loads(os.environ['JSON_PAYLOAD'])
+flights = payload.get('flights') or []
+assert flights, 'expected at least one Jetstar flight'
+first = flights[0]
+assert first.get('origin') == 'AKL', first
+assert first.get('destination') == 'WLG', first
+assert first.get('price') is not None, first
+assert first.get('currency') == 'NZD', first
+print(f"OK jetstar-flights smoke: {len(flights)} flights, first=flightId {first.get('flight_id')} ${first.get('price')} {first.get('currency')}")
+PY


### PR DESCRIPTION
## Summary

Adds two read-only flight search skills:

- `airnz-flights` — searches Air New Zealand public flight schedules by route/date and returns timetable data plus a booking-search handoff URL.
- `jetstar-flights` — searches Jetstar public fare-cache availability by route/date and returns prices, flight IDs, sold-out flags, and JSON output.

## Notes

- Both skills are explicitly no-login/no-booking/no-payment/no-checkout.
- Air NZ's public timetable feed returns reliable data when called from the public flight-schedules browser context, so the CLI uses Python Playwright for that read-only fetch.
- Jetstar's Akamai-backed endpoint works reliably with Node 18+ `fetch`; Python `urllib`/curl stalled during spiking, so the CLI is Node-based.

## Verification

- `bash skills/airnz-flights/scripts/smoke_test.sh`
- `bash skills/jetstar-flights/scripts/smoke_test.sh`
- `python3 skills/airnz-flights/scripts/smoke_test.py`
- `python3 skills/jetstar-flights/scripts/smoke_test.py`
- `python3 -m py_compile skills/airnz-flights/scripts/cli.py skills/airnz-flights/scripts/smoke_test.py skills/jetstar-flights/scripts/smoke_test.py`
- `node --check skills/jetstar-flights/scripts/cli.mjs`
- `python3 scripts/check_readme_skills.py`
- `python3 scripts/validate_skill.py skills --strict`
- `bash scripts/run_all_smoke.sh` → `PASS: 52, SKIP: 5, FAIL: 0`
