### PR TITLE
feat(nz-electricity): energy-margin points AI to official alternatives when exact split is unavailable

### DIFF
--- a/skills/nz-electricity/SKILL.md
+++ b/skills/nz-electricity/SKILL.md
@@ -37,7 +37,7 @@ This skill ships support for:
 - Retail plan comparison, tariff advice, Powerswitch-style savings, or ICP-specific billing questions
 - Authenticated EMI API products, EM6 paid feeds, private user data, or account actions
 - Current real-time node load, current node generation, or current generation mix; the documented EM6 endpoints for those returned unauthorized in live testing
-- Reconstructing gentailer energy margins from spot prices, generation volumes, hedge positions, or retail demand; the `energy-margin` command reports official source availability only until a public official dataset exists
+- Reconstructing gentailer energy margins from spot prices, generation volumes, hedge positions, or retail demand; the `energy-margin` command reports official source availability and points to official alternatives, but does not derive the per-company split
 - ICP-specific outage status, outage subscriptions, outage reporting, or fault logging
 - Redistributing public-data extracts as a standalone dataset
 
@@ -72,7 +72,7 @@ python3 skills/nz-electricity/scripts/cli.py <command> [flags]
 - `dg-trends [--fuel solar_all] [--market-segment All|Res|SME|Com|Ind] [--capacity All_Total|Small|Large] [--region-type NZ|ZONE|...] [--from DATE] [--to DATE] [--json]` — EMI GUEHMT installed distributed-generation trends
 - `dg-latest [--fuel solar_all] [--market-segment All|Res|SME|Com|Ind] [--capacity All_Total|Small|Large] [--region-type NZ|ZONE|...] [--json]` — latest GUEHMT distributed-generation rows
 - `dg-summary [--fuel solar_all] [--market-segment All|Res|SME|Com|Ind] [--capacity All_Total|Small|Large] [--region-type NZ|ZONE|...] [--from DATE] [--to DATE] [--yearly] [--json]` — summarise GUEHMT distributed-generation trends
-- `energy-margin [--company COMPANY] [--from DATE] [--to DATE] [--json]` — probe the official EA gentailer energy-margin dashboard/article and report whether machine-readable rows are currently available
+- `energy-margin [--company COMPANY] [--from DATE] [--to DATE] [--json]` — probe the official EA gentailer energy-margin source; when the exact per-company split is not machine-retrievable, return guidance plus the official alternatives (EA per-company net profit, gentailer segment financials, retail gross margin, the aggregate figure, and the post-5-Jul-2026 feed)
 - `outages [--company COMPANY] [--region REGION] [--all] [--json]` — current public outage records from supported NZ lines companies; `--all` also includes planned, scheduled, or recent records where feeds expose them
 
 Examples:
@@ -104,7 +104,7 @@ python3 skills/nz-electricity/scripts/cli.py outages --region tahawai --json
 - `demand` uses the public Electricity Authority EMI Demand trends CSV report from `https://www.emi.ea.govt.nz/Wholesale/Reports/W_GD_C`
 - `prices` and `generation` use public Electricity Authority EMI CSV dataset files from `https://www.emi.ea.govt.nz`
 - `dg-trends`, `dg-latest`, and `dg-summary` use the public Electricity Authority EMI GUEHMT retail CSV report from `https://www.emi.ea.govt.nz/Retail/Reports/guehmt`
-- `energy-margin` probes the Electricity Authority energy-margin dashboard/article and linked Tableau public workbook; it returns explicit source-unavailable status while those public official surfaces do not expose machine-readable per-company rows
+- `energy-margin` probes the Electricity Authority energy-margin dashboard/article and linked Tableau public workbook; it returns explicit source-unavailable status while those public official surfaces do not expose machine-readable per-company rows, and points to official alternatives (per-company net profit and segment financials, retail gross margin, the EA aggregate, and the aggregate-only feed due from 5 July 2026) so a caller is not left empty-handed
 - `outages` uses clean public distributor feeds for Vector, Wellington Electricity, Orion, Powerco, Aurora Energy, WEL Networks, Unison, Counties Energy, and Top Energy
 - Vector's public map exposes outage shapes only, so Vector records may only have an approximate centroid and outage type
 - Northpower was checked but not shipped because its outage map uses Livewire snapshot/update state rather than a clean stable public JSON feed
