### PR TITLE
feat: add grocer.nz public price skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ python3 skills/fuelclock-nz/scripts/cli.py summary
 # Latest NZ news
 python3 skills/nz-news/scripts/cli.py headlines
 
+# NZ supermarket stores and pricing history
+python3 skills/grocer-nz/scripts/cli.py stores --query Papakura
+
 # Auckland Transport real-time (needs AT API key)
 python3 skills/at-transport/scripts/cli.py alerts
 ```
@@ -89,6 +92,7 @@ If you're a business looking at this and thinking "how do we actually want AI ag
 | [fuelclock-nz](skills/fuelclock-nz/SKILL.md) | Query NZ fuel prices, supply, inbound tankers, MSO status, geopolitical shipping risk markets, and NZ fuel headlines from fuelclock.nz. No authentication required. |
 | [gaspy-nz](skills/gaspy-nz/SKILL.md) | Query Gaspy NZ public crowd-sourced fuel price statistics through a lightweight no-login CLI. Use when the task involves Gaspy crowd-sourced NZ fuel price snapshots, national observed averages, top cheapest 91 stations, station/brand counts, or recent confirmation totals. Read-only; no login or price reporting. |
 | [geonet-nz](skills/geonet-nz/SKILL.md) | Query GeoNet New Zealand public earthquake, volcano alert, and GeoNet news endpoints through a lightweight no-login CLI. Use when the task involves recent NZ earthquakes, felt/MMI-filtered quakes, earthquake detail by publicID, volcanic alert levels, volcanic activity bulletins, or GeoNet public geohazard updates. Read-only; no authentication required. |
+| [grocer-nz](skills/grocer-nz/SKILL.md) | Query grocer.nz public NZ supermarket price data — store lookup, product search, current per-store prices, and historical product price rows from public DuckDB/parquet assets. Use for NZ grocery/supermarket pricing across Woolworths, New World, PAK'nSAVE, Fresh Choice, and related stores. Read-only; no login or private user data. |
 | [homes-nz](skills/homes-nz/SKILL.md) | Query homes.co.nz NZ residential property estimates (HomesEstimate/HEV), sales history, suburb trends, and nearby comparable properties. No login required. |
 | [interest-co-nz](skills/interest-co-nz/SKILL.md) | Query interest.co.nz public mortgage-rate tables through a lightweight no-login HTML parser. Use when the task involves current New Zealand mortgage rates, bank home-loan rates, variable/floating rates, fixed terms from 6 months to 5 years, special LVR rows, or comparing advertised mortgage rates across NZ lenders. Read-only; no application, lead, login, or quote submission. |
 | [jetstar-flights](skills/jetstar-flights/SKILL.md) | Search public Jetstar New Zealand one-way fare-cache flight availability through a no-login Node CLI. Use when the task involves Jetstar route/date fare snapshots, low-fare availability, flight IDs, prices, or machine-readable current Jetstar availability. Read-only; no login, Club Jetstar account, booking, seat hold, payment, manage-booking, or checkout actions. |
@@ -173,6 +177,7 @@ python3 skills/trademe-nz/scripts/smoke_test.py
 python3 skills/nzbn-register/scripts/smoke_test.py
 python3 skills/eventfinda-nz/scripts/smoke_test.py
 python3 skills/woolworths-nz/scripts/smoke_test.py
+python3 skills/grocer-nz/scripts/smoke_test.py
 python3 skills/auckland-bin-schedule/scripts/smoke_test.py
 ```
 

