### PR TITLE
nz-university-experts: search NZ university expert directories

### DIFF
--- a/skills/nz-university-experts/SKILL.md
+++ b/skills/nz-university-experts/SKILL.md
@@ -52,6 +52,9 @@ Run via `python3 scripts/cli.py <command>`:
 
 - University of Auckland: `https://profiles.auckland.ac.nz/api/users` (public JSON
   search). Keyless, read-only.
+- Massey University: public Solr expert search (`.../profiles_solr_native.cfc`).
+  Keyless. Its records include email/phone; this skill **deliberately drops** those
+  and emits expertise only.
 
 ## Notes
 

--- a/skills/nz-university-experts/SKILL.md
+++ b/skills/nz-university-experts/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: nz-university-experts
+description: Search New Zealand university "Find an Expert" directories for named academics with their title, department, curated expertise tags, and public profile URL. Use when you need to find a university expert on a topic, verify a finding with an academic, or build an SME/advisory candidate list beyond publication data. Keyless, read-only, via each portal's public JSON API. Returns ephemeral shortlists — discovery is not consent and output is never a contact list.
+---
+
+# NZ University Experts
+
+## Goal
+
+Search NZ universities' public expert directories by topic and get back named
+academics with **curated expertise** (self-declared research tags), title,
+department, and a public profile link. This complements `find-experts-nz`
+(publication graphs): directory data includes staff who don't publish much and
+the expertise *they* chose to be found by. Keyless, read-only, Python stdlib only.
+
+## Use this when
+
+- You need university experts on a topic and want their self-declared expertise, not
+  just publication counts.
+- You're building a candidate shortlist for a consented SME / advisory network.
+- You want a public profile URL to hand a human steward alongside a finding.
+
+## Do not use this for
+
+- Building or storing a contact list. **Discovery is not consent.** Output is an
+  *ephemeral* shortlist for a human steward — never a stored candidate list, never
+  auto-contacted. Profile pages hold contact details; this skill does not collect them.
+- Non-academic practitioners (tradespeople, front-line staff) — they aren't in
+  university directories. Use industry associations / registers, or the org axis
+  (`nzbn-register`, `charities-services-nz`).
+
+## Workflow
+
+1. `unis` — list supported universities and which are searchable now (`api`) vs
+   roadmap (`todo`).
+2. `search "<topic>" --uni <slug>` — ranked directory matches with expertise tags
+   and profile URLs.
+3. Hand the shortlist to a human steward. A human decides who (if anyone) to
+   approach; a human always presses send. This skill stops at discovery.
+
+## Commands
+
+Run via `python3 scripts/cli.py <command>`:
+
+- `search QUERY [--uni SLUG] [--limit N] [--json]` — search a university's expert
+  directory (default `--uni auckland`).
+- `unis [--json]` — list supported universities, their slug, and status.
+
+`--json` is supported on both commands.
+
+## Sources
+
+- University of Auckland: `https://profiles.auckland.ac.nz/api/users` (public JSON
+  search). Keyless, read-only.
+
+## Notes
+
+- Stdlib-only. All egress via the shared `nzfetch` helper, so a transient block is
+  reported as `network error` (exit 2), not a crash.
+- Never fabricate: every field is returned verbatim from the portal's public API.
+- Only `api`-status universities are wired up today; the rest are a documented
+  roadmap. See [`references/guide.md`](references/guide.md) for the consent boundary
+  and **how to add a university** (identify its portal's public JSON search endpoint).

--- a/skills/nz-university-experts/references/guide.md
+++ b/skills/nz-university-experts/references/guide.md
@@ -1,0 +1,61 @@
+# nz-university-experts — guide
+
+## The consent boundary (read this first)
+
+This skill does **discovery**, not **contact**. University "Find an Expert" pages are
+public, and searching them is like reading a directory. But approaching a person is a
+Privacy Act 2020 collection event, so the output here is an **ephemeral candidate
+shortlist** for a human steward — never a stored list, never auto-contacted.
+
+Each academic's public profile page carries their contact details; this skill does
+**not** collect or emit them. It returns only what identifies expertise: name, title,
+department, self-declared expertise tags, and the public profile URL. A human visits
+the profile and decides whether to reach out.
+
+For the For Good repo: never write a discovered person's name into the public repo.
+Findings attribute expert input by **role only** ("reviewed by a University of
+Auckland gerontology academic"), per ADR-0010 and Constitution Article III.
+
+## Why this complements find-experts-nz
+
+`find-experts-nz` ranks people by what they've *published* (OpenAlex + Crossref).
+This skill reads what universities *curate*: the expertise tags an academic chose to
+be found by, their current role and department, and staff who are directory-listed
+but not prolific publishers. Use both — publications show output, directories show
+self-declared focus and current position.
+
+## How to add a university
+
+Every wired-up portal is just its public JSON search endpoint. To add one:
+
+1. Open the university's "Find an Expert" / staff-profile search in a browser.
+2. Watch the Network tab (XHR/fetch) as you search — find the request that returns
+   JSON results (for Auckland it's `POST /api/users` with a JSON body of
+   `params` + `filters`).
+3. Add an adapter function in `scripts/cli.py` that calls it via `nzfetch` and maps
+   its records to `{name, title, positions[], expertise[], profile_url, university}`.
+4. Register it in `ADAPTERS` with `"method": "api"`. Until then leave it `"todo"`.
+
+Keep it to **public, read-only search endpoints** only — no login, token, or
+account-scoped API. If a portal has no public JSON search, leave it `todo` rather
+than scraping rendered HTML.
+
+## Supported / roadmap
+
+- **auckland** — `api`, live. `https://profiles.auckland.ac.nz/api/users`.
+- **otago, vuw, canterbury, massey, aut, waikato, lincoln** — `todo`: each needs its
+  portal's public JSON search endpoint identified (step 2 above). Run `unis` for the
+  current list.
+
+## Reaching non-academics
+
+University directories only hold academics. For practitioners and organisations,
+discover the **organisation** and let a human invite it — compose:
+
+- `nzbn-register` / `companies-office-nz` — businesses by name; industry, directors.
+- `charities-services-nz` — NGOs by sector/activity; officer roles; grant signals.
+
+## Exit codes
+
+- `0` success · `1` usage/validation error · `2` `network error` (transient block or
+  upstream outage — smoke tests SKIP rather than FAIL on this).

--- a/skills/nz-university-experts/references/guide.md
+++ b/skills/nz-university-experts/references/guide.md
@@ -42,10 +42,16 @@ than scraping rendered HTML.
 
 ## Supported / roadmap
 
-- **auckland** — `api`, live. `https://profiles.auckland.ac.nz/api/users`.
-- **otago, vuw, canterbury, massey, aut, waikato, lincoln** — `todo`: each needs its
-  portal's public JSON search endpoint identified (step 2 above). Run `unis` for the
-  current list.
+- **auckland** — `api`, live. `POST /api/users` (JSON body).
+- **massey** — `api`, live. Solr expert search (`.../profiles_solr_native.cfc`,
+  form-encoded, `method=getExpertsFromSolr`). Its docs carry email/phone — the adapter
+  drops them; keep it that way in any new adapter.
+- **otago, vuw, canterbury, aut, waikato, lincoln** — `todo`: each needs its portal's
+  public JSON search endpoint identified (step 2 above). Run `unis` for the current list.
+
+**When a portal returns contact details** (Massey returns email/phone), map only
+name / title / department / expertise / profile_url. Never emit email, phone, or
+image fields — this skill surfaces expertise for a human steward, not a contact list.
 
 ## Reaching non-academics
 

--- a/skills/nz-university-experts/scripts/cli.py
+++ b/skills/nz-university-experts/scripts/cli.py
@@ -14,12 +14,30 @@ Each portal exposes a public JSON search API (e.g. University of Auckland's
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import pathlib
+import re
 import sys
+import urllib.parse
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3] / "lib"))
 import nzfetch  # noqa: E402