@@ -113,7 +113,7 @@ python3 skills/nz-electricity/scripts/cli.py outages --region tahawai --json
 - EMI final/interim energy prices are half-hourly by point of connection; recent files may be interim until finalized
 - EMI generation output by plant is monthly and historical, not current real-time generation mix
 - EMI distributed-generation trends are monthly retail report data derived from registry fields; market segments are not mutually exclusive, and Solar+Batteries category changes in November 2023 can create Solar/Other series breaks
-- Gentailer energy-margin values are not reconstructed or copied into this skill; use the `energy-margin` status payload to show whether the official Authority surface is currently machine-readable
+- Gentailer energy-margin values are not reconstructed or copied into this skill; the exact per-company split existed only in an EA Tableau dashboard that has been removed (and was never archived), and the collection resuming 5 July 2026 publishes aggregated monthly data only. The `energy-margin` payload's `guidance`, `aggregate_energy_margin`, and `alternatives` fields point callers at the official per-company sources that do exist (net profit, segment financials, retail gross margin)
 - Distributor outage feeds vary by company and may omit cause, customer count, or restoration time
 - Default output is human-readable; every data command supports `--json` for chaining into other tools
 - Avoid high-volume polling; use narrow regions, nodes, date ranges, and months

--- a/skills/nz-electricity/scripts/cli.py
+++ b/skills/nz-electricity/scripts/cli.py
@@ -41,6 +41,96 @@ TABLEAU_ENERGY_MARGIN_VIZQL = (
     "https://public.tableau.com/vizql/w/Energymargin/v/Energymargin/startSession/viewing"
     "?%3AshowVizHome=no&%3Aembed=y&%3Adisplay_count=n&%3Aorigin=viz_share_link&%3Aredirect=auth"
 )
+EA_ENERGY_MARGIN_PROJECT = "https://www.ea.govt.nz/projects/all/energy-margin-information/"
+
+# When the exact per-company split cannot be fetched, point the caller at the
+# official surfaces that DO carry per-company or aggregate data. These were
+# confirmed reachable on 2026-07-09; see issue #172 for the full source hunt.
+ENERGY_MARGIN_GUIDANCE = (
+    "The exact official per-company energy-margin dollars for July-December 2024 are not "
+    "machine-retrievable: they existed only in an interactive Tableau dashboard that the "
+    "Electricity Authority has since removed (it was never archived), and the ongoing collection "
+    "from 5 July 2026 (clause 2.16 of the Code) publishes AGGREGATED, averaged monthly data only, "
+    "never a per-company split. Do not reconstruct the split from prices and volumes and present it "
+    "as the EA figure, and do not treat third-party preserved chart copies as an official source. "
+    "For per-company detail, use the official alternatives below (different but related metrics)."
+)
+
+# Official EA aggregate the Authority published in durable form (article text).
+ENERGY_MARGIN_AGGREGATE = {
+    "metric": "energy margin, all gentailers combined",
+    "period": "2024-07 to 2024-12",
+    "scope": "Contact, Genesis, Mercury, Meridian, Manawa, Nova (combined; not split by company)",
+    "weekly_range_million_nzd": [60, 95],
+    "weekly_average_million_nzd": 76,
+    "source": "Electricity Authority, 'Gentailer energy margins in 2024'",
+    "source_url": EA_ENERGY_MARGIN_ARTICLE,
+}
+
+# Reference values and pointers that ARE official and per-company. Figures are the
+# EA's own published values (article text) — included to point callers at the right
+# metric/source, not as a substitute for the removed per-company energy-margin split.
+ENERGY_MARGIN_ALTERNATIVES = [
+    {
+        "what": "EA per-company net profit (weekly average, Jul-Dec 2024)",
+        "metric": "net profit (not energy margin)",
+        "reference_values_million_nzd": {
+            "Meridian": -4.65,
+            "Genesis": 3.6,
+            "Mercury": -2.58,
+            "Contact": 5.46,
+        },
+        "note": (
+            "Official EA-published per-company figures. Net profit, not energy margin, and covers "
+            "only the four listed gentailers (not Manawa/Nova). Closest official per-company number."
+        ),
+        "source_url": EA_ENERGY_MARGIN_ARTICLE,
+    },
+    {
+        "what": "Gentailer interim/annual reports (segment financials)",
+        "metric": "segment EBITDAF, generation volumes, wholesale/retail revenue",
+        "note": (
+            "Auditable per-company financials the EA links to directly. Different framing from the "
+            "EA energy margin, but the underlying official source of company profitability."
+        ),
+        "source_urls": {
+            "Genesis": "https://media.genesisenergy.co.nz/genesis/investor/2025/fy25_genesis_interim_report.pdf",
+            "Mercury": "https://www.mercury.co.nz/-/media/project/mercury/mercury/pdfs-other/investor-relations/2025/mercury_interim_report_2025.pdf",
+            "Meridian": "https://www.meridianenergy.co.nz/public/Investors/Reports-and-presentations/Interim-results-and-reports/2025/Media-Announcement.pdf",
+            "Contact": "https://contact.co.nz/aboutus/investor-centre/reports-and-presentations",
+        },
+    },
+    {
+        "what": "EA retail gross margin dashboard + NZIER retail-margin disclosure",
+        "metric": "retail gross margin (retail side, not generation-side energy margin)",
+        "note": "Per-company retail margins; complements the generation-side energy margin.",
+        "source_urls": {
+            "EA retail gross margin": "https://www.ea.govt.nz/data-and-insights/charts-and-dashboards/retail-gross-margin/",
+            "NZIER report (June 2024)": "https://www.nzier.org.nz/hubfs/Public%20Publications/Client%20reports/Gentailer%20retail%20margin%20disclosure%20report%20June%202024.pdf",
+        },
+    },
+    {
+        "what": "Future EA aggregate energy-margin release (from 5 July 2026)",
+        "metric": "aggregated, averaged energy margin, monthly",
+        "note": (
+            "New clause 2.16 collection. Machine-readable once published, but aggregate-only — it will "
+            "not restore the per-company split. Wire it in here when it goes live."
+        ),
+        "source_url": EA_ENERGY_MARGIN_PROJECT,
+    },
+    {
+        "what": "EA datasets & tools/APIs hubs (raw wholesale data)",
+        "metric": "generation output, dispatch/final energy prices (inputs, not margins)",
+        "note": (
+            "Use the skill's own 'generation' and 'prices' commands, or these hubs, only if you must "
+            "derive an estimate — label any derivation clearly as unofficial."
+        ),
+        "source_urls": {
+            "Datasets": "https://www.ea.govt.nz/data-and-insights/datasets/",
+            "Tools & APIs": "https://www.ea.govt.nz/data-and-insights/tools-and-apis/",
+        },
+    },
+]
 UA = "nz-electricity-skill/1.0 (+https://github.com/thecolab-ai/.skills)"
 
 REGION_ALIASES = {
@@ -1809,6 +1899,16 @@ def cmd_energy_margin(args: argparse.Namespace) -> None:
         if unavailable
         else "The official Tableau workbook did not yield machine-readable per-company rows from this probe."
     )