--- a/skills/grocer-nz/SKILL.md
+++ b/skills/grocer-nz/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: grocer-nz
+description: Query grocer.nz public NZ supermarket price data — store lookup, product search, current per-store prices, and historical product price rows from public DuckDB/parquet assets. Use for NZ grocery/supermarket pricing across Woolworths, New World, PAK'nSAVE, Fresh Choice, and related stores. Read-only; no login or private user data.
+---
+
+
+# Grocer.nz Public Price Data
+
+## Overview
+
+This skill queries public data exposed by **grocer.nz**, a New Zealand grocery price comparison app. It is useful for current supermarket price checks, per-store comparisons, and historical product price rows.
+
+The CLI uses:
+
+- Grocer public static assets: `https://assets-prod.grocer.nz/public/`
+- Public DuckDB base database: `base_v3.duckdb.br`
+- Per-store current price parquet files: `prices_per_store_v3/public_prices_<store_id>.parquet`
+- Per-product history parquet files: `price_history_v3/price_history_<product_id>.parquet`
+- Grocer frontend Meilisearch product index for search.
+
+Script path:
+
+```bash
+skills/grocer-nz/scripts/cli.py
+```
+
+The script bootstraps `duckdb` via `uv` when the active Python does not already have it.
+
+## When to Use
+
+- Adam asks for historic supermarket pricing in NZ.
+- Adam wants to compare prices across Woolworths, New World, PAK'nSAVE, Fresh Choice, Super Value, The Warehouse, etc.
+- Adam wants a store id for a known store, e.g. Papakura.
+- Adam wants price history for a known Grocer product id.
+- Adam wants current prices for one product across selected stores.
+
+Do **not** use this for authenticated Grocer Pro features, private user lists, or anything requiring sign-in. This skill is read-only public data only.
+
+## Commands
+
+Set a helper variable:
+
+```bash
+GROCER=skills/grocer-nz/scripts/cli.py
+```
+
+### List stores
+
+```bash
+python3 $GROCER stores --query Papakura
+python3 $GROCER stores --vendor "PAK" --limit 20 --json
+```
+
+Useful known Papakura ids from live smoke:
+
+- `118` — Woolworths Papakura
+- `206` — Fresh Choice Papakura
+- `230` — PAK'nSAVE Papakura
+- `307` — New World Papakura
+
+### Search products
+
+Search only:
+
+```bash
+python3 $GROCER search "milk" --limit 5
+```
+
+Search plus current prices in matching stores:
+
+```bash
+python3 $GROCER search "milk" --store-query Papakura --limit 3
+python3 $GROCER search "whittakers" --store-id 230 --store-id 307 --json
+```
+
+The search command returns Grocer product ids. Use those ids with `prices` and `history`.
+
+### Current prices for a product
+
+```bash
+python3 $GROCER prices 5461 --store-query Papakura
+python3 $GROCER prices 5461 --store-id 230 --store-id 307 --json
+```
+
+`--all-stores` is supported but can be slow because it downloads many per-store parquet files:
+
+```bash
+python3 $GROCER prices 5461 --all-stores --limit 30
+```
+
+### Price history for a product
+
+```bash
+python3 $GROCER history 5461 --store-query Papakura --limit 20
+python3 $GROCER history 5461 --store-id 230 --json
+```
+
+History files are per product and include store-level rows when available.
+
+### Raw product metadata
+
+```bash
+python3 $GROCER product 5461 --json
+```
+
+## Data Notes
+
+See `references/api-notes.md` for the sniffed endpoints and file layout.
+
+Important model fields:
+
+- Products: `id`, `name`, `brand`, `unit`, `size`, `redirected_to`
+- Stores: `id`, `vendor_id`, `name`, `is_enabled`
+- Current prices: `updated_at`, `store_id`, `product_id`, `original_price_cent`, `sale_price_cent`, `club_price_cent`, `online_price_cent`, multibuy fields
+- Price history: `updated_at`, `store_id`, `price_cent`
+
+Prices are stored in **NZ cents**. `$5.50` is represented as `550`.
+
+## Common Pitfalls
+
+1. **No store selected = limited price context.** Product search comes from Meilisearch. Current per-store pricing requires store ids or `--store-query` so the CLI can download the relevant parquet files.
+2. **`--all-stores` can be noisy/slow.** It may download hundreds of current price parquet files. Prefer targeted store ids for fast checks.
+3. **The `.br` DuckDB file may arrive already decompressed.** The CLI treats Grocer's `base_v3.duckdb.br` CDN response as a DuckDB file directly because Cloudflare/Caddy often transparently decodes it.
+4. **DuckDB DDL cannot use prepared parameters for `read_parquet(?)`.** Quote local parquet paths explicitly before `create view ... as select * from read_parquet('<path>')`; parameter binding works for normal `select` filters but not this statement shape.
+5. **History parquet schema is leaner than the app's local table.** Per-product history files may only include `updated_at`, `store_id`, and `price_cent`; get `vendor_id` by joining `public_stores`, and infer product id from the requested history file.
+6. **Historical availability varies.** Some products/stores have no history parquet or no rows for a selected store.
+7. **Effective price is conservative.** The CLI reports `effective_price_cent` as the minimum of original/sale/club/online when present. Multibuy needs human interpretation because quantity matters.
+8. **Live smoke tests depend on upstream stock/history.** Product `5461` and Papakura stores were live-valid when added, but upstream catalogue changes can make the smoke fail without a code bug.
+9. **This is public read-only data.** Do not try to bypass sign-in or scrape private Grocer user/list/pro features.
+
+## Verification Checklist
+
+Run these before relying on a fresh install:
+
+```bash
+python3 $GROCER stores --query Papakura --json
+python3 $GROCER search "milk" --store-query Papakura --limit 2
+python3 $GROCER prices 5461 --store-query Papakura --limit 10
+python3 $GROCER history 5461 --store-query Papakura --limit 5
+```
+
+Expected smoke signal: Papakura stores include Woolworths/New World/PAK'nSAVE, and product `5461` returns Anchor 2L milk pricing/history rows for at least PAK'nSAVE/New World/Woolworths Papakura when current Grocer data includes them.

