### PR TITLE
nzfetch owns a consistent modern Chrome-149 fingerprint; skills stop overriding it

### DIFF
--- a/lib/nzfetch.py
+++ b/lib/nzfetch.py
@@ -24,6 +24,17 @@ Handle the two typed errors so a transient block SKIPS rather than hard-fails:
     except nzfetch.FetchError as e:
         die(str(e))
 
+nzfetch owns the browser fingerprint. Every request carries a consistent current
+Chrome header set by default (User-Agent + matching sec-ch-ua / Sec-Fetch-* /
+Accept-Language / Priority). A skill should NOT pass its own fingerprint headers:
+a skill User-Agent or sec-ch-ua that disagrees with the rest of the set is itself
+a bot signal. Pass ``headers={...}`` only for SEMANTIC headers a source needs (an
+API key, Authorization, Referer, Content-Type, X-Requested-With) — those merge
+over the defaults and win. nzfetch stays fully capable of overrides: set
+``NZFETCH_UA`` for the User-Agent, pass any header in ``headers=`` (it wins), or
+use ``browser_headers=False`` for a lean set — but default to nzfetch's headers
+wherever they already work.
+
 Environment (all optional):
     FETCH_PROXY / HTTPS_PROXY   rotating proxy URL, e.g. http://user:pass@host:port
                                — a SECRET. Never hard-code it, never print it, never
@@ -49,10 +60,18 @@ import urllib.parse
 import urllib.request
 import zlib
 
+# Keep the UA version and the sec-ch-ua brand list in sync — a real Chrome sends a
+# UA and Client-Hints that agree, and a mismatch is itself a bot signal. Bump this
+# one constant to track current stable Chrome. Values below mirror a real Chrome
+# request captured from DevTools (macOS, Chrome 149).
+CHROME_VERSION = "149"
 DEFAULT_UA = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
-    "(KHTML, like Gecko) Chrome/125.0 Safari/537.36"
+    f"(KHTML, like Gecko) Chrome/{CHROME_VERSION}.0.0.0 Safari/537.36"
 )
+# The GREASE-style brand list Chrome 149 emits (order + the "Not)A;Brand" token
+# match the real header exactly).
+SEC_CH_UA = f'"Google Chrome";v="{CHROME_VERSION}", "Chromium";v="{CHROME_VERSION}", "Not)A;Brand";v="24"'
 
 
 def _browser_headers(url: str, accept: str) -> dict:
