### PR TITLE
ci: notify the-for-good-project on push to main

### DIFF
--- a/.github/workflows/notify-forgood.yml
+++ b/.github/workflows/notify-forgood.yml
@@ -1,0 +1,35 @@
+# Tell thecolab-ai/the-for-good-project immediately when main moves, instead
+# of making it wait for its hourly poll. That repo vendors this one as a git
+# submodule and has its own workflow
+# (.github/workflows/update-skills-submodule.yml) that opens a PR bumping the
+# submodule pointer whenever it sees a change — this just wakes it up sooner
+# by firing a repository_dispatch event it listens for.
+#
+# Requires a secret FORGOOD_DISPATCH_TOKEN: a fine-grained PAT scoped to ONLY
+# thecolab-ai/the-for-good-project with "Contents: Read" and "Actions: Read
+# and write" permissions (Actions write is what lets it send a dispatch
+# event). Until that secret exists, this step no-ops — the hourly poll on the
+# other side is the fallback either way, so this workflow is safe to merge
+# before the secret is created.
+name: Notify consumers of main update
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  notify-the-for-good-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch skills-updated event
+        env:
+          GH_TOKEN: ${{ secrets.FORGOOD_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::warning::FORGOOD_DISPATCH_TOKEN not set — skipping. thecolab-ai/the-for-good-project will still pick this up on its hourly poll."
+            exit 0
+          fi
+          gh api repos/thecolab-ai/the-for-good-project/dispatches \
+            -f event_type=skills-updated \
+            -f "client_payload[sha]=${GITHUB_SHA}"


### PR DESCRIPTION
## Why

thecolab-ai/the-for-good-project vendors this repo as a git submodule and currently only polls hourly for updates (`update-skills-submodule.yml`, cron). This adds a push-triggered notification so it doesn't wait up to an hour.

## What

New workflow: on every push to `main`, fires a `repository_dispatch` event (`skills-updated`) at `thecolab-ai/the-for-good-project`. That repo's existing workflow will be updated (companion PR) to listen for it in addition to its current schedule/manual triggers — no change to its logic otherwise (still opens a PR bumping the submodule pointer, still auto-merges on a passing review).

## Requires

A `FORGOOD_DISPATCH_TOKEN` secret in this repo — a **fine-grained PAT scoped to only `thecolab-ai/the-for-good-project`**, with `Contents: Read` + `Actions: Read and write`. Deliberately narrow: it can't touch any other repo, can't approve/merge, can only kick off that repo's own workflow runs. Until the secret is set, this workflow no-ops with a warning (the hourly poll on the other side still covers it), so this is safe to merge before the secret exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XaCFSqfJDTmT1wGn8yvBYv