### PR TITLE
Fix woolworths-nz count to reflect returned products

### DIFF
--- a/skills/woolworths-nz/scripts/cli.py
+++ b/skills/woolworths-nz/scripts/cli.py
@@ -168,7 +168,7 @@ def products_query(target: str, *, search: str | None = None, category_id: str |
         params["categoryId"] = category_id
     started = time.perf_counter()
     payload = request_json("/products", params=params)
-    products = product_items(payload)
+    products = product_items(payload)[:limit]
     elapsed_ms = round((time.perf_counter() - started) * 1000)
     return {
         "target": target,
@@ -176,7 +176,7 @@ def products_query(target: str, *, search: str | None = None, category_id: str |
         "category_id": category_id,
         "count": len(products),
         "elapsed_ms": elapsed_ms,
-        "products": products[:limit],
+        "products": products,
         "raw_total": nested(payload or {}, "products", "totalRecordCount"),
     }
 


### PR DESCRIPTION
## What

`products_query` reported `count` as the **pre-limit** total while slicing `products` to `--limit`, so the count and the returned list disagreed:

- `search milk --limit 2 --json` → returned 2 products but reported `count=5`
- `specials --limit 3 --json` → returned 3 products but reported `count=11`

## Fix

Slice the product list once before computing `count`, so `count` always equals `len(products)`. Safe for all callers: `cmd_search` recomputes count after its `--size` filter, and `cmd_specials` passes its own larger fetch limit.

## Testing

Found by an individual CLI test sweep across all 63 skills (60 pass / 3 key-gated skip / 0 fail — this was the only real code defect).

- `search milk --limit 2 --json` → `count=2 len=2` ✅
- `specials --limit 3 --json` → `count=3 len=3` ✅
- `python3 scripts/validate_skill.py skills/woolworths-nz` → OK ✅
- woolworths-nz smoke test → all 4 pass ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)