+    alternatives = ENERGY_MARGIN_ALTERNATIVES
+    if company_filter:
+        # Keep only alternatives that cover the requested company (all cover it except
+        # the four-company net-profit list, which omits Manawa/Nova).
+        alternatives = [
+            alt
+            for alt in alternatives
+            if "reference_values_million_nzd" not in alt
+            or company_filter in alt["reference_values_million_nzd"]
+        ]
     data = {
         "source": "Electricity Authority gentailer energy margin dashboard/article",
         "source_url": EA_ENERGY_MARGIN_DASHBOARD,
@@ -1821,10 +1921,14 @@ def cmd_energy_margin(args: argparse.Namespace) -> None:
         "to": to_date,
         "count": 0,
         "energy_margins": [],
+        "guidance": ENERGY_MARGIN_GUIDANCE,
+        "aggregate_energy_margin": ENERGY_MARGIN_AGGREGATE,
+        "alternatives": alternatives,
         "source_checks": checks,
         "caveats": [
             "This command does not reconstruct margins from prices and generation volumes.",
             "This command does not ship copied chart values or third-party preserved data.",
+            "The per-company energy-margin split is not officially machine-retrievable; use 'alternatives' for related official per-company data.",
             "When the Authority publishes an official CSV/API feed, wire that feed here before returning rows.",
         ],
         "elapsed_ms": round((time.perf_counter() - started) * 1000),
@@ -2090,6 +2194,31 @@ def render_energy_margin(data: dict[str, Any]) -> str:
             )
     else:
         lines.append(data.get("reason") or "No official energy-margin rows returned.")