@@ -76,13 +95,16 @@ def _browser_headers(url: str, accept: str) -> dict:
     h = {
         "User-Agent": ua,
         "Accept": accept if accept else "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Language": "en-NZ,en-AU;q=0.9,en;q=0.8",
+        "Accept-Language": "en-GB,en-US;q=0.9,en;q=0.8",
         "Accept-Encoding": "gzip, deflate",  # only what we can decode in stdlib
         "Cache-Control": "no-cache",
         "Pragma": "no-cache",
-        "sec-ch-ua": '"Chromium";v="125", "Not.A/Brand";v="24", "Google Chrome";v="125"',
+        "sec-ch-ua": SEC_CH_UA,
         "sec-ch-ua-mobile": "?0",
         "sec-ch-ua-platform": '"macOS"',
+        # Chrome's Fetch Priority hint: u=0 (highest) for a document navigation,
+        # u=1 for an API/subresource fetch. Matches a real request exactly.
+        "Priority": "u=0, i" if is_doc else "u=1, i",
         "Sec-Fetch-Dest": "document" if is_doc else "empty",
         "Sec-Fetch-Mode": "navigate" if is_doc else "cors",
         "Sec-Fetch-Site": "same-origin",
@@ -244,19 +266,24 @@ def fetch_bytes(
     # (fetch_text=False, fetch_json=True) when given; else inferred from accept.
     expects_json = expect_json if expect_json is not None else ("json" in (accept or "").lower())
     proxy = proxy_url()
-    openers: list = [None]  # attempt 1 = direct
+    openers: list = [None]  # attempt 1 = direct (urlopen, which accepts context=)
     if proxy:
         handler = urllib.request.ProxyHandler({"http": proxy, "https": proxy})
+        # A custom SSL context must be baked into an HTTPSHandler on the opener —
+        # OpenerDirector.open() does NOT accept a context= kwarg (passing it raises
+        # TypeError), so it can't be forwarded per-call like urlopen's.
+        extra = [urllib.request.HTTPSHandler(context=context)] if context is not None else []
         retries = max(1, int(os.environ.get("PROXY_RETRIES", "3")))
-        openers += [urllib.request.build_opener(handler)] * retries
-    open_kw = {"timeout": timeout}
+        openers += [urllib.request.build_opener(handler, *extra)] * retries
+    # context= only goes to the direct urlopen; the proxy openers carry it in their handler.
+    direct_kw = {"timeout": timeout}
     if context is not None:
-        open_kw["context"] = context
+        direct_kw["context"] = context
     last = "no attempt made"
     for opener in openers:
         req = urllib.request.Request(url, data=data, headers=hdrs, method=method)
         try:
-            resp = opener.open(req, **open_kw) if opener else urllib.request.urlopen(req, **open_kw)
+            resp = opener.open(req, timeout=timeout) if opener else urllib.request.urlopen(req, **direct_kw)
             body = _decompress(resp.read(), resp.headers.get("Content-Encoding"))
             content_type = (resp.headers.get("Content-Type") or "").lower()
             final_url = resp.geturl()

--- a/skills/akahu-personal/scripts/cli.py
+++ b/skills/akahu-personal/scripts/cli.py
@@ -91,7 +91,6 @@ class AkahuClient:
             "Authorization": f"Bearer {self.user_token}",
             "X-Akahu-Id": self.app_token,
             "Accept": "application/json",
-            "User-Agent": "thecolab-skills-akahu-personal/1.0",
         }
         if json_body is not None:
             body = json.dumps(json_body).encode("utf-8")

--- a/skills/at-transport/scripts/cli.py
+++ b/skills/at-transport/scripts/cli.py
@@ -25,7 +25,6 @@ import nzfetch  # noqa: E402
 
 BASE_URL = "https://api.at.govt.nz"
 API_KEY = os.environ.get("AT_API_KEY", "de42128902d24a7a86a013633f7aa832")
-UA = "at-transport-skill/1.0 (+https://github.com/thecolab-ai/.skills)"
 DEFAULT_TIMEOUT = 15
 
 try:
@@ -45,7 +44,6 @@ def request_json(path: str, timeout: int = DEFAULT_TIMEOUT) -> Any:
     headers = {
         "Accept": "application/json",
         "Ocp-Apim-Subscription-Key": API_KEY,
-        "User-Agent": UA,
     }
     try:
         body, _ct, _final = nzfetch.fetch_bytes(url, headers=headers, timeout=timeout, accept="application/json")

--- a/skills/bargainchemist-nz/scripts/cli.py
+++ b/skills/bargainchemist-nz/scripts/cli.py
@@ -28,10 +28,6 @@ BOOST_SUGGEST_BASE = "https://services.mybcapps.com/bc-sf-filter/search/suggest"
 SHOP = "bargain-chemist.myshopify.com"
 DEFAULT_LIMIT = 12
 MAX_LIMIT = 50
-UA = os.environ.get(
-    "BARGAINCHEMIST_NZ_USER_AGENT",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
-)
 
 
 class ApiError(Exception):
@@ -69,7 +65,6 @@ def request_json(url: str, params: dict[str, Any] | None = None, timeout: int = 
         "Accept-Language": "en-NZ,en;q=0.9",
         "Origin": BASE_WEB,
         "Referer": BASE_WEB + "/",
-        "User-Agent": UA,
     }
     try:
         body, _ct, final_url = nzfetch.fetch_bytes(url, headers=headers, timeout=timeout, accept="application/json, text/plain, */*")

--- a/skills/bookme-nz/scripts/cli.py
+++ b/skills/bookme-nz/scripts/cli.py
@@ -161,7 +161,6 @@ def request_json(path: str, params: dict[str, Any] | None = None, timeout: int =
     headers = {
         "Accept": "application/json, text/plain, */*",
         "Referer": BASE_WEB + "/",
-        "User-Agent": UA,
         "X-Requested-With": "XMLHttpRequest",
     }
     try:

--- a/skills/briscoes-nz/scripts/cli.py
+++ b/skills/briscoes-nz/scripts/cli.py
@@ -26,10 +26,6 @@ BASE_WEB = "https://www.briscoes.co.nz"
 GRAPHQL_URL = BASE_WEB + "/graphql"
 DEFAULT_KLEVU_HOST = "aucs34.ksearchnet.com"
 DEFAULT_KLEVU_API_KEY = "klevu-173190000117617559"
-UA = os.environ.get(
-    "BRISCOES_NZ_USER_AGENT",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
-)
 
 KLEVU_FIELDS = [
     "isDiscountPrice",
@@ -177,7 +173,6 @@ def request_json(url: str, payload: dict[str, Any], timeout: int = 25) -> Any:
         "Content-Type": "application/json",
         "Origin": BASE_WEB,
         "Referer": BASE_WEB + "/",
-        "User-Agent": UA,
     }
     try:
         raw_bytes, _ct, _final = nzfetch.fetch_bytes(url, data=data, method="POST", headers=headers, timeout=timeout, accept="application/json, text/plain, */*")

--- a/skills/chemistwarehouse-nz/scripts/cli.py
+++ b/skills/chemistwarehouse-nz/scripts/cli.py
@@ -28,7 +28,6 @@ BASE_API = "https://www.chemistwarehouse.co.nz/searchapiv2"
 BASE_WEB = "https://www.chemistwarehouse.co.nz"
 SOURCE = "chemistwarehouse-nz-searchapiv2"
 ROOT_LOCATION = "//catalog01/en_AU/categories<{catalog01_chemnz}"
-UA = os.environ.get("CHEMISTWAREHOUSE_NZ_USER_AGENT", "Mozilla/5.0")
 
 
 class HTMLText(HTMLParser):
@@ -61,12 +60,14 @@ def api_url(path: str, params: dict[str, Any]) -> str:
 def request_json(path: str, params: dict[str, Any], timeout: int = 25) -> tuple[Any, str]:
     url = api_url(path, params)
     headers = {
-        "User-Agent": UA,
         "Accept": "application/json,text/plain,*/*",
         "Referer": BASE_WEB + "/",
     }
     try:
-        body, _ct, _final = nzfetch.fetch_bytes(url, headers=headers, timeout=timeout, accept="application/json,text/plain,*/*")
+        # This searchapiv2 endpoint returns HTTP 500 when sent the full Chrome
+        # Client-Hint / Sec-Fetch-* header set; a lean request (browser_headers
+        # =False) returns real data. Let nzfetch own the UA but skip the hints.
+        body, _ct, _final = nzfetch.fetch_bytes(url, headers=headers, timeout=timeout, accept="application/json,text/plain,*/*", browser_headers=False)
         raw = body.decode("utf-8", "replace")
         return json.loads(raw), url
     except nzfetch.Blocked as e:

--- a/skills/christchurch-bin-schedule/scripts/cli.py
+++ b/skills/christchurch-bin-schedule/scripts/cli.py
@@ -19,7 +19,6 @@ from typing import Any
 ADDRESS_SUGGEST_URL = "https://opendata.ccc.govt.nz/CCCSearch/rest/address/suggest"
 COLLECTION_URL = "https://ccc.govt.nz/services/rubbish-and-recycling/collections/getProperty"
 MAIN_PAGE = "https://ccc.govt.nz/services/rubbish-and-recycling/collections/"
-UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/148.0.0.0 Safari/537.36"
 
 BIN_LABELS = {
     "Garbage": "Rubbish (red bin)",
@@ -34,7 +33,7 @@ def fetch_json(url: str, headers: dict[str, str] | None = None, timeout: int = 1
     try:
         return nzfetch.fetch_json(
             url,
-            headers={"User-Agent": UA, **(headers or {})},
+            headers=headers,
             timeout=timeout,
             context=ctx,
         )

--- a/skills/class4-grants-nz/scripts/cli.py
+++ b/skills/class4-grants-nz/scripts/cli.py
@@ -67,7 +67,7 @@ def request(url: str, timeout: int = 30):
 
 def fetch_json(url: str, timeout: int = 30) -> dict[str, Any]:
     try:
-        return nzfetch.fetch_json(url, timeout=timeout, headers={"User-Agent": UA}, accept="*/*")
+        return nzfetch.fetch_json(url, timeout=timeout, accept="*/*")
     except nzfetch.Blocked as e:
         die(f"network error calling {url}: {e}")
     except nzfetch.FetchError as e:
@@ -129,7 +129,7 @@ def clean_row(row: dict[str, str]) -> dict[str, Any]:
 def csv_rows(timeout: int = 90) -> Iterable[dict[str, str]]:
     try:
         body, _ct, _final = nzfetch.fetch_bytes(
-            GRANTS_CSV_URL, timeout=timeout, accept="*/*", headers={"User-Agent": UA}
+            GRANTS_CSV_URL, timeout=timeout, accept="*/*"
         )
     except nzfetch.Blocked as e:
         die(f"network error downloading grants CSV: {e}")

--- a/skills/companies-office-nz/scripts/cli.py
+++ b/skills/companies-office-nz/scripts/cli.py
@@ -32,11 +32,6 @@ BASE = "https://app.companiesoffice.govt.nz/companies/app"
 SVC = BASE + "/service/services"
 UI = BASE + "/ui/pages/companies"
 
-UA = os.environ.get(
-    "CO_USER_AGENT",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36",
-)
-
 # entityStatus integer → readable label (observed values only)
 STATUS_MAP = {
     10: "PRE-REGISTRATION",
@@ -63,7 +58,6 @@ def get_json(url: str, timeout: int = 25) -> Any:
             timeout=timeout,
             accept="application/json, text/html, */*",
             headers={
-                "User-Agent": UA,
                 "Referer": BASE + "/ui/pages/companies/search",
                 "X-Requested-With": "XMLHttpRequest",
             },
@@ -80,7 +74,6 @@ def get_html(url: str, timeout: int = 25) -> str:
             url,
             timeout=timeout,
             accept="text/html,*/*",
-            headers={"User-Agent": UA},
         )
     except nzfetch.Blocked as e:
         die(f"network error: {e}")

--- a/skills/deprivation-nz/scripts/cli.py
+++ b/skills/deprivation-nz/scripts/cli.py
@@ -32,7 +32,6 @@ SERVICE = (
 SA1_LAYER = SERVICE + "/0/query"
 SA2_LAYER = SERVICE + "/1/query"
 ITEM_PAGE = "https://www.arcgis.com/home/item.html?id=d0caefba5f8f42d6918fc52faacec00b"
-UA = "deprivation-nz-skill/1.0 (+https://github.com/thecolab-ai/.skills)"
 
 SA1_FIELDS = "SA12023_code,NZDep2023,NZDep2023_Score,URPopnSA1_2023,SA22023_name"
 SA2_FIELDS = (
@@ -59,7 +58,7 @@ def query(layer_url: str, params: dict[str, str], timeout: int = 45) -> dict[str
     url = layer_url + "?" + urllib.parse.urlencode(base, safe="=,'%")
     try:
         data = nzfetch.fetch_json(
-            url, timeout=timeout, headers={"User-Agent": UA}, accept="application/json"
+            url, timeout=timeout, accept="application/json"
         )
     except nzfetch.Blocked as e:
         die(f"network error calling feature service: {e}")

--- a/skills/doc-nz/scripts/cli.py
+++ b/skills/doc-nz/scripts/cli.py
@@ -26,10 +26,6 @@ BOOKING_API = "https://prod-nz-rdr.recreation-management.tylerapp.com/nzrdr/rdr/
 BOOKING_WEB = "https://bookings.doc.govt.nz/Web/"
 DOC_SITE = "https://www.doc.govt.nz"
 ALERTS_INDEX = DOC_SITE + "/parks-and-recreation/know-before-you-go/alerts/"
-UA = os.environ.get(
-    "DOC_NZ_USER_AGENT",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
-)
 
 
 def die(message: str, code: int = 1) -> None:
@@ -145,7 +141,6 @@ def booking_headers() -> dict[str, str]:
         "Accept": "application/json, text/plain, */*",
         "Origin": "https://bookings.doc.govt.nz",
         "Referer": BOOKING_WEB,
-        "User-Agent": UA,
     }
 
 
@@ -168,7 +163,7 @@ def request_booking_json(path: str, payload: dict[str, Any] | None = None, timeo
 
 def request_doc_json(path: str, timeout: int = 25) -> Any:
     url = DOC_SITE + "/api/" + path.lstrip("/")
-    headers = {"Accept": "application/json, text/plain, */*", "Referer": DOC_SITE + "/", "User-Agent": UA}
+    headers = {"Accept": "application/json, text/plain, */*", "Referer": DOC_SITE + "/"}
     try:
         return nzfetch.fetch_json(url, headers=headers, timeout=timeout)
     except nzfetch.Blocked as e:
@@ -178,7 +173,7 @@ def request_doc_json(path: str, timeout: int = 25) -> Any:
 
 
 def request_text(url: str, timeout: int = 25) -> tuple[str, str]:
-    headers = {"Accept": "text/html,application/xhtml+xml", "User-Agent": UA}
+    headers = {"Accept": "text/html,application/xhtml+xml"}
     try:
         body, _content_type, final_url = nzfetch.fetch_bytes(url, headers=headers, timeout=timeout, expect_json=False)
         return body.decode("utf-8", "replace"), final_url

--- a/skills/education-counts-nz/scripts/cli.py
+++ b/skills/education-counts-nz/scripts/cli.py
@@ -94,20 +94,12 @@ def request_headers(url: str) -> dict[str, str]:
         if is_asset
         else "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8"
     )
+    # Only semantic headers here; nzfetch owns the browser fingerprint
+    # (User-Agent, sec-ch-ua*, Sec-Fetch-*, Accept-Language, cache hints) as a
+    # consistent Chrome set — passing our own would contradict it.
     return {
-        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
         "Accept": accept,
-        "Accept-Language": "en-NZ,en;q=0.9",
-        "Cache-Control": "no-cache",
-        "Pragma": "no-cache",
-        "Upgrade-Insecure-Requests": "1",
         "Referer": f"{parsed.scheme}://{parsed.netloc}/",
-        "Sec-Fetch-Dest": "document" if not is_asset else "empty",
-        "Sec-Fetch-Mode": "navigate" if not is_asset else "cors",
-        "Sec-Fetch-Site": "same-origin",
-        "sec-ch-ua": '"Chromium";v="146", "Not A(Brand";v="24", "Google Chrome";v="146"',
-        "sec-ch-ua-mobile": "?0",
-        "sec-ch-ua-platform": '"macOS"',
     }
 
 

--- a/skills/first-table-nz/scripts/cli.py
+++ b/skills/first-table-nz/scripts/cli.py
@@ -23,7 +23,6 @@ import nzfetch  # noqa: E402
 
 SITE = "https://www.firsttable.co.nz"
 GRAPHQL_URL = "https://stellate.firsttable.net/graphql"
-USER_AGENT = "Mozilla/5.0 (compatible; thecolab-first-table-nz-skill/1.0)"
 DEFAULT_CITY = "auckland"
 DEFAULT_PEOPLE = 2
 
@@ -155,7 +154,7 @@ def die(message: str, code: int = 1) -> None:
 
 
 def http_json_or_text(url: str, *, data: bytes | None = None, headers: dict[str, str] | None = None) -> tuple[Any, str, int]:
-    req_headers = {"User-Agent": USER_AGENT, "Accept": "application/json,text/html;q=0.9,*/*;q=0.8"}
+    req_headers = {"Accept": "application/json,text/html;q=0.9,*/*;q=0.8"}
     if headers:
         req_headers.update(headers)
     # A POST carries a JSON GraphQL body and expects parsed JSON back (an HTML

--- a/skills/fyi-oia-nz/scripts/cli.py
+++ b/skills/fyi-oia-nz/scripts/cli.py
@@ -30,10 +30,6 @@ SEARCH_URLS = (
     BASE_URL + "/search",
 )
 
-USER_AGENT = os.environ.get(
-    "FYI_OIA_USER_AGENT",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
-)
 REQUEST_TIMEOUT_SECONDS = 30
 UA_HTTP_ACCEPT = "application/json, text/html, application/atom+xml, */*"
 BLOCK_MARKERS = (
@@ -98,7 +94,6 @@ def fetch_bytes(url: str, timeout: int = REQUEST_TIMEOUT_SECONDS) -> tuple[bytes
             url,
             timeout=timeout,
             accept=UA_HTTP_ACCEPT,
-            headers={"User-Agent": USER_AGENT},
         )
     except nzfetch.Blocked as exc:
         raise CliError(f"upstream_blocked: network error from {url}: {exc}", status="upstream_blocked")

--- a/skills/gaspy-nz/scripts/cli.py
+++ b/skills/gaspy-nz/scripts/cli.py
@@ -19,10 +19,6 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3] / "lib"))
 import nzfetch  # noqa: E402
 
 BASE_FEED = "https://gaspy-datamine-stats.firebaseio.com/.json"
-UA = os.environ.get(
-    "GASPY_NZ_USER_AGENT",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
-)
 
 FUEL_TYPES: dict[str, dict[str, str | None]] = {
     "1": {"fuel": "91", "label": "Unleaded 91", "unit": "c/L", "datamine_key": "91"},
@@ -47,7 +43,6 @@ def request_json(url: str = BASE_FEED, timeout: int = 20) -> Any:
     headers = {
         "Accept": "application/json",
         "Referer": "https://www.gaspy.nz/stats.html",
-        "User-Agent": UA,
     }
     try:
         return nzfetch.fetch_json(url, timeout=timeout, headers=headers)

--- a/skills/grocer-nz/scripts/cli.py
+++ b/skills/grocer-nz/scripts/cli.py
@@ -41,7 +41,7 @@ BASE = "https://assets-prod.grocer.nz/public"
 MEILI = "https://meilisearch.grocer.nz"
 MEILI_KEY = "7f58239330307ec585c86863f985ab83cbb9ce951a9601c66e158548fb632fd1"
 CACHE = pathlib.Path(os.environ.get("GROCER_NZ_CACHE", "~/.cache/grocer-nz")).expanduser()
-HEADERS = {"User-Agent": "Mozilla/5.0 (Hermes grocer.nz skill)", "Referer": "https://grocer.nz/"}
+HEADERS = {"Referer": "https://grocer.nz/"}
 MAX_LIMIT = 100
 
 

--- a/skills/homes-nz/scripts/cli.py
+++ b/skills/homes-nz/scripts/cli.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import argparse
 import json
 import math
-import os
 import pathlib
 import sys
 import time
@@ -22,10 +21,6 @@ import nzfetch  # noqa: E402
 BASE_WEB = "https://homes.co.nz"
 BASE_GATEWAY = "https://gateway.homes.co.nz"
 BASE_API = "https://api-gateway.homes.co.nz"
-UA = os.environ.get(
-    "HOMES_NZ_USER_AGENT",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
-)
 
 STATE_LABELS = {
     0: "for_sale",
@@ -63,7 +58,6 @@ def request_json(base: str, path: str, params: dict[str, Any] | None = None, tim
         "Accept": "application/json, text/plain, */*",
         "Origin": BASE_WEB,
         "Referer": BASE_WEB + "/",
-        "User-Agent": UA,
     }
     try:
         return nzfetch.fetch_json(url, timeout=timeout, headers=headers)

--- a/skills/nz-airports/scripts/cli.py
+++ b/skills/nz-airports/scripts/cli.py
@@ -27,11 +27,6 @@ except Exception:  # pragma: no cover - Python <3.9 fallback
     ZoneInfo = None  # type: ignore[assignment]
 
 
-UA = os.environ.get(
-    "NZ_AIRPORTS_USER_AGENT",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
-)
-ADSB_UA = "nz-airports-cli/1.0"
 ADSB_TIMEOUT_SECONDS = 6
 ADSB_MAX_AIRCRAFT = 250
 
@@ -97,7 +92,6 @@ def request_text(url: str, timeout: int = 25) -> str:
     accept = "text/html,application/xhtml+xml,application/xml;q=0.9,application/json;q=0.8,*/*;q=0.7"
     headers = {
         "Accept": accept,
-        "User-Agent": UA,
     }
     try:
         return nzfetch.fetch_text(url, timeout=timeout, headers=headers, accept=accept)
@@ -112,7 +106,6 @@ def request_json(url: str, timeout: int = 25) -> Any:
     headers = {
         "Accept": accept,
         "Referer": url.rsplit("/", 1)[0] + "/",
-        "User-Agent": UA,
     }
     try:
         body, _ct, _final = nzfetch.fetch_bytes(url, timeout=timeout, headers=headers, accept=accept)
@@ -142,7 +135,6 @@ def request_akl_fids_json(endpoint: str, params: dict[str, str], timeout: int = 
         "App-Version": AKL_FIDS_APP_VERSION,
         "Authorization": akl_fids_auth_header(),
         "Content-Type": "application/vnd.api+json",
-        "User-Agent": UA,
     }
     try:
         body, _ct, _final = nzfetch.fetch_bytes(url, timeout=timeout, headers=headers, accept=accept)
@@ -167,7 +159,6 @@ def request_adsb_aircraft(code: str) -> tuple[list[dict[str, Any]], str]:
     url = adsb_url(code)
     headers = {
         "Accept": "application/json",
-        "User-Agent": ADSB_UA,
     }
     try:
         body, _ct, _final = nzfetch.fetch_bytes(

--- a/skills/nz-angel-investment/scripts/cli.py
+++ b/skills/nz-angel-investment/scripts/cli.py
@@ -37,7 +37,6 @@ AANZ_DOWNLOAD_REST = AANZ_BASE + "/wp-json/wp/v2/dlm_download"
 DEFAULT_TIMEOUT = 10
 DEFAULT_LIMIT = 25
 MAX_LIMIT = 100
-UA = "nz-angel-investment-skill/1.0 (+https://github.com/thecolab-ai/.skills)"
 
 
 class UpstreamUnavailable(RuntimeError):
@@ -198,7 +197,6 @@ def limit_value(value: int) -> int:
 
 def fetch_bytes(url: str, timeout: int = DEFAULT_TIMEOUT) -> bytes:
     headers = {
-        "User-Agent": UA,
         "Accept": "application/json,text/html,application/xhtml+xml,application/xml,application/pdf,*/*;q=0.8",
         "Accept-Language": "en-NZ,en;q=0.9",
     }

--- a/skills/nz-buses/scripts/cli.py
+++ b/skills/nz-buses/scripts/cli.py
@@ -23,10 +23,6 @@ import nzfetch  # noqa: E402
 
 BASE_API = os.environ.get("METLINK_API_BASE", "https://api.opendata.metlink.org.nz/v1").rstrip("/")
 BASE_PORTAL = "https://opendata.metlink.org.nz/"
-UA = os.environ.get(
-    "NZ_BUSES_USER_AGENT",
-    "nz-buses-skill/1.0 (+https://opendata.metlink.org.nz/)",
-)
 
 # Metlink uses standard GTFS bus route_type=3 and extended school-bus
 # route_type=712. Rail (2), ferry (4), and cable car (5) are intentionally out
@@ -70,7 +66,6 @@ def request_json(path: str, params: dict[str, Any] | None = None, timeout: int =
         if clean:
             url += "?" + urllib.parse.urlencode(clean)
     headers = {
-        "User-Agent": UA,
         "x-api-key": api_key(),
     }
     try:

--- a/skills/nz-cinemas/scripts/cli.py
+++ b/skills/nz-cinemas/scripts/cli.py
@@ -28,11 +28,6 @@ except Exception:  # pragma: no cover - old Python fallback
     ZoneInfo = None  # type: ignore
 
 
-UA = os.environ.get(
-    "NZ_CINEMAS_USER_AGENT",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
-)
-
 EVENT_BASE = "https://www.eventcinemas.co.nz"
 RIALTO_BASE = "https://www.rialto.co.nz"
 HOYTS_API = "https://apim-aea.hoyts.co.nz/cinemaapi-nz-live/api"
@@ -70,7 +65,6 @@ def request_text(
         url += "?" + urllib.parse.urlencode(params, doseq=True)
     req_headers = {
         "Accept": "text/html,application/json;q=0.9,*/*;q=0.8",
-        "User-Agent": UA,
     }
     if headers:
         req_headers.update(headers)

--- a/skills/nz-comcom/scripts/cli.py
+++ b/skills/nz-comcom/scripts/cli.py
@@ -22,10 +22,6 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3] / "lib"))
 import nzfetch  # noqa: E402
 
 BASE = "https://www.comcom.govt.nz"
-UA = (
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
-    "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
-)
 DOC_EXT_RE = re.compile(r"\.(pdf|docx?|xlsx?|pptx?|csv)$", re.I)
 
 
@@ -38,7 +34,7 @@ def fetch(url: str, timeout: int = 20) -> str:
     try:
         return nzfetch.fetch_text(
             url, timeout=timeout, accept="text/html,*/*",
-            headers={"User-Agent": UA}, context=ctx,
+            context=ctx,
         )
     except nzfetch.Blocked as e:
         raise ApiError(f"network error contacting comcom.govt.nz: {e}") from e

--- a/skills/nz-council/scripts/cli.py
+++ b/skills/nz-council/scripts/cli.py
@@ -1338,7 +1338,6 @@ def fetch_text_result(
     # stay on urllib (localhost, never proxied).
     accept = "text/html,application/xhtml+xml,application/json"
     req_headers = {
-        "User-Agent": UA,
         "Accept": accept,
     }
     if headers:

--- a/skills/nz-ferries/scripts/cli.py
+++ b/skills/nz-ferries/scripts/cli.py
@@ -546,12 +546,15 @@ def request_text(url: str, *, referer: str | None = None, timeout: int = 25, ope
     if referer:
         headers["Referer"] = referer
     if opener is None:
+        # Let nzfetch own the User-Agent (its own browser UA); the opener cookie-jar
+        # path below keeps the skill UA it was primed with.
+        nz_headers = {k: v for k, v in headers.items() if k.lower() != "user-agent"}
         try:
             return nzfetch.fetch_text(
                 url,
                 timeout=timeout,
                 accept=headers["Accept"],
-                headers=headers,
+                headers=nz_headers,
                 browser_headers=False,
             )
         except nzfetch.Blocked as e:
@@ -612,7 +615,9 @@ def request_json(
             die(f"network error calling {url}: {e.reason}")
         except json.JSONDecodeError as e:
             die(f"invalid JSON from {url}: {e}")
-    extra_headers = {k: v for k, v in headers.items() if k.lower() != "accept"}
+    # Drop Accept (passed via accept=) and User-Agent (nzfetch owns the UA); the
+    # opener cookie-jar path above keeps the skill UA it was primed with.
+    extra_headers = {k: v for k, v in headers.items() if k.lower() not in ("accept", "user-agent")}
     try:
         raw_bytes, _ct, _final = nzfetch.fetch_bytes(
             url,
@@ -838,7 +843,7 @@ def at_request_json(path: str, *, timeout: int = 25) -> Any:
             url,
             timeout=timeout,
             accept="application/json",
-            headers={"Ocp-Apim-Subscription-Key": AT_API_KEY, "User-Agent": UA},
+            headers={"Ocp-Apim-Subscription-Key": AT_API_KEY},
         )
     except nzfetch.Blocked as e:
         die(f"network error calling {url}: {e}")

--- a/skills/nz-healthpoint/scripts/cli.py
+++ b/skills/nz-healthpoint/scripts/cli.py
@@ -29,10 +29,6 @@ except Exception:  # pragma: no cover - Python <3.9 fallback
 
 
 BASE = "https://www.healthpoint.co.nz"
-UA = os.environ.get(
-    "HEALTHPOINT_NZ_USER_AGENT",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
-)
 PAGE_SIZE = 40
 
 BRANCHES: list[dict[str, Any]] = [
@@ -180,7 +176,7 @@ def request_text(path_or_url: str, params: dict[str, Any] | None = None, timeout
             url,
             timeout=timeout,
             accept="text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-            headers={"User-Agent": UA, "Referer": BASE + "/"},
+            headers={"Referer": BASE + "/"},
         )
     except nzfetch.Blocked as e:
         die(f"network error: {e}")

--- a/skills/nz-libraries/scripts/cli.py
+++ b/skills/nz-libraries/scripts/cli.py
@@ -186,6 +186,9 @@ def request_text(url, *, headers=None, data=None, method=None, timeout=35, opene
     # Route the ordinary path through the shared nzfetch helper. The Accept header
     # drives nzfetch's JSON-vs-HTML challenge check, so hand it over as `accept=`.
     accept = req_headers.pop("Accept")
+    # Let nzfetch own the User-Agent (its own browser UA + matching Client-Hints);
+    # the opener cookie-jar path above keeps USER_AGENT for its urllib request.
+    req_headers.pop("User-Agent", None)
     try:
         return nzfetch.fetch_text(
             url, headers=req_headers, accept=accept, data=data, method=method, timeout=timeout

--- a/skills/nz-ministers/scripts/cli.py
+++ b/skills/nz-ministers/scripts/cli.py
@@ -34,11 +34,6 @@ import nzfetch  # noqa: E402
 
 BASE = "https://www.beehive.govt.nz"
 RSS_URL = f"{BASE}/rss.xml"
-DEFAULT_UA = os.environ.get(
-    "NZ_MINISTERS_USER_AGENT",
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
-    "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36",
-)
 CACHE_FILE = os.path.join(tempfile.gettempdir(), "nz-ministers-incap.json")
 CACHE_TTL_SECONDS = 300  # reuse browser-obtained Incapsula clearance (sessions are short-lived)
 ARTICLE_TYPES = ("release", "speech", "feature")
@@ -73,7 +68,7 @@ def is_incapsula(text: str) -> bool:
 def fetch_rss() -> str:
     """The root RSS feed is allowlisted and needs no clearance."""
     try:
-        text = _open(RSS_URL, {"User-Agent": DEFAULT_UA, "Accept": "application/rss+xml, application/xml, */*"})
+        text = _open(RSS_URL, {"Accept": "application/rss+xml, application/xml, */*"})
     except nzfetch.Blocked as e:
         raise ApiError("beehive RSS feed is temporarily blocked; try again shortly") from e
     except nzfetch.FetchError as e:

--- a/skills/nz-news/scripts/cli.py
+++ b/skills/nz-news/scripts/cli.py
@@ -19,7 +19,6 @@ from typing import Any
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3] / "lib"))
 import nzfetch  # noqa: E402
 
-UA = "nz-news-cli/1.0 (+https://github.com/thecolab-ai/.skills)"
 DEFAULT_TIMEOUT = 10
 
 # Feed definitions
@@ -214,7 +213,6 @@ def fetch_feed(feed: dict) -> dict:
             feed["url"],
             timeout=DEFAULT_TIMEOUT,
             accept="application/rss+xml,application/atom+xml,application/xml,text/xml,*/*",
-            headers={"User-Agent": UA},
         )
         duration_ms = round((time.monotonic() - start) * 1000)
         items = parse_atom_items(xml, feed) if feed.get("format") == "atom" else parse_rss_items(xml, feed)

--- a/skills/nz-parliament/scripts/cli.py
+++ b/skills/nz-parliament/scripts/cli.py
@@ -25,10 +25,6 @@ import nzfetch  # noqa: E402
 BASE = "https://bills.parliament.nz"
 SEARCH_URL = f"{BASE}/api/data/search"
 BILL_URL = f"{BASE}/api/data/Bill"
-UA = (
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
-    "(KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36"
-)
 GUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
 
 
@@ -39,7 +35,6 @@ class ApiError(RuntimeError):
 def _request(url: str, *, payload: dict[str, Any] | None = None, timeout: int = 15) -> Any:
     data = json.dumps(payload).encode("utf-8") if payload is not None else None
     headers = {
-        "User-Agent": UA,
         "Accept": "application/json",
         "Origin": BASE,
         "Referer": BASE + "/",

--- a/skills/nz-pricewatch/scripts/cli.py
+++ b/skills/nz-pricewatch/scripts/cli.py
@@ -22,10 +22,6 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3] / "lib"))
 import nzfetch  # noqa: E402
 
 BASE_WEB = "https://pricespy.co.nz"
-UA = (
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
-    "(KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36"
-)
 
 CATEGORY_ALIASES = {
     "tv": 107,
@@ -110,7 +106,6 @@ def request_text(path_or_url: str, params: dict[str, Any] | None = None, timeout
         "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
         "Accept-Language": "en-NZ,en;q=0.9",
         "Referer": BASE_WEB + "/",
-        "User-Agent": UA,
     }
     try:
         return nzfetch.fetch_text(

--- a/skills/nz-road-closures/scripts/cli.py
+++ b/skills/nz-road-closures/scripts/cli.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import pathlib
 import re
 import sys
@@ -20,10 +19,6 @@ import nzfetch  # noqa: E402
 JOURNEY_BASE = "https://www.journeys.nzta.govt.nz"
 DATA_BASE = JOURNEY_BASE + "/assets/map-data-cache"
 CAMERA_BASE = "https://www.trafficnz.info"
-UA = os.environ.get(
-    "NZ_ROAD_CLOSURES_USER_AGENT",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/147.0.0.0 Safari/537.36",
-)
 
 EVENT_TYPE_ALIASES = {
     "closure": {"closures"},
@@ -41,7 +36,6 @@ def fetch_json(filename: str, timeout: int = 30) -> Any:
     headers = {
         "Accept": "application/json",
         "Referer": JOURNEY_BASE + "/highway-conditions",
-        "User-Agent": UA,
     }
     try:
         return nzfetch.fetch_json(url, timeout=timeout, headers=headers)

--- a/skills/nz-tides-surf/scripts/cli.py
+++ b/skills/nz-tides-surf/scripts/cli.py
@@ -38,11 +38,6 @@ SWELLMAP_SURF_BASE = SWELLMAP_SITE + "/surf-forecasts/new-zealand"
 METOCEAN_DOCS = "https://developer.metservice.com/docs/api-catalog/point-forecast-api/"
 NIWA_SITE = "https://niwa.co.nz"
 
-UA = os.environ.get(
-    "NZ_TIDES_SURF_USER_AGENT",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
-)
-
 NZ_TZ = ZoneInfo("Pacific/Auckland") if ZoneInfo else timezone(timedelta(hours=12))
 
 
@@ -117,7 +112,7 @@ def die(message: str, code: int = 1) -> None:
 
 
 def request_text(url: str, *, accept: str = "text/html,application/xhtml+xml,*/*;q=0.7", timeout: int = 25) -> tuple[str, str]:
-    headers = {"Accept": accept, "User-Agent": UA}
+    headers = {"Accept": accept}
     if url.startswith(LINZ_SITE):
         headers["Referer"] = LINZ_SITE + "/products-services/tides-and-tidal-streams/tide-predictions"
     try:

--- a/skills/nz-trains/scripts/cli.py
+++ b/skills/nz-trains/scripts/cli.py
@@ -29,7 +29,6 @@ except Exception:  # pragma: no cover - old Python fallback
 
 
 BASE_API = "https://api.opendata.metlink.org.nz/v1"
-UA = os.environ.get("NZ_TRAINS_USER_AGENT", "thecolab-nz-trains-skill/1.0")
 NZ_TZ = ZoneInfo("Pacific/Auckland") if ZoneInfo else timezone.utc
 
 LINE_ORDER = ["JVL", "KPL", "HVL", "MEL", "WRL"]
@@ -102,7 +101,6 @@ def request_json(path: str, params: dict[str, Any] | None = None, timeout: int =
         url += "?" + urllib.parse.urlencode(clean)
     headers = {
         "Accept": "application/json",
-        "User-Agent": UA,
         "x-api-key": require_api_key(),
     }
     try:

--- a/skills/nz-tv-guide/scripts/cli.py
+++ b/skills/nz-tv-guide/scripts/cli.py
@@ -34,11 +34,6 @@ FREEVIEW_GUIDE = "https://freeviewnz.tv/whats-on/tv-guide/"
 NZ_TZ_NAME = "Pacific/Auckland"
 NZ = ZoneInfo(NZ_TZ_NAME) if ZoneInfo else timezone(timedelta(hours=12))
 
-UA = os.environ.get(
-    "NZ_TV_GUIDE_USER_AGENT",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
-)
-
 SKY_GROUPS = {
     "all": ("4b7LA20J4iHaThwky9iVqn", "All Channels"),
     "sport": ("5P95WEpsEA6TcDMOsPmV19", "Sports"),
@@ -214,7 +209,6 @@ def request_text(
         url += "?" + urllib.parse.urlencode(params, doseq=True)
     req_headers = {
         "Accept": "text/html,application/json;q=0.9,*/*;q=0.8",
-        "User-Agent": UA,
     }
     if headers:
         req_headers.update(headers)

--- a/skills/nzbn-register/scripts/cli.py
+++ b/skills/nzbn-register/scripts/cli.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import sys
 import time
@@ -21,10 +20,6 @@ import nzfetch  # noqa: E402
 
 BASE_WEB = "https://www.nzbn.govt.nz"
 PROXY = BASE_WEB + "/api/business/nzbn"
-UA = os.environ.get(
-    "NZBN_REGISTER_USER_AGENT",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36",
-)
 
 
 def die(message: str, code: int = 1) -> None:
@@ -38,7 +33,6 @@ def nzbn_path(uri: str, timeout: int = 25) -> Any:
     headers = {
         "Accept": "application/json, text/plain, */*",
         "Referer": BASE_WEB + "/mynzbn/search/",
-        "User-Agent": UA,
     }
     try:
         body, _ct, _final = nzfetch.fetch_bytes(

--- a/skills/nzpost/scripts/cli.py
+++ b/skills/nzpost/scripts/cli.py
@@ -31,7 +31,6 @@ API_PARCELS = "/parceltrack/parcels"
 LOCATIONS_API_BASE = "https://api.nzpost.co.nz/digital/postshop-locations/v2"
 ADDRESS_API = "https://tools.nzpost.co.nz/legacy/api/suggest"
 
-UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:151.0) Gecko/20100101 Firefox/151.0"
 REFERER = "https://www.nzpost.co.nz/tools/tracking"
 ADDRESS_REFERER = "https://www.nzpost.co.nz/tools/address-postcode-finder"
 
@@ -159,7 +158,6 @@ def fetch_tracking_multi(tracking_references: list[str], timeout: int = 15) -> d
     )
     url = f"{API_BASE}{API_PARCELS}?{params}"
     headers = {
-        "User-Agent": UA,
         "Referer": REFERER,
         "Content-Type": "application/json",
     }
@@ -200,7 +198,7 @@ def _geocode_via_keyword(query: str, timeout: int = 15) -> tuple[float, float] |
     """Try NZ Post locations KEYWORD API for geocoding. Returns (lat, lng) if found, else None."""
     params = urllib.parse.urlencode({"type": "KEYWORD", "value": query, "max": 1})
     url = f"{LOCATIONS_API_BASE}/locations?{params}"
-    headers = {"User-Agent": UA, "Referer": REFERER}
+    headers = {"Referer": REFERER}
     try:
         data = nzfetch.fetch_json(url, timeout=timeout, headers=headers)
     except Exception:
@@ -228,12 +226,15 @@ def _geocode_via_nominatim(query: str, timeout: int = 15) -> tuple[float, float]
         "limit": 1,
     })
     url = f"{NOMINATIM_URL}?{params}"
+    # Nominatim's ToS REQUIRES an identifying contact User-Agent, so keep the
+    # custom UA here and pass browser_headers=False so nzfetch doesn't add
+    # contradictory Chrome Client-Hints on top of it.
     headers = {
         "User-Agent": NOMINATIM_UA,
         "Accept-Language": "en",
     }
     try:
-        results = nzfetch.fetch_json(url, timeout=timeout, headers=headers)
+        results = nzfetch.fetch_json(url, timeout=timeout, headers=headers, browser_headers=False)
     except Exception:
         return None
 
@@ -262,7 +263,7 @@ def fetch_locations_by_coords(lat: float, lng: float, max_results: int = 10, tim
     value = json.dumps({"latitude": lat, "longitude": lng})
     params = urllib.parse.urlencode({"type": "NEARBY", "value": value, "max": max_results})
     url = f"{LOCATIONS_API_BASE}/locations?{params}"
-    headers = {"User-Agent": UA, "Referer": REFERER}
+    headers = {"Referer": REFERER}
     raw = _http_get(url, headers, timeout)
     try:
         data = json.loads(raw)
@@ -275,7 +276,7 @@ def fetch_locations_by_keyword(keyword: str, max_results: int = 10, timeout: int
     """Fetch NZ Post locations by keyword. Returns list of location dicts."""
     params = urllib.parse.urlencode({"type": "KEYWORD", "value": keyword, "max": max_results})
     url = f"{LOCATIONS_API_BASE}/locations?{params}"
-    headers = {"User-Agent": UA, "Referer": REFERER}
+    headers = {"Referer": REFERER}
     raw = _http_get(url, headers, timeout)
     try:
         data = json.loads(raw)
@@ -332,7 +333,6 @@ def fetch_addresses(query: str, limit: int = 10, timeout: int = 15) -> list[dict
     params = urllib.parse.urlencode({"q": query, "max": limit})
     url = f"{ADDRESS_API}?{params}"
     headers = {
-        "User-Agent": UA,
         "Referer": ADDRESS_REFERER,
         "Accept": "application/json",
     }

--- a/skills/nzta-crash-data-nz/scripts/cli.py
+++ b/skills/nzta-crash-data-nz/scripts/cli.py
@@ -38,7 +38,6 @@ CSV_URL = (
     "8d684f1841fa4dbea6afaefc8a1ba0fc/csv?layers=0"
 )
 
-UA = "nzta-crash-data-nz-skill/1.0 (+https://github.com/thecolab-ai/.skills)"
 TIMEOUT = 10
 PAGE_SIZE = 2000
 DEFAULT_LIMIT = 50
@@ -164,7 +163,7 @@ def request_json(
 ) -> dict[str, Any]:
     target = url
     data = None
-    headers = {"User-Agent": UA, "Accept": "application/json"}
+    headers = {"Accept": "application/json"}
     if params:
         encoded = urllib.parse.urlencode(params).encode("utf-8")
         if method == "POST":
@@ -189,7 +188,7 @@ def request_json(
 def request_csv_rows(scan_cap: int) -> tuple[list[dict[str, str]], bool]:
     try:
         body, _ct, _final = nzfetch.fetch_bytes(
-            CSV_URL, timeout=TIMEOUT, accept="text/csv", headers={"User-Agent": UA}
+            CSV_URL, timeout=TIMEOUT, accept="text/csv"
         )
     except nzfetch.Blocked as exc:
         raise DataError(f"network error downloading CKAN/ArcGIS CSV mirror: {exc}") from exc

--- a/skills/nzx/scripts/cli.py
+++ b/skills/nzx/scripts/cli.py
@@ -29,7 +29,6 @@ except Exception:
 TICKER_BASE = "https://api.nzx.com/ticker/1.0"
 PUBLIC_BASE = "https://api.nzx.com/public"
 NZX_WEB = "https://www.nzx.com"
-UA = "nzx-skill/1.0 (+https://github.com/thecolab-ai/.skills)"
 DELAY_NOTE = "NZX market data is delayed by 20 minutes and may be cached."
 
 INDEX_ALIASES = {
@@ -55,7 +54,6 @@ def die(message: str, code: int = 1) -> None:
 def request_json(url: str, timeout: int = 20) -> Any:
     headers = {
         "Accept": "application/json, text/plain, */*",
-        "User-Agent": UA,
         "Referer": NZX_WEB + "/",
     }
     try:

--- a/skills/osm-nz/scripts/cli.py
+++ b/skills/osm-nz/scripts/cli.py
@@ -210,6 +210,9 @@ def fetch_overpass(query: str) -> Any:
     """POST an Overpass QL query and return parsed JSON."""
     data = urllib.parse.urlencode({"data": query}).encode("ascii")
     try:
+        # The Overpass API usage policy asks for an identifying User-Agent, so
+        # keep the custom UA and pass browser_headers=False so nzfetch doesn't
+        # add contradictory Chrome Client-Hints on top of it.
         return nzfetch.fetch_json(
             OVERPASS_URL,
             data=data,
@@ -220,6 +223,7 @@ def fetch_overpass(query: str) -> Any:
                 "User-Agent": UA,
                 "Accept": "application/json",
             },
+            browser_headers=False,
         )
     except nzfetch.Blocked as e:
         die(f"network error calling Overpass: {e}")

--- a/skills/paknsave-nz/scripts/cli.py
+++ b/skills/paknsave-nz/scripts/cli.py
@@ -44,7 +44,6 @@ def money(cents: Any) -> str:
 def request_json(method: str, url: str, data: Any = None, token: str | None = None, timeout: int = 30) -> Any:
     body = None
     headers = {
-        "User-Agent": UA,
         "Accept": "application/json, text/plain, */*",
         "Origin": BASE_WEB,
         "Referer": BASE_WEB + "/",

--- a/skills/pbtech-nz/scripts/cli.py
+++ b/skills/pbtech-nz/scripts/cli.py
@@ -6,15 +6,11 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3] / "lib"))
 import nzfetch  # noqa: E402
 from html.parser import HTMLParser
 BASE='https://www.pbtech.co.nz'
+# Only semantic headers; nzfetch owns the browser fingerprint (User-Agent,
+# sec-ch-ua*, Sec-Fetch-*, Accept-Language) as one consistent Chrome set.
 HEADERS={
- 'User-Agent':'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36',
  'Accept':'text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8',
- 'Accept-Language':'en-US,en;q=0.9',
  'Referer':'https://www.pbtech.co.nz/',
- 'Sec-Fetch-Dest':'document','Sec-Fetch-Mode':'navigate','Sec-Fetch-Site':'same-origin','Sec-Fetch-User':'?1',
- 'Upgrade-Insecure-Requests':'1',
- 'sec-ch-ua':'"Chromium";v="146", "Not-A.Brand";v="24", "Google Chrome";v="146"',
- 'sec-ch-ua-mobile':'?0','sec-ch-ua-platform':'"Windows"'
 }
 def die(m,c=1): print(f'pbtech-nz: {m}',file=sys.stderr); raise SystemExit(c)
 def fetch(url):

--- a/skills/rbnz-data/scripts/cli.py
+++ b/skills/rbnz-data/scripts/cli.py
@@ -11,17 +11,11 @@ CHARTS={
  'twi':'{39B96144-129C-4D86-AEA9-DAB75CDE26F4}',
  'retail-rates':'{9E689530-C72C-493C-B41C-C9750BDD2C69}',
 }
+# Only semantic headers; nzfetch owns the browser fingerprint (User-Agent,
+# sec-ch-ua*, Sec-Fetch-*, Accept-Language) as one consistent Chrome set.
 BROWSER_HEADERS={
- 'User-Agent':'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36',
  'Accept':'application/json, text/plain, application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, */*',
- 'Accept-Language':'en-US,en;q=0.9',
  'Referer':'https://www.rbnz.govt.nz/statistics',
- 'Sec-Fetch-Dest':'empty',
- 'Sec-Fetch-Mode':'cors',
- 'Sec-Fetch-Site':'same-origin',
- 'sec-ch-ua':'"Chromium";v="146", "Not-A.Brand";v="24", "Google Chrome";v="146"',
- 'sec-ch-ua-mobile':'?0',
- 'sec-ch-ua-platform':'"Windows"',
 }
 def die(m,c=1): print(f'rbnz-data: {m}',file=sys.stderr); raise SystemExit(c)
 def http_text(url, headers=None, timeout=30):
@@ -36,7 +30,7 @@ def http_bytes(url, timeout=60):
  except nzfetch.FetchError as e: die(str(e))
 def get(action, params):
  url=BASE+action+'?'+urllib.parse.urlencode({k:v for k,v in params.items() if v is not None})
- data=json.loads(http_text(url, {'User-Agent':BROWSER_HEADERS['User-Agent'],'Accept':'application/json'}))
+ data=json.loads(http_text(url, {'Accept':'application/json'}))
  if not data.get('success'): die(f'API returned success=false: {data.get("error")}')
  return data['result'],url
 def norm_pkg(p):

--- a/skills/seek-co-nz/scripts/cli.py
+++ b/skills/seek-co-nz/scripts/cli.py
@@ -33,10 +33,11 @@ def die(message: str, code: int = 1) -> NoReturn:
 
 
 def fetch_text(url: str, *, timeout: int = 30) -> tuple[str, str]:
+    # nzfetch owns the browser fingerprint (User-Agent, sec-ch-ua*, Sec-Fetch-*,
+    # Accept-Language, Upgrade-Insecure-Requests) as one consistent Chrome set;
+    # only the semantic Referer is ours.
     headers = {
-        "Accept-Language": "en-NZ,en;q=0.9",
         "Referer": "https://www.seek.co.nz/",
-        "Upgrade-Insecure-Requests": "1",
     }
     try:
         body, _ct, final_url = nzfetch.fetch_bytes(


### PR DESCRIPTION
Follow-up to #164/#168. Addresses two maintainer observations: (1) lots of skills still hard-code a User-Agent, and (2) nzfetch should own the fingerprint but stay override-capable — *default to nzfetch where it works*.

## The problem
A skill that passed `headers={"User-Agent": "<skill>/1.0"}` (or its own `sec-ch-ua`) into an nzfetch call sent a **non-browser / stale identity wearing nzfetch's Chrome Client-Hints** — a self-contradicting fingerprint that makes bot detection *more* likely, the opposite of what the migration intended. Proven:

```
User-Agent : stats-nz-skill/1.0
sec-ch-ua  : "...Google Chrome";v="125"   ← contradiction
```

## nzfetch
- **Real current Chrome (149)** captured from DevTools: UA + `sec-ch-ua` synced via one `CHROME_VERSION` constant (a version mismatch is itself a tell), exact GREASE token `"Not)A;Brand";v="24"`, the `Priority` hint (`u=0,i` nav / `u=1,i` fetch), `Accept-Language: en-GB,en-US;q=0.9,en`.
- **Fix a real crash:** the proxy path passed `context=` to `OpenerDirector.open()`, which rejects it (`TypeError`) — every custom-SSL skill crashed once the direct attempt was blocked and it fell to the proxy. Now the SSL context is baked into the opener's `HTTPSHandler`; `context=` only goes to the direct `urlopen`. (education-counts-nz went 3-FAIL → PASS/PASS.)
- **Documented contract:** nzfetch owns the fingerprint by default; pass `headers=` only for *semantic* headers (API keys, auth, Referer, Content-Type). Stays fully override-capable — `NZFETCH_UA`, `headers=` wins, `browser_headers=False`.

## Skills (~43)
Remove the per-skill `User-Agent` override from nzfetch calls so each inherits the one consistent fingerprint; 4 skills also drop contradicting `sec-ch-ua`/`Sec-Fetch` hints (education-counts, pbtech, rbnz, seek-co).

**Exceptions kept — each justified and tested:** cookie-jar / CDP-localhost / raw-urllib paths (not nzfetch calls); Nominatim + Overpass contact-UA required by ToS (kept with `browser_headers=False`); cookie-bound Incapsula-clearance UAs. Where removing the UA regressed a fetch (chemistwarehouse HTTP 500 on the full client-hints), kept `browser_headers=False` so nzfetch still owns the UA without the contradicting hints.

## Verification
Every edited skill: `py_compile`, `validate [OK]`, smoke unchanged, and the proxied subcommand returns the same real data (or same clean SKIP) as before. A full **with/without-proxy** suite across all skills is finishing now; no modified skill has regressed (the only FAILs are unmodified pre-existing retail sites bunnings/carjam that block every IP).

Secret handling unchanged: proxy URL read only from `$FETCH_PROXY`/`$HTTPS_PROXY` env — nothing hard-coded/printed/committed.