### PR TITLE
fix(stats-nz): tolerate migration catalogue wording changes

### DIFF
--- a/skills/stats-nz/scripts/cli.py
+++ b/skills/stats-nz/scripts/cli.py
@@ -333,7 +333,11 @@ def gdp_doc() -> dict[str, str]:
 
 
 def migration_doc() -> dict[str, str]:
-    return find_catalog_doc(["international migration", "estimated migration by age and sex"])
+    # Stats NZ release titles/filenames have used both "estimated migration by
+    # age and sex" and "estimated migration by age sex" wording. Match the
+    # stable component terms instead of one exact phrase so the command survives
+    # routine monthly catalogue title changes.
+    return find_catalog_doc(["international migration", "estimated migration", "age", "sex"])
 
 
 def cmd_cpi(args: argparse.Namespace) -> None:


### PR DESCRIPTION
## Summary
- fix Stats NZ migration catalogue lookup after upstream title changed from `estimated migration by age and sex` to `estimated migration by age sex`
- match stable component terms instead of one brittle exact phrase

## Verification
- `python3 skills/stats-nz/scripts/smoke_test.py`
- `bash scripts/run_all_smoke.sh` → `PASS: 62, SKIP: 5, FAIL: 0`