+        if data.get("guidance"):
+            lines.append("")
+            lines.append(data["guidance"])
+        agg = data.get("aggregate_energy_margin") or {}
+        if agg:
+            lo, hi = (agg.get("weekly_range_million_nzd") or [None, None])[:2]
+            lines.append("")
+            lines.append(
+                f"Official EA aggregate ({agg.get('period')}): ${lo}-{hi}m/week, "
+                f"avg ${agg.get('weekly_average_million_nzd')}m across all gentailers combined."
+            )
+        alternatives = data.get("alternatives") or []
+        if alternatives:
+            lines.append("")
+            lines.append("Where to get official per-company data instead:")
+            for alt in alternatives:
+                lines.append(f"- {alt.get('what')} ({alt.get('metric')})")
+                refs = alt.get("reference_values_million_nzd") or {}
+                for company, value in refs.items():
+                    sign = "-" if value < 0 else ""
+                    lines.append(f"    {company}: {sign}${abs(value)}m")
+                if alt.get("source_url"):
+                    lines.append(f"    {alt['source_url']}")
+                for label, url in (alt.get("source_urls") or {}).items():
+                    lines.append(f"    {label}: {url}")
         lines.append("")
         lines.append("Checked official surfaces:")
         for check in data.get("source_checks") or []:

--- a/skills/nz-electricity/scripts/smoke_test.py
+++ b/skills/nz-electricity/scripts/smoke_test.py
@@ -177,10 +177,43 @@ def test_energy_margin_status():
         print(f"  stdout: {result.stdout[:200]}")
         print("  Expected no copied or derived margin rows while the official feed is unavailable")
         return False
+    if not data.get("guidance"):
+        print("  Expected guidance text pointing at official alternatives")
+        return False
+    alternatives = data.get("alternatives")
+    if not isinstance(alternatives, list) or not alternatives:
+        print("  Expected non-empty alternatives[] to point AI at official per-company sources")
+        return False
+    if not all(alt.get("source_url") or alt.get("source_urls") for alt in alternatives):
+        print("  Expected every alternative to carry a source URL")
+        return False
+    if not (data.get("aggregate_energy_margin") or {}).get("weekly_average_million_nzd"):
+        print("  Expected official aggregate energy-margin reference")
+        return False
     return True
 
 
 results.append(test("energy-margin reports official source status", test_energy_margin_status))
+
+
+def test_energy_margin_company_filters_alternatives():
+    # Nova is not in the four-company EA net-profit list, so that alternative must drop out.
+    result = run(["energy-margin", "--company", "nova", "--timeout", "5", "--json"])
+    if result.returncode != 0:
+        print(f"  stderr: {result.stderr[:200]}")
+        return False
+    data = json.loads(result.stdout)
+    for alt in data.get("alternatives") or []:
+        refs = alt.get("reference_values_million_nzd") or {}
+        if refs and "Nova" not in refs:
+            print("  Expected net-profit alternative (no Nova) to be filtered out for --company nova")
+            return False
+    return True
+
+
+results.append(
+    test("energy-margin filters alternatives by company", test_energy_margin_company_filters_alternatives)
+)
 
 
 def test_energy_margin_rejects_unknown_company():


### PR DESCRIPTION
## What & why

Follow-up to #172. The `energy-margin` command previously just reported `source_unavailable` and left the caller with nothing. Research (recorded on #172) confirmed the exact **per-company gentailer energy-margin split (Jul–Dec 2024)** is genuinely not machine-retrievable — it lived only in an EA Tableau dashboard that has been removed and was never archived, and the collection resuming **5 July 2026** (clause 2.16 of the Code) publishes **aggregated monthly** data only, never a per-company split.

So instead of dead-ending, the command now **points the AI in the right direction**.

## What changed

When no exact rows are available, the payload now also carries:

- **`guidance`** — why the split isn't retrievable, plus explicit "don'ts" (no prices×volumes reconstruction passed off as the EA figure; no third-party chart copies as an official source).
- **`aggregate_energy_margin`** — the EA's official durable figure ($60–95m/week, avg $76m, all gentailers combined).
- **`alternatives`** — five official routes to per-company data, each with metric, note, and verified source URLs:
  1. EA per-company **net profit** (with figures: Meridian −$4.65m, Genesis $3.6m, Mercury −$2.58m, Contact $5.46m)
  2. Gentailer **interim/annual reports** (segment EBITDAF)
  3. EA **retail gross margin** + NZIER report
  4. The **future aggregate feed** (from 5 Jul 2026)
  5. EA **datasets/APIs** hubs (raw inputs, derivation-only)

`--company` filters the alternatives (e.g. `nova` drops the four-company net-profit list). Both `--json` and human-readable output updated. Still a **pointer, not a fetcher** — no reconstructed or copied rows are emitted.

## Verification

- `python3 scripts/validate_skill.py skills/nz-electricity --strict` — clean
- Smoke tests: all pass, including two new assertions (guidance/alternatives present with URLs; `--company` filtering)
- Ran both output modes by hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)