+
+_TAG_RE = re.compile(r"<[^>]+>")
+
+
+def html_to_lines(raw):
+    """Turn an HTML snippet of <p>/<li> items into a clean list of strings."""
+    if not raw:
+        return []
+    parts = re.split(r"</?(?:p|li|br|div)[^>]*>", raw, flags=re.IGNORECASE)
+    out = []
+    for p in parts:
+        text = html.unescape(_TAG_RE.sub("", p)).strip()
+        if text and text not in out:
+            out.append(text)
+    return out
 
 
 def die(msg: str, code: int = 1) -> None:
@@ -97,6 +115,51 @@ def auckland_search(query: str, limit: int) -> tuple[list, int]:
     return experts, total
 
 
+# ---------------------------------------------------------------- Massey
+
+
+MASSEY_BASE = "https://www.massey.ac.nz"
+MASSEY_API = (MASSEY_BASE + "/massey/app_templates/_pagetemplates/pagelets/search/"
+              "people/profile_solr_native/profiles_solr_native.cfc")
+
+
+def massey_search(query: str, limit: int) -> tuple[list, int]:
+    """Massey University — public Solr-backed expert search (keyword mode).
+
+    The API returns contact details (email/phone); we deliberately drop them —
+    this skill emits expertise, not a contact list.
+    """
+    body = urllib.parse.urlencode({
+        "experts_keywords_auto_selected": "none", "experts_keywords": query,
+        "experts_position_auto_selected": "none", "experts_position": "",
+        "experts_college": "", "experts_department": "", "solrHost": "tur-solr1",
+        "method": "getExpertsFromSolr", "radioSelect": "keywords",
+    }).encode()
+    data = fetch_json(
+        MASSEY_API, data=body, method="POST",
+        headers={"accept": "application/json, text/javascript, */*; q=0.01",
+                 "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
+                 "x-requested-with": "XMLHttpRequest", "user-agent": _UA,
+                 "referer": f"{MASSEY_BASE}/massey/expertise/profile.cfm"},
+    )
+    docs = ((data.get("response") or {}).get("docs")) or []
+    experts = []
+    for r in docs[:limit]:
+        path = r.get("url") or ""
+        experts.append({
+            "name": r.get("known_as") or r.get("last_name"),
+            "title": r.get("position"),
+            "positions": [{"role": r.get("position"),
+                           "department": r.get("department")
+                           or r.get("college")}],
+            "expertise": html_to_lines(r.get("interests")),
+            "profile_url": (MASSEY_BASE + path) if path.startswith("/") else (path or None),
+            "university": "Massey University",
+        })  # note: email/phone/extension fields intentionally NOT collected
+    total = (((data.get("response") or {}).get("numFound")) or len(docs))
+    return experts, total
+
+
 # ---------------------------------------------------------------- registry
 
 
