### PR TITLE
ci: run GitHub Actions on Node 24

### DIFF
--- a/.github/workflows/readme-skills.yml
+++ b/.github/workflows/readme-skills.yml
@@ -7,6 +7,9 @@ on:
       - 'README.md'
       - 'scripts/check_readme_skills.py'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   check:
     name: Validate README skills table

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -8,6 +8,9 @@ on:
     # 06:00 NZST daily (UTC+12 → 18:00 UTC previous day)
     - cron: '0 18 * * *'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   smoke:
     runs-on: [self-hosted, linux, x64, skills-smoke]
@@ -20,7 +23,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Install CloakBrowser for browser-assisted smoke tests
         run: |

--- a/.github/workflows/validate-skills.yml
+++ b/.github/workflows/validate-skills.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   validate-skills:
     runs-on: [self-hosted, linux, x64, skills-smoke]


### PR DESCRIPTION
## Summary
- Opt GitHub Actions into the Node 24 JavaScript action runtime.
- Update the smoke workflow's explicit Node setup from 22 to 24.

## Verification
- `python3 scripts/check_readme_skills.py`
- `python3 scripts/validate_skill.py skills --strict`
- `git diff --check`
