### PR TITLE
fix(eeca-ev-chargers-nz): classify data.govt.nz bot-block as a networ…

### DIFF
--- a/skills/eeca-ev-chargers-nz/scripts/cli.py
+++ b/skills/eeca-ev-chargers-nz/scripts/cli.py
@@ -53,16 +53,42 @@ def request(url: str, timeout: int = 30):
     return urllib.request.urlopen(req, timeout=timeout)
 
 
+def _looks_like_bot_challenge(body: str, content_type: str) -> bool:
+    """A public NZ source behind Incapsula/Cloudflare answers a JSON API request
+    with an HTML interstitial (often HTTP 200). That is a transient *block*, not
+    a dead source or malformed JSON — detect it so callers classify it as such."""
+    if "text/html" in content_type:
+        return True
+    head = body.lstrip()[:512].lower()
+    return (
+        head.startswith("<")
+        or "<!doctype html" in head
+        or "incapsula" in body.lower()
+        or "_incapsula_resource" in body.lower()
+        or "request unsuccessful" in head
+    )
+
+
 def fetch_json(url: str, timeout: int = 30) -> dict[str, Any]:
     try:
         with request(url, timeout=timeout) as resp:
-            return json.loads(resp.read().decode("utf-8", "replace"))
+            raw = resp.read().decode("utf-8", "replace")
+            content_type = (resp.headers.get("Content-Type") or "").lower()
     except urllib.error.HTTPError as e:
         raw = e.read().decode("utf-8", "replace")
+        # 403/429 (with or without an HTML challenge body) mean the public
+        # source is bot-blocking this network — a transient block, so report it
+        # as a network error (callers/smoke tests skip rather than hard-fail).
+        if e.code in (403, 429):
+            die(f"network error: HTTP {e.code} from {url} — the public source is bot-blocking this network (blocked). {raw[:200]}")
         die(f"HTTP {e.code} from {url}: {raw[:240]}")
     except urllib.error.URLError as e:
         die(f"network error calling {url}: {e.reason}")
+    try:
+        return json.loads(raw)
     except json.JSONDecodeError as e:
+        if _looks_like_bot_challenge(raw, content_type):
+            die(f"network error: {url} returned a non-JSON bot-challenge response (blocked — likely an Incapsula/Cloudflare interstitial, not a dead source).")
         die(f"invalid JSON from {url}: {e}")
 
 

--- a/skills/eeca-ev-chargers-nz/scripts/smoke_test.py
+++ b/skills/eeca-ev-chargers-nz/scripts/smoke_test.py
@@ -33,12 +33,20 @@ def is_network_failure(result: subprocess.CompletedProcess) -> bool:
             "network error",
             "timed out",
             "timeout",
+            "http 403",
             "http 429",
             "http 500",
             "http 502",
             "http 503",
             "http 504",
             "urlopen error",
+            # data.govt.nz / EECA sit behind Incapsula, which answers API
+            # requests with an HTML bot-challenge (often HTTP 200) — a transient
+            # block, not a real failure. Skip rather than hard-fail on these.
+            "blocked",
+            "bot-challenge",
+            "bot-blocking",
+            "incapsula",
         ]
     )
 


### PR DESCRIPTION
…k failure, not invalid JSON

catalogue.data.govt.nz sits behind Incapsula, which answers the CKAN API with an HTML challenge (often HTTP 200). fetch_json json.loads()'d that and died 'invalid JSON', so the datasets command hard-failed and smoke_test.py exited 1 (is_network_failure did not recognise the block) — even though it's a transient block, not a dead source or malformed JSON.

- fetch_json now reads the body + content-type, detects an HTML/Incapsula bot-challenge (and 403/429), and reports it as a 'network error ... (blocked)'.
- is_network_failure gains blocked/bot-challenge/incapsula/http-403 markers.

Smoke test now SKIPs the blocked call (exit 0) instead of failing, matching the education-counts-nz skill's block handling.