@@ -115,8 +178,9 @@ ADAPTERS = {
             "method": "todo", "portal": "https://people.wgtn.ac.nz"},
     "canterbury": {"name": "University of Canterbury", "method": "todo",
                    "portal": "https://researchprofiles.canterbury.ac.nz"},
-    "massey": {"name": "Massey University", "method": "todo",
-               "portal": "https://www.massey.ac.nz/about/our-people"},
+    "massey": {"name": "Massey University", "method": "api",
+               "portal": MASSEY_BASE + "/massey/expertise/profile.cfm",
+               "search": massey_search},
     "aut": {"name": "Auckland University of Technology", "method": "todo",
             "portal": "https://academics.aut.ac.nz"},
     "waikato": {"name": "University of Waikato", "method": "todo",

--- a/skills/nz-university-experts/scripts/cli.py
+++ b/skills/nz-university-experts/scripts/cli.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""nz-university-experts — search NZ university "Find an Expert" directories.
+
+Read-only, keyless queries against university expert-directory JSON APIs.
+Returns EPHEMERAL candidate shortlists (name, title, department, expertise,
+public profile URL) for a human steward — discovery is not consent, and the
+output is never a contact list. Python stdlib only.
+
+Each portal exposes a public JSON search API (e.g. University of Auckland's
+/api/users) which we call directly. Universities not yet wired up are listed by
+`unis` as `todo`; see references/guide.md for how to add one.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[3] / "lib"))
+import nzfetch  # noqa: E402
+
+
+def die(msg: str, code: int = 1) -> None:
+    print(json.dumps({"error": msg}), file=sys.stderr)
+    sys.exit(code)
+
+
+def fetch_json(url, **kw):
+    try:
+        return nzfetch.fetch_json(url, **kw)
+    except nzfetch.Blocked as e:
+        die(f"network error: upstream_blocked: {e}", 2)
+    except nzfetch.FetchError as e:
+        die(f"network error: upstream_unavailable: {e}", 2)
+
+
+# ---------------------------------------------------------------- Auckland
+
+
+AUCKLAND_BASE = "https://profiles.auckland.ac.nz"
+_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0 Safari/537.36"
+
+
+def auckland_search(query: str, limit: int) -> tuple[list, int]:
+    """University of Auckland — public /api/users JSON search."""
+    per_page = 25
+    experts: list[dict] = []
+    total = 0
+    start = 0
+    while len(experts) < limit:
+        payload = json.dumps({
+            "params": {"by": "text", "category": "user", "text": query,
+                       "startFrom": start, "perPage": per_page},
+            "filters": [
+                {"name": n, "matchDocsWithMissingValues": True, "useValuesToFilter": False}
+                for n in ("customFilterOne", "department", "tags",
+                          "customFilterTwo", "customFilterThree")
+            ],
+        }).encode()
+        data = fetch_json(
+            f"{AUCKLAND_BASE}/api/users",
+            data=payload, method="POST",
+            headers={"content-type": "application/json", "accept": "application/json",
+                     "user-agent": _UA, "origin": AUCKLAND_BASE,
+                     "referer": f"{AUCKLAND_BASE}/search?by=text&type=user"},
+        )
+        page = data.get("resource") or []
+        total = ((data.get("pagination") or {}).get("total")) or total
+        if not page:
+            break
+        for r in page:
+            positions = [
+                {"role": p.get("position"), "department": p.get("department")}
+                for p in (r.get("positions") or [])
+            ]
+            expertise = [
+                t.get("value") for t in ((r.get("tags") or {}).get("explicit") or [])
+                if t.get("value")
+            ]
+            slug = r.get("discoveryUrlId")
+            experts.append({
+                "name": r.get("firstNameLastName")
+                or " ".join(filter(None, [r.get("firstName"), r.get("lastName")])),
+                "title": r.get("title"),
+                "positions": positions,
+                "expertise": expertise,
+                "profile_url": f"{AUCKLAND_BASE}/{slug}" if slug else None,
+                "university": "University of Auckland",
+            })
+            if len(experts) >= limit:
+                break
+        start += per_page
+        if start >= total:
+            break
+    return experts, total
+
+
+# ---------------------------------------------------------------- registry
+
+
+ADAPTERS = {
+    "auckland": {
+        "name": "University of Auckland",
+        "method": "api",
+        "portal": AUCKLAND_BASE,
+        "search": auckland_search,
+    },
+    # Documented in references/guide.md, not yet wired up (each needs its portal's
+    # public JSON search endpoint identified — see the guide's "adding a university"):
+    "otago": {"name": "University of Otago", "method": "todo",
+              "portal": "https://www.otago.ac.nz/profiles"},
+    "vuw": {"name": "Te Herenga Waka — Victoria University of Wellington",
+            "method": "todo", "portal": "https://people.wgtn.ac.nz"},
+    "canterbury": {"name": "University of Canterbury", "method": "todo",
+                   "portal": "https://researchprofiles.canterbury.ac.nz"},
+    "massey": {"name": "Massey University", "method": "todo",
+               "portal": "https://www.massey.ac.nz/about/our-people"},
+    "aut": {"name": "Auckland University of Technology", "method": "todo",
+            "portal": "https://academics.aut.ac.nz"},
+    "waikato": {"name": "University of Waikato", "method": "todo",
+                "portal": "https://www.waikato.ac.nz/staff-profiles"},
+    "lincoln": {"name": "Lincoln University", "method": "todo",
+                "portal": "https://researchers.lincoln.ac.nz"},
+}
+
+
+def cmd_unis(args) -> None:
+    rows = [
+        {"slug": s, "name": a["name"], "method": a["method"], "portal": a["portal"]}
+        for s, a in ADAPTERS.items()
+    ]
+    if args.json:
+        print(json.dumps({"kind": "universities", "count": len(rows),
+                          "universities": rows}, indent=2))
+        return
+    for r in rows:
+        ready = "✅ api" if r["method"] == "api" else f"… {r['method']}"
+        print(f"{r['slug']:12} {ready:14} {r['name']}")
+    print("\nOnly 'api' portals are searchable now; others are documented roadmap "
+          "(references/guide.md).")
+
+
+def cmd_search(args) -> None:
+    adapter = ADAPTERS.get(args.uni)
+    if not adapter:
+        die(f"unknown university '{args.uni}'. Run `unis` to list supported slugs.")
+    if adapter["method"] != "api" or "search" not in adapter:
+        die(f"'{args.uni}' ({adapter['name']}) is not wired up yet "
+            f"(method={adapter['method']}). Run `unis`; see references/guide.md.")
+    experts, total = adapter["search"](args.query, args.limit)
+    out = {
+        "kind": "university-experts",
+        "note": "Ephemeral candidate shortlist from a public directory. "
+        "Discovery is not consent — do not store or bulk-contact.",
+        "university": adapter["name"],
+        "query": args.query,
+        "total_available": total,
+        "count": len(experts),
+        "experts": experts,
+    }
+    if args.json:
+        print(json.dumps(out, indent=2))
+        return
+    if not experts:
+        print(f"No matches for {args.query!r} at {adapter['name']}.")
+        return
+    print(f"Experts for {args.query!r} — {adapter['name']} "
+          f"({len(experts)} of {total}):\n")
+    for i, e in enumerate(experts, 1):
+        pos = "; ".join(
+            f"{p['role']}, {p['department']}" if p.get("department") else (p.get("role") or "")
+            for p in e["positions"]
+        ) or "(no listed position)"
+        print(f"{i:2}. {e['name']} — {e['title'] or ''}")
+        print(f"    {pos}")
+        if e["expertise"]:
+            print(f"    Expertise: {', '.join(e['expertise'][:8])}")
+        if e["profile_url"]:
+            print(f"    {e['profile_url']}")
+    print("\nNote: ephemeral shortlist from public data — discovery is not consent.")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser(
+        prog="nz-university-experts",
+        description="Search NZ university expert directories (public, keyless). "
+        "Ephemeral shortlists only — discovery is not consent.",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    s = sub.add_parser("search", help="search a university's expert directory")
+    s.add_argument("query", help="free-text topic / expertise / name")
+    s.add_argument("--uni", default="auckland",
+                   help="university slug (default auckland; run `unis` to list)")
+    s.add_argument("--limit", type=int, default=10, help="experts to return")
+    s.add_argument("--json", action="store_true")
+    s.set_defaults(func=cmd_search)
+
+    u = sub.add_parser("unis", help="list supported universities and their status")
+    u.add_argument("--json", action="store_true")
+    u.set_defaults(func=cmd_unis)
+
+    args = p.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/skills/nz-university-experts/scripts/cli.py
+++ b/skills/nz-university-experts/scripts/cli.py
@@ -58,7 +58,6 @@ def fetch_json(url, **kw):
 
 
 AUCKLAND_BASE = "https://profiles.auckland.ac.nz"
-_UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/149.0 Safari/537.36"
 
 
 def auckland_search(query: str, limit: int) -> tuple[list, int]:
@@ -81,7 +80,7 @@ def auckland_search(query: str, limit: int) -> tuple[list, int]:
             f"{AUCKLAND_BASE}/api/users",
             data=payload, method="POST",
             headers={"content-type": "application/json", "accept": "application/json",
-                     "user-agent": _UA, "origin": AUCKLAND_BASE,
+                     "origin": AUCKLAND_BASE,
                      "referer": f"{AUCKLAND_BASE}/search?by=text&type=user"},
         )
         page = data.get("resource") or []