--- a/skills/grocer-nz/references/api-notes.md
+++ b/skills/grocer-nz/references/api-notes.md
@@ -1,0 +1,169 @@
+# grocer.nz API / asset notes
+
+Sniffed 2026-05-31 from `https://grocer.nz/` using the browser resource list and bundled JS assets.
+
+## Frontend assets
+
+Main bundles observed:
+
+- `https://grocer.nz/assets/index-D3XCRpnM.js`
+- `https://grocer.nz/assets/server-DLE0sY-V.js`
+
+The server worker bundle contains the data access layer. Important discoveries:
+
+```text
+Remote public asset base: https://assets-prod.grocer.nz/public
+Meilisearch host:        https://meilisearch.grocer.nz
+Meilisearch index:       products
+```
+
+The frontend search key is embedded client-side and used as a public bearer token for product search. Treat it as a public frontend key, not a secret. Do not store private tokens or user credentials in this skill.
+
+## Static public files
+
+Base database:
+
+```text
+https://assets-prod.grocer.nz/public/base_v3.duckdb.br
+```
+
+Despite the `.br` suffix, responses may be transparently decoded by the CDN and arrive as a DuckDB database file. The CLI saves it as `base_v3.duckdb`.
+
+Per-store current prices:
+
+```text
+https://assets-prod.grocer.nz/public/prices_per_store_v3/public_prices_<store_id>.parquet
+```
+
+Per-product price history:
+
+```text
+https://assets-prod.grocer.nz/public/price_history_v3/price_history_<product_id>.parquet
+```
+
+## DuckDB schema from worker bundle
+
+The app creates these public tables locally:
+
+```sql
+create table if not exists public_meta (updated_at timestamptz);
+
+create table if not exists public_vendors (
+  id integer,
+  name varchar
+);
+
+create table if not exists public_stores (
+  id           integer,
+  vendor_id    integer,
+  name         varchar,
+  is_enabled   boolean
+);
+
+create table if not exists public_products (
+  id             integer,
+  name           varchar,
+  brand          varchar,
+  unit           varchar,
+  size           varchar,
+  redirected_to  integer
+);
+
+create table if not exists public_barcodes (
+  barcode varchar,
+  product_id integer
+);
+
+create table if not exists public_prices (
+  updated_at               timestamptz,
+  store_id                 integer,
+  product_id               integer,
+  original_price_cent      integer,
+  sale_price_cent          integer,
+  club_price_cent          integer,
+  online_price_cent        integer,
+  multibuy_price_cent      integer,
+  multibuy_quantity        integer,
+  club_multibuy_price_cent integer,
+  club_multibuy_quantity   integer
+);
+
+create table if not exists public_collections (
+  id            integer,
+  name          varchar,
+  is_comparable boolean
+);
+
+create table if not exists public_collection_members (
+  collection_id integer,
+  product_id    integer
+);
+
+create table if not exists public_collection_hierarchy (
+  parent_id integer,
+  child_id  integer
+);
+
+create table if not exists public_price_history (
+  updated_at timestamptz,
+  store_id integer,
+  product_id integer,
+  price_cent integer
+);
+```
+
+Actual history parquet files are per-product and contain at least:
+
+```text
+updated_at, store_id, price_cent
+```
+
+The CLI injects the product id from the requested file path instead of expecting a `product_id` column in history parquet.
+
+## Meilisearch search shape
+
+Search endpoint:
+
+```http
+POST https://meilisearch.grocer.nz/indexes/products/search
+Authorization: Bearer <frontend search key>
+Content-Type: application/json
+```
+
+Useful payload:
+
+```json
+{
+  "q": "milk",
+  "limit": 10,
+  "offset": 0,
+  "filter": ["stores IN [ 118, 230, 307 ]"],
+  "attributesToRetrieve": ["id", "name", "brand", "size", "unit", "categories", "stores"]
+}
+```
+
+Search results include product ids and the store ids that carry each product, but not current prices. Current prices come from the per-store parquet files.
+
+## Live smoke receipts
+
+Verified live with:
+
+```bash
+python3 scripts/cli.py stores --query Papakura --json
+python3 scripts/cli.py search "milk" --store-query Papakura --limit 2
+python3 scripts/cli.py prices 5461 --store-query Papakura --limit 10
+python3 scripts/cli.py history 5461 --store-query Papakura --limit 5
+```
+
+Observed Papakura ids:
+
+- `118` Woolworths Papakura
+- `206` Fresh Choice Papakura
+- `230` PAK'nSAVE Papakura
+- `307` New World Papakura
+
+Observed product smoke:
+
+- Product `5461` — Anchor Milk Lite 98.5% Fat Free 2L
+- Current price rows returned for PAK'nSAVE Papakura, Woolworths Papakura, and New World Papakura.
+- History rows returned from `price_history_v3/price_history_5461.parquet`.

