### PR TITLE
nzfetch: retry truncated reads, real Chrome-149 fingerprint, retries→3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,7 +83,7 @@ POST `data`/`method`, and a custom SSL `context=` are preserved through the prox
 | Env | Meaning |
 |---|---|
 | `FETCH_PROXY` / `HTTPS_PROXY` | Rotating proxy URL, e.g. `http://user:pass@host:port`. **A SECRET** — never hard-code, print, or commit it; `nzfetch` reads it from the env only. |
-| `PROXY_RETRIES` | Retries through the proxy on a block, a fresh IP each (default 2). Raise it if a source is heavily flagged; lower keeps many-fetch skills fast under a tight timeout. |
+| `PROXY_RETRIES` | Retries through the proxy on a block **or a truncated read** (default 3). A rotating pool gets a fresh IP each retry; a single-IP proxy re-attempts (still clears transient truncations). Raise it for a stubborn wall or a proxy that often truncates large responses. |
 | `NZFETCH_UA` | Override the User-Agent for a source that needs a specific one. |
 
 Even without adopting `nzfetch`, any skill that uses `urllib` already **honours `HTTPS_PROXY`

--- a/lib/nzfetch.py
+++ b/lib/nzfetch.py
@@ -28,9 +28,11 @@ Environment (all optional):
     FETCH_PROXY / HTTPS_PROXY   rotating proxy URL, e.g. http://user:pass@host:port
                                — a SECRET. Never hard-code it, never print it, never
                                commit it. nzfetch reads it from the env only.
-    PROXY_RETRIES              retries through the proxy on a block, a fresh IP each
-                               (default 2). Raise it for a stubborn wall; lower keeps
-                               many-fetch skills fast under a tight test timeout.
+    PROXY_RETRIES              retries through the proxy on a block or a truncated
+                               read (default 3). A rotating pool gets a fresh IP each
+                               retry; a single-IP proxy just re-attempts (which still
+                               clears transient truncations). Raise it for a stubborn
+                               wall or a proxy that often truncates large responses.
     NZFETCH_UA                 override the User-Agent if a source needs a specific one.
 
 No proxy set → nzfetch just does the single direct request (same as before), so a
@@ -39,6 +41,7 @@ skill that imports it keeps working unchanged when no proxy is configured.
 from __future__ import annotations
 
 import gzip
+import http.client
 import json
 import os
 import urllib.error
@@ -244,7 +247,7 @@ def fetch_bytes(
     openers: list = [None]  # attempt 1 = direct
     if proxy:
         handler = urllib.request.ProxyHandler({"http": proxy, "https": proxy})
-        retries = max(1, int(os.environ.get("PROXY_RETRIES", "2")))
+        retries = max(1, int(os.environ.get("PROXY_RETRIES", "3")))
         openers += [urllib.request.build_opener(handler)] * retries
     open_kw = {"timeout": timeout}
     if context is not None:
@@ -271,6 +274,13 @@ def fetch_bytes(
             continue
         except (TimeoutError, OSError) as e:  # bare socket timeout / connection reset
             last = f"network error: {e}"
+            continue
+        except http.client.HTTPException as e:
+            # A truncated / malformed response body — most often
+            # http.client.IncompleteRead when a chunked response is cut off
+            # mid-stream (common through a proxy on a large body). Transient:
+            # retry (a fresh connection / IP usually completes it).
+            last = f"network error: incomplete read ({type(e).__name__})"
             continue
         if _looks_like_challenge(body.decode("utf-8", "replace"), content_type, expected_json=expects_json):
             last = "bot-challenge interstitial"


### PR DESCRIPTION
Follow-up to #164 (the shared nzfetch helper).

## Problem
A large chunked response cut off mid-stream raises `http.client.IncompleteRead`, which is an `HTTPException` — **not** an `OSError` — so it slipped past nzfetch's existing retry catch and surfaced as a raw traceback / invalid-JSON hard failure. This shows up through a proxy on big bodies: e.g. `catalogue.data.govt.nz` public-housing register data truncated at ~316 KiB through a residential proxy (`IncompleteRead(323410 bytes read)`), then completing fine on a re-request.

## Fix
- Catch `http.client.HTTPException` in the fetch loop and **retry** — a transient truncation now recovers instead of failing the caller.
- Bump default `PROXY_RETRIES` **2 → 3**. A single-IP (residential) proxy doesn't rotate, so retries mainly ride out transient truncations; 3 attempts clears the large-body case reliably where 2 sometimes didn't. Per-hop latency on a local proxy is low, so the extra attempt is cheap.

## Verified
`public-housing-nz local-stats` (the ~316 KiB CKAN body): FAIL→**PASS** through a proxy at the new default. Re-checked `interest-co-nz`, `data-govt-nz` (SKIP→PASS) — no regression. Unit checks (challenge gating, AWS-WAF markers, 406/451 blocks, header modes) all still pass.

No secret in the diff (env-only proxy handling unchanged).