@@ -139,7 +138,7 @@ def massey_search(query: str, limit: int) -> tuple[list, int]:
         MASSEY_API, data=body, method="POST",
         headers={"accept": "application/json, text/javascript, */*; q=0.01",
                  "content-type": "application/x-www-form-urlencoded; charset=UTF-8",
-                 "x-requested-with": "XMLHttpRequest", "user-agent": _UA,
+                 "x-requested-with": "XMLHttpRequest",
                  "referer": f"{MASSEY_BASE}/massey/expertise/profile.cfm"},
     )
     docs = ((data.get("response") or {}).get("docs")) or []

--- a/skills/nz-university-experts/scripts/smoke_test.py
+++ b/skills/nz-university-experts/scripts/smoke_test.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Smoke tests for nz-university-experts (public directory APIs, stdlib only)."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+CLI = SKILL_DIR / "scripts" / "cli.py"
+
+
+def run(args, timeout=60):
+    return subprocess.run([sys.executable, str(CLI), *args],
+                          capture_output=True, text=True, timeout=timeout)
+
+
+def is_network_skip(result):
+    text = (result.stdout + result.stderr).lower()
+    return result.returncode == 2 and (
+        "network error" in text or "blocked" in text or "upstream" in text
+    )
+
+
+def test(name, fn):
+    try:
+        outcome = fn()
+        if outcome == "skip":
+            print(f"[SKIP] {name}")
+            return "skip"
+        print(f"[{'PASS' if outcome else 'FAIL'}] {name}")
+        return bool(outcome)
+    except Exception as e:  # noqa: BLE001
+        print(f"[FAIL] {name}")
+        print(f"  error: {e}")
+        return False
+
+
+def test_help():
+    r = run(["--help"], timeout=20)
+    return r.returncode == 0 and "search" in r.stdout and "unis" in r.stdout
+
+
+def test_unis():
+    r = run(["unis", "--json"], timeout=20)
+    if r.returncode != 0:
+        print(f"  stderr: {r.stderr.strip()}")
+        return False
+    d = json.loads(r.stdout)
+    slugs = [u["slug"] for u in d.get("universities", [])]
+    return d.get("kind") == "universities" and "auckland" in slugs
+
+
+def test_unknown_uni():
+    r = run(["search", "x", "--uni", "nope"], timeout=20)
+    return r.returncode == 1  # validation error, no network
+
+
+def test_search_auckland():
+    r = run(["search", "aged care", "--uni", "auckland", "--limit", "3", "--json"])
+    if is_network_skip(r):
+        return "skip"
+    if r.returncode != 0:
+        print(f"  stderr: {r.stderr.strip()}")
+        return False
+    d = json.loads(r.stdout)
+    if d.get("kind") != "university-experts" or not isinstance(d.get("experts"), list):
+        return False
+    if not d["experts"]:
+        return True  # reachable but empty is acceptable
+    e = d["experts"][0]
+    return "name" in e and "profile_url" in e and "expertise" in e
+
+
+def test_todo_uni_refused():
+    r = run(["search", "x", "--uni", "otago"], timeout=20)
+    return r.returncode == 1 and "wired up" in (r.stdout + r.stderr)
+
+
+def main():
+    results = [
+        test("help lists subcommands", test_help),
+        test("unis lists auckland", test_unis),
+        test("unknown uni errors", test_unknown_uni),
+        test("todo uni is refused", test_todo_uni_refused),
+        test("auckland search returns experts", test_search_auckland),
+    ]
+    passed = sum(1 for r in results if r is True)
+    skipped = sum(1 for r in results if r == "skip")
+    failed = sum(1 for r in results if r is False)
+    print(f"\n{passed} passed, {skipped} skipped, {failed} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/skills/nz-university-experts/scripts/smoke_test.py
+++ b/skills/nz-university-experts/scripts/smoke_test.py
@@ -74,6 +74,22 @@ def test_search_auckland():
     return "name" in e and "profile_url" in e and "expertise" in e
 
 
+def test_search_massey_no_contact():
+    r = run(["search", "milk", "--uni", "massey", "--limit", "3", "--json"])
+    if is_network_skip(r):
+        return "skip"
+    if r.returncode != 0:
+        print(f"  stderr: {r.stderr.strip()}")
+        return False
+    # Contact details must never leak into output.
+    low = r.stdout.lower()
+    if "@massey" in low or '"email"' in low or '"phone"' in low:
+        print("  LEAK: contact detail present in output")
+        return False
+    d = json.loads(r.stdout)
+    return d.get("university") == "Massey University" and isinstance(d.get("experts"), list)
+
+
 def test_todo_uni_refused():
     r = run(["search", "x", "--uni", "otago"], timeout=20)
     return r.returncode == 1 and "wired up" in (r.stdout + r.stderr)
@@ -86,6 +102,7 @@ def main():
         test("unknown uni errors", test_unknown_uni),
         test("todo uni is refused", test_todo_uni_refused),
         test("auckland search returns experts", test_search_auckland),
+        test("massey search, no contact leak", test_search_massey_no_contact),
     ]
     passed = sum(1 for r in results if r is True)
     skipped = sum(1 for r in results if r == "skip")