--- a/skills/grocer-nz/scripts/cli.py
+++ b/skills/grocer-nz/scripts/cli.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""CLI for public grocer.nz supermarket price data.
+
+Uses Grocer's public static DuckDB/parquet assets plus its public frontend
+Meilisearch search key. Dependencies are bootstrapped via uv when absent.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import shutil
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+NEEDS = ("duckdb",)
+try:
+    import duckdb  # type: ignore
+except Exception:
+    if os.environ.get("GROCER_NZ_BOOTSTRAPPED") != "1" and shutil.which("uv"):
+        env = os.environ.copy()
+        env["GROCER_NZ_BOOTSTRAPPED"] = "1"
+        os.execvpe(
+            "uv",
+            ["uv", "run", "--quiet", "--with", "duckdb", "python", __file__, *sys.argv[1:]],
+            env,
+        )
+    raise
+
+BASE = "https://assets-prod.grocer.nz/public"
+MEILI = "https://meilisearch.grocer.nz"
+MEILI_KEY = "7f58239330307ec585c86863f985ab83cbb9ce951a9601c66e158548fb632fd1"
+CACHE = pathlib.Path(os.environ.get("GROCER_NZ_CACHE", "~/.cache/grocer-nz")).expanduser()
+HEADERS = {"User-Agent": "Mozilla/5.0 (Hermes grocer.nz skill)", "Referer": "https://grocer.nz/"}
+MAX_LIMIT = 100
+
+
+def http_get(url: str, *, headers: dict[str, str] | None = None) -> bytes:
+    req = urllib.request.Request(url, headers={**HEADERS, **(headers or {})})
+    with urllib.request.urlopen(req, timeout=120) as r:
+        return r.read()
+
+
+def http_json(url: str, payload: dict[str, Any], *, headers: dict[str, str] | None = None) -> dict[str, Any]:
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json", **HEADERS, **(headers or {})},
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return json.loads(r.read().decode())
+
+
+def download(url: str, path: pathlib.Path, *, force: bool = False) -> pathlib.Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if force or not path.exists() or path.stat().st_size == 0:
+        path.write_bytes(http_get(url))
+    return path
+
+
+def base_db(force: bool = False) -> pathlib.Path:
+    CACHE.mkdir(parents=True, exist_ok=True)
+    # Despite the .br suffix, CDN responses are often transparently decoded.
+    return download(f"{BASE}/base_v3.duckdb.br", CACHE / "base_v3.duckdb", force=force)
+
+
+def price_file(store_id: int, force: bool = False) -> pathlib.Path | None:
+    path = CACHE / "prices_per_store_v3" / f"public_prices_{store_id}.parquet"
+    try:
+        return download(f"{BASE}/prices_per_store_v3/public_prices_{store_id}.parquet", path, force=force)
+    except urllib.error.HTTPError as e:
+        if e.code in (403, 404):
+            return None
+        raise
+
+
+def history_file(product_id: int, force: bool = False) -> pathlib.Path | None:
+    path = CACHE / "price_history_v3" / f"price_history_{product_id}.parquet"
+    try:
+        return download(f"{BASE}/price_history_v3/price_history_{product_id}.parquet", path, force=force)
+    except urllib.error.HTTPError as e:
+        if e.code in (403, 404):
+            return None
+        raise
+
+
+def con(force: bool = False):
+    db = base_db(force=force)
+    c = duckdb.connect(":memory:")
+    sql = "attach " + sql_quote_path(db) + " as base (READ_ONLY)"
+    c.execute(sql)
+    return c
+
+
+def rows_to_dicts(cur) -> list[dict[str, Any]]:
+    cols = [d[0] for d in cur.description]
+    out = []
+    for row in cur.fetchall():
+        item = {}
+        for k, v in zip(cols, row):
+            if hasattr(v, "isoformat"):
+                v = v.isoformat()
+            item[k] = v
+        out.append(item)
+    return out
+
+
+def cents(v: Any) -> str:
+    return "-" if v is None else f"${int(v)/100:.2f}"
+
+
+def effective_expr(alias: str = "pr") -> str:
+    return f"least(coalesce({alias}.sale_price_cent, 999999999), coalesce({alias}.club_price_cent, 999999999), coalesce({alias}.online_price_cent, 999999999), coalesce({alias}.original_price_cent, 999999999))"
+
+
+def bounded_limit(value: int) -> int:
+    return max(1, min(int(value), MAX_LIMIT))
+
+
+def bounded_offset(value: int) -> int:
+    return max(0, int(value))
+
+
+def meili_filter_string(value: str) -> str:
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def print_result(data: Any, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2, ensure_ascii=False, default=str))
+    elif isinstance(data, list):
+        for item in data:
+            print(" | ".join(f"{k}={v}" for k, v in item.items()))
+    else:
+        print(data)
+
+
+def cmd_stores(args):
+    c = con(force=args.refresh)
+    where = ["s.is_enabled = true"] if not args.include_disabled else []
+    params: list[Any] = []
+    if args.query:
+        where.append("lower(s.name) like ?")
+        params.append(f"%{args.query.lower()}%")
+    if args.vendor:
+        where.append("lower(v.name) like ?")
+        params.append(f"%{args.vendor.lower()}%")
+    sql = """
+      select s.id, v.name as vendor, s.name, s.is_enabled
+      from base.public_stores s
+      left join base.public_vendors v on v.id = s.vendor_id
+    """
+    if where:
+        sql += " where " + " and ".join(where)
+    sql += " order by v.name, s.name limit ?"
+    params.append(args.limit)
+    rows = rows_to_dicts(c.execute(sql, params))
+    print_result(rows, args.json)
+
+
+def resolve_store_ids(c, store_ids: list[int], store_query: str | None) -> list[int]:
+    ids = list(dict.fromkeys(store_ids))
+    if store_query:
+        rows = c.execute(
+            "select id from base.public_stores where is_enabled=true and lower(name) like ? order by name",
+            [f"%{store_query.lower()}%"],
+        ).fetchall()
+        ids.extend(int(r[0]) for r in rows)
+    return list(dict.fromkeys(ids))
+
+
+def meili_search(term: str, limit: int, offset: int, store_ids: list[int] | None = None, category: str = "") -> dict[str, Any]:
+    filters = []
+    limit = bounded_limit(limit)
+    offset = bounded_offset(offset)
+    if store_ids:
+        filters.append(f"stores IN [ {', '.join(map(str, store_ids))} ]")
+    if category:
+        level = len(category.split(" > "))
+        filters.append(f'categories.level_{level} = "{meili_filter_string(category)}"')
+    payload = {
+        "q": term,
+        "limit": limit,
+        "offset": offset,
+        "filter": filters,
+        "attributesToRetrieve": ["id", "name", "brand", "size", "unit", "categories", "stores"],
+    }
+    return http_json(f"{MEILI}/indexes/products/search", payload, headers={"Authorization": f"Bearer {MEILI_KEY}"})
+
+
+def sql_quote_path(path: pathlib.Path) -> str:
+    return "'" + str(path).replace("'", "''") + "'"
+
+
+def attach_price_views(c, store_ids: list[int], refresh: bool = False) -> list[int]:
+    ok = []
+    for sid in store_ids:
+        p = price_file(sid, force=refresh)
+        if not p:
+            continue
+        sql = "create or replace view prices_{} as select * from read_parquet({})".format(
+            sid, sql_quote_path(p)
+        )
+        c.execute(sql)
+        ok.append(sid)
+    return ok
+
+
+def cmd_search(args):
+    c = con(force=args.refresh)
+    store_ids = resolve_store_ids(c, args.store_id or [], args.store_query)
+    result = meili_search(args.term, args.limit, args.offset, store_ids or None, args.category or "")
+    hits = result.get("hits", [])
+    ids = [int(h["id"]) for h in hits]
+    if store_ids and ids:
+        ok = attach_price_views(c, store_ids, refresh=args.refresh)
+        if ok:
+            union = " union all ".join([f"select * from prices_{sid}" for sid in ok])
+            placeholders = ",".join(["?"] * len(ids))
+            sql = """
+              with price_union as ({union})
+              select p.id as product_id, s.id as store_id, s.name as store_name,
+                     pr.updated_at, pr.original_price_cent, pr.sale_price_cent, pr.club_price_cent,
+                     pr.online_price_cent, pr.multibuy_price_cent, pr.multibuy_quantity,
+                     {effective_price} as effective_price_cent
+              from price_union pr
+              join base.public_products p on p.id = pr.product_id
+              join base.public_stores s on s.id = pr.store_id
+              where p.id in ({placeholders})
+              order by p.id, effective_price_cent, s.name
+            """.format(union=union, effective_price=effective_expr(), placeholders=placeholders)
+            price_rows = rows_to_dicts(c.execute(sql, ids))
+            by_pid: dict[int, list[dict[str, Any]]] = {}
+            for r in price_rows:
+                by_pid.setdefault(int(r["product_id"]), []).append(r)
+            for h in hits:
+                h["prices"] = by_pid.get(int(h["id"]), [])
+    if args.json:
+        print_result({"estimatedTotalHits": result.get("estimatedTotalHits"), "hits": hits}, True)
+    else:
+        print(f"estimatedTotalHits={result.get('estimatedTotalHits')}")
+        for h in hits:
+            label = " ".join(str(x) for x in [h.get("brand"), h.get("name"), h.get("size")] if x)
+            print(f"{h['id']} | {label}")
+            for p in h.get("prices", [])[:10]:
+                print(f"  {p['store_name']}: eff {cents(p['effective_price_cent'])} orig {cents(p['original_price_cent'])} sale {cents(p['sale_price_cent'])} club {cents(p['club_price_cent'])} updated {p['updated_at']}")
+
+
+def cmd_prices(args):
+    c = con(force=args.refresh)
+    store_ids = resolve_store_ids(c, args.store_id or [], args.store_query)
+    if args.all_stores or not store_ids:
+        store_ids = [int(r[0]) for r in c.execute("select id from base.public_stores where is_enabled=true order by id").fetchall()]
+    ok = attach_price_views(c, store_ids, refresh=args.refresh)
+    if not ok:
+        print_result([], args.json)
+        return
+    union = " union all ".join([f"select * from prices_{sid}" for sid in ok])
+    sql = """
+      with price_union as ({union})
+      select p.id as product_id, p.brand, p.name, p.size, s.id as store_id, s.name as store_name,
+             pr.updated_at, pr.original_price_cent, pr.sale_price_cent, pr.club_price_cent,
+             pr.online_price_cent, pr.multibuy_price_cent, pr.multibuy_quantity,
+             {effective_price} as effective_price_cent
+      from price_union pr
+      join base.public_products p on p.id=pr.product_id
+      join base.public_stores s on s.id=pr.store_id
+      where p.id=?
+      order by effective_price_cent, s.name
+      limit ?
+    """.format(union=union, effective_price=effective_expr())
+    rows = rows_to_dicts(c.execute(sql, [args.product_id, args.limit]))
+    if args.json:
+        print_result(rows, True)
+    else:
+        for r in rows:
+            print(f"{r['store_name']}: eff {cents(r['effective_price_cent'])} orig {cents(r['original_price_cent'])} sale {cents(r['sale_price_cent'])} club {cents(r['club_price_cent'])} updated {r['updated_at']}")
+
+
+def cmd_history(args):
+    c = con(force=args.refresh)
+    p = history_file(args.product_id, force=args.refresh)
+    if not p:
+        print_result([], args.json)
+        return
+    sql = "create or replace view hist as select * from read_parquet({})".format(
+        sql_quote_path(p)
+    )
+    c.execute(sql)
+    where = []
+    params: list[Any] = []
+    ids = resolve_store_ids(c, args.store_id or [], args.store_query)
+    if ids:
+        where.append("h.store_id in (" + ",".join(["?"] * len(ids)) + ")")
+        params.extend(ids)
+    where_sql = "where " + " and ".join(where) if where else ""
+    sql = """
+      select h.updated_at, h.store_id, s.vendor_id, s.name as store_name, h.price_cent
+      from hist h
+      left join base.public_stores s on s.id=h.store_id
+      {where_sql}
+      order by h.updated_at desc, s.name
+      limit ?
+    """.format(where_sql=where_sql)
+    rows = rows_to_dicts(c.execute(sql, [*params, args.limit]))
+    if args.json:
+        print_result(rows, True)
+    else:
+        for r in rows:
+            print(f"{r['updated_at']} | {r['store_name'] or r['store_id']} | {cents(r['price_cent'])}")
+
+
+def cmd_product(args):
+    c = con(force=args.refresh)
+    rows = rows_to_dicts(c.execute("""
+      select p.*, c1.name as category_1, c2.name as category_2, c3.name as category_3
+      from base.public_products p
+      left join base.public_collection_members cm1 on cm1.product_id=p.id
+      left join base.public_collections c1 on c1.id=cm1.collection_id and c1.is_comparable=true
+      left join base.public_collections c2 on false
+      left join base.public_collections c3 on false
+      where p.id=?
+      limit 1
+    """, [args.product_id]))
+    # Category joins in the app are hierarchy-derived; raw product row is the reliable bit here.
+    if not rows:
+        rows = rows_to_dicts(c.execute("select * from base.public_products where id=?", [args.product_id]))
+    print_result(rows[0] if rows else {}, args.json)
+
+
+def main(argv=None):
+    p = argparse.ArgumentParser(description="Query public grocer.nz supermarket price/search/history data")
+    p.add_argument("--refresh", action="store_true", help="refresh cached public files")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("stores", help="list stores")
+    sp.add_argument("--query", "-q")
+    sp.add_argument("--vendor")
+    sp.add_argument("--include-disabled", action="store_true")
+    sp.add_argument("--limit", type=int, default=50)
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_stores)
+
+    sp = sub.add_parser("search", help="search products; optionally include current prices for selected stores")
+    sp.add_argument("term")
+    sp.add_argument("--store-id", type=int, action="append", default=[])
+    sp.add_argument("--store-query")
+    sp.add_argument("--category", default="")
+    sp.add_argument("--limit", type=int, default=10)
+    sp.add_argument("--offset", type=int, default=0)
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_search)
+
+    sp = sub.add_parser("prices", help="current prices for a product id across selected stores")
+    sp.add_argument("product_id", type=int)
+    sp.add_argument("--store-id", type=int, action="append", default=[])
+    sp.add_argument("--store-query")
+    sp.add_argument("--all-stores", action="store_true", help="download/query all enabled store price parquet files; can be slow")
+    sp.add_argument("--limit", type=int, default=50)
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_prices)
+
+    sp = sub.add_parser("history", help="historical price rows for a product id")
+    sp.add_argument("product_id", type=int)
+    sp.add_argument("--store-id", type=int, action="append", default=[])
+    sp.add_argument("--store-query")
+    sp.add_argument("--limit", type=int, default=100)
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_history)
+
+    sp = sub.add_parser("product", help="raw product metadata by id")
+    sp.add_argument("product_id", type=int)
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_product)
+
+    args = p.parse_args(argv)
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/grocer-nz/scripts/smoke_test.py
+++ b/skills/grocer-nz/scripts/smoke_test.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Live smoke test for the grocer-nz skill."""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "scripts" / "cli.py"
+
+
+def run(*args: str) -> str:
+    proc = subprocess.run(
+        [sys.executable, str(CLI), *args],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=180,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"command failed: {' '.join(args)}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+    return proc.stdout
+
+
+def main() -> None:
+    stores = json.loads(run("stores", "--query", "Papakura", "--json"))
+    names = {store["name"] for store in stores}
+    assert "Woolworths Papakura" in names
+    assert "PAK'nSAVE Papakura" in names
+    assert "New World Papakura" in names
+
+    search = run("search", "milk", "--store-query", "Papakura", "--limit", "2")
+    assert "Anchor" in search
+    assert "PAK'nSAVE Papakura" in search or "New World Papakura" in search
+
+    prices = run("prices", "5461", "--store-query", "Papakura", "--limit", "10")
+    assert "PAK'nSAVE Papakura" in prices
+    assert "$" in prices
+
+    history = run("history", "5461", "--store-query", "Papakura", "--limit", "5")
+    assert "$" in history
+    assert "Papakura" in history
+
+    print("grocer-nz smoke ok")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Intent

Adds a read-only `grocer-nz` skill so agents can query NZ supermarket pricing from grocer.nz public data instead of re-sniffing the site each time.

## Shape / Rationale

- Uses Grocer's public static DuckDB/parquet assets for store metadata, current per-store prices, and product price history.
- Uses Grocer's public frontend Meilisearch product index for product discovery.
- Keeps the connector read-only: no login, no private user lists, no cart/checkout/account actions.
- Includes a CLI, API/asset notes, live smoke test, and README registration.
- Bounds search limits and escapes category filters to avoid accidental high-load/malformed Meilisearch queries.

## Safety boundaries

- Public data only; no credentials or authenticated Grocer features.
- The Meilisearch bearer value is the frontend public search key already shipped to browsers; documented as public client config, not a private secret.
- `--all-stores` is explicit because it can download many per-store parquet files.
- Historical/live smoke data can change upstream, so the skill documents that fragility.

## Verification

```bash
python3 -m py_compile skills/grocer-nz/scripts/cli.py skills/grocer-nz/scripts/smoke_test.py
python3 scripts/validate_skill.py skills/grocer-nz --strict
python3 skills/grocer-nz/scripts/smoke_test.py
git diff --check --cached
```

Results:

- Skill validation passed with no issues.
- Live smoke passed: `grocer-nz smoke ok`.
- Smoke verified Papakura stores and product `5461` Anchor Milk Lite 98.5% Fat Free 2L pricing/history.
- Added-line security scan for hardcoded private secrets, shell injection, eval/exec, pickle, and f-string SQL came back clean.

## Independent review

SubClaude reviewed the staged diff and returned **passed: true** with no blockers. Suggestions were addressed before commit:

- bounded Meilisearch limit/offset
- escaped category filter strings
- removed unused imports
- documented live-smoke upstream fragility