### PR DESCRIPTION
## What

A keyless, read-only skill that searches NZ universities' public "Find an Expert" directories by topic, returning named academics with **curated expertise tags**, title, department, and a public profile URL. Companion to `find-experts-nz` (which ranks by publications) — this reads what universities *curate*, including staff who don't publish much and the expertise they chose to be found by.

## Universities wired up

- **University of Auckland** — `POST /api/users` (public JSON).
- **Massey University** — public Solr expert search (`.../profiles_solr_native.cfc`).

Both keyless, no cookies. `unis` lists these plus the roadmap (otago, vuw, canterbury, aut, waikato, lincoln), each of which just needs its portal's public JSON search endpoint identified — the guide documents how (Network tab → the XHR that returns JSON → an adapter).

## Design boundaries

- **Discovery is not consent.** Output is an *ephemeral* shortlist for a human steward — never a stored candidate/contact list.
- **No contact details collected.** Massey's API returns email/phone; the adapter drops them and emits expertise only. A smoke test asserts nothing like `@massey`/`email`/`phone` reaches output.
- Findings attribute expert input by role only (ADR-0010 / Article III) — this skill returns names for a steward to act on, not for the public repo.

## Conventions

- All egress via shared `lib/nzfetch`; Python stdlib only; read-only, keyless.
- Adapter registry so more portals slot in.
- Passes `validate_skill.py`; **6/6 smoke tests pass** against live APIs.

## Note

No browser dependency — the portals expose clean JSON APIs, so CloakBrowser isn't needed for these.