### PR TITLE
fix: harden Wellington data trust boundaries

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -3599,10 +3599,13 @@
         "data-gwrc.opendata.arcgis.com",
         "www.arcgis.com",
         "hub.arcgis.com",
+        "services.arcgis.com",
         "services1.arcgis.com",
         "services2.arcgis.com",
         "gis.wcc.govt.nz",
+        "giswebprd.gw.govt.nz",
         "mapping.gw.govt.nz",
+        "maps.gw.govt.nz",
         "gis-snowflake-opendata-public-wcc-arcgis-prod.s3.ap-southeast-2.amazonaws.com"
       ],
       "last_verified": "2026-07-22",

--- a/skills/gwrc-hilltop-nz/SKILL.md
+++ b/skills/gwrc-hilltop-nz/SKILL.md
@@ -62,7 +62,7 @@ python3 skills/gwrc-hilltop-nz/scripts/cli.py collections
 
 - `sites [--measurement NAME] [--search TEXT] [--limit N] [--json]` — monitoring sites with lat/long
 - `measurements --site NAME [--json]` — data sources, labels, copy-pastable `request as` names, units, and date spans at one site
-- `latest --site NAME --measurement NAME [--window-hours N] [--json]` — most recent observation; a plain label resolves to the freshest matching series, while an exact `request as` value selects that series explicitly
+- `latest --site NAME --measurement NAME [--exact-request-as] [--window-hours N] [--json]` — most recent observation; a plain label resolves to the freshest matching series. Use `--exact-request-as` to force literal `request as` selection when a value such as `Stage` also collides with a display label.
 - `rainfall [--hours N] [--search TEXT] [--limit N] [--json]` — per-gauge totals over the window, wettest first
 - `rivers [--hours N] [--search TEXT] [--limit N] [--json]` — latest level/flow per site with min/max and rising/falling/steady trend
 - `collections [--json]` — Hilltop collection names
@@ -83,7 +83,9 @@ council run `collections --council <key>` and pass `--collection NAME`.
 - Sites can expose duplicate labels such as `Stage` under multiple data sources.
   `measurements` prints each exact `request as` value; `latest --measurement Stage`
   selects the matching series with the newest advertised `to` timestamp and reports
-  both `requested_measurement` and `resolved_measurement` in JSON.
+  both `requested_measurement` and `resolved_measurement` in JSON. Add
+  `--exact-request-as` to select a literal `request as` value when it also matches
+  a display label.
 - `rainfall` and `rivers` exclude decommissioned gauges that still answer with
   years-old data, and report how many were excluded; `latest` flags such readings
   with `stale: true` and their age in hours.

--- a/skills/gwrc-hilltop-nz/SKILL.md
+++ b/skills/gwrc-hilltop-nz/SKILL.md
@@ -61,8 +61,8 @@ python3 skills/gwrc-hilltop-nz/scripts/cli.py collections
 ```
 
 - `sites [--measurement NAME] [--search TEXT] [--limit N] [--json]` — monitoring sites with lat/long
-- `measurements --site NAME [--json]` — data sources, measurements, units, and date spans at one site
-- `latest --site NAME --measurement NAME [--window-hours N] [--json]` — most recent observation
+- `measurements --site NAME [--json]` — data sources, labels, copy-pastable `request as` names, units, and date spans at one site
+- `latest --site NAME --measurement NAME [--window-hours N] [--json]` — most recent observation; a plain label resolves to the freshest matching series, while an exact `request as` value selects that series explicitly
 - `rainfall [--hours N] [--search TEXT] [--limit N] [--json]` — per-gauge totals over the window, wettest first
 - `rivers [--hours N] [--search TEXT] [--limit N] [--json]` — latest level/flow per site with min/max and rising/falling/steady trend
 - `collections [--json]` — Hilltop collection names
@@ -80,6 +80,10 @@ council run `collections --council <key>` and pass `--collection NAME`.
 - Gauges log every ~5–15 minutes but upload every 2–3 hours: treat "latest" as up to
   a few hours behind reality, and never as a substitute for official warnings.
 - Timestamps are NZ local time exactly as published by the server.
+- Sites can expose duplicate labels such as `Stage` under multiple data sources.
+  `measurements` prints each exact `request as` value; `latest --measurement Stage`
+  selects the matching series with the newest advertised `to` timestamp and reports
+  both `requested_measurement` and `resolved_measurement` in JSON.
 - `rainfall` and `rivers` exclude decommissioned gauges that still answer with
   years-old data, and report how many were excluded; `latest` flags such readings
   with `stale: true` and their age in hours.

--- a/skills/gwrc-hilltop-nz/references/source-notes.md
+++ b/skills/gwrc-hilltop-nz/references/source-notes.md
@@ -48,6 +48,11 @@ Verified live 22 July 2026 (server version 2606.0.2.92, `<Agency>GWRC</Agency>`)
   every request type.
 - Errors come back as `<HilltopServer><Error>...</Error>` with HTTP 200; the CLI maps
   unknown-site errors to invalid-input exit 2 and other server errors to exit 5.
+- Measurement labels are not unique per site. `MeasurementList` can expose several
+  `Stage` rows under different data sources, each with a distinct `RequestAs` value.
+  The `measurements` command prints that copy-pastable value. For a plain label,
+  `latest` selects the matching row with the newest advertised `To` timestamp; an
+  explicit `RequestAs` value selects that exact series.
 
 ## Generalisation
 

--- a/skills/gwrc-hilltop-nz/references/source-notes.md
+++ b/skills/gwrc-hilltop-nz/references/source-notes.md
@@ -51,8 +51,9 @@ Verified live 22 July 2026 (server version 2606.0.2.92, `<Agency>GWRC</Agency>`)
 - Measurement labels are not unique per site. `MeasurementList` can expose several
   `Stage` rows under different data sources, each with a distinct `RequestAs` value.
   The `measurements` command prints that copy-pastable value. For a plain label,
-  `latest` selects the matching row with the newest advertised `To` timestamp; an
-  explicit `RequestAs` value selects that exact series.
+  `latest` selects the matching row with the newest advertised `To` timestamp.
+  `--exact-request-as` forces literal `RequestAs` selection when that value also
+  collides with a display label. JSON records whether exact mode was used.
 
 ## Generalisation
 

--- a/skills/gwrc-hilltop-nz/scripts/cli.py
+++ b/skills/gwrc-hilltop-nz/scripts/cli.py
@@ -132,16 +132,21 @@ def parse_measurement_list(root: ET.Element) -> list[dict[str, Any]]:
     return rows
 
 
-def select_measurement_request(rows: list[dict[str, Any]], requested: str) -> str:
+def select_measurement_request(rows: list[dict[str, Any]], requested: str, *, exact: bool = False) -> str:
     """Resolve a display label to the freshest matching Hilltop RequestAs name."""
     folded = requested.casefold()
+    if exact:
+        exact_matches = [row for row in rows if (row.get("request_as") or "").casefold() == folded]
+        if exact_matches:
+            return exact_matches[0]["request_as"]
+        die(f"no exact RequestAs value {requested!r} at this site; use the measurements command", 2)
     matches = [row for row in rows if (row.get("measurement") or "").casefold() == folded]
     if matches:
         freshest = max(matches, key=lambda row: row.get("to") or "")
         return freshest.get("request_as") or freshest.get("measurement") or requested
-    exact = [row for row in rows if (row.get("request_as") or "").casefold() == folded]
-    if exact:
-        return exact[0]["request_as"]
+    request_matches = [row for row in rows if (row.get("request_as") or "").casefold() == folded]
+    if request_matches:
+        return request_matches[0]["request_as"]
     return requested
 
 
@@ -310,7 +315,11 @@ def cmd_measurements(args: argparse.Namespace) -> None:
 def cmd_latest(args: argparse.Namespace) -> None:
     measurements_url = hilltop_url(args.base_url, "MeasurementList", Site=args.site)
     measurement_rows = parse_measurement_list(fetch_root(measurements_url, args.base_url))
-    resolved_measurement = select_measurement_request(measurement_rows, args.measurement)
+    resolved_measurement = select_measurement_request(
+        measurement_rows,
+        args.measurement,
+        exact=args.exact_request_as,
+    )
     url = hilltop_url(
         args.base_url,
         "GetData",
@@ -344,6 +353,7 @@ def cmd_latest(args: argparse.Namespace) -> None:
         "site": block["site"],
         "requested_measurement": args.measurement,
         "resolved_measurement": resolved_measurement,
+        "exact_request_as": args.exact_request_as,
         "measurement": block["item_name"] or args.measurement,
         "units": block["units"],
         "window_hours": args.window_hours,
@@ -532,6 +542,11 @@ def main() -> None:
     s = sub.add_parser("latest", help="latest observation for one site and measurement")
     s.add_argument("--site", required=True, help="exact site name from the sites command")
     s.add_argument("--measurement", required=True, help="display label or exact 'request as' value from measurements")
+    s.add_argument(
+        "--exact-request-as",
+        action="store_true",
+        help="treat --measurement only as a literal RequestAs value, even when it collides with a display label",
+    )
     s.add_argument("--window-hours", type=positive_int(720), default=72, help="lookback window in hours (default 72)")
     add_common(s)
     s.set_defaults(func=cmd_latest)

--- a/skills/gwrc-hilltop-nz/scripts/cli.py
+++ b/skills/gwrc-hilltop-nz/scripts/cli.py
@@ -3,8 +3,8 @@
 
 Rainfall gauges and river/stream levels and flows through the public Hilltop
 REST endpoint. Read-only, no authentication. Timestamps are NZ local time as
-published by the server. The base URL is parameterisable so the same Hilltop
-query pattern works against other regional councils' servers.
+published by the server. A verified registry exposes the same Hilltop query
+pattern across supported regional councils without accepting arbitrary endpoints.
 """
 from __future__ import annotations
 
@@ -130,6 +130,19 @@ def parse_measurement_list(root: ET.Element) -> list[dict[str, Any]]:
                 }
             )
     return rows
+
+
+def select_measurement_request(rows: list[dict[str, Any]], requested: str) -> str:
+    """Resolve a display label to the freshest matching Hilltop RequestAs name."""
+    folded = requested.casefold()
+    matches = [row for row in rows if (row.get("measurement") or "").casefold() == folded]
+    if matches:
+        freshest = max(matches, key=lambda row: row.get("to") or "")
+        return freshest.get("request_as") or freshest.get("measurement") or requested
+    exact = [row for row in rows if (row.get("request_as") or "").casefold() == folded]
+    if exact:
+        return exact[0]["request_as"]
+    return requested
 
 
 def parse_time_series(root: ET.Element) -> list[dict[str, Any]]:
@@ -286,16 +299,23 @@ def cmd_measurements(args: argparse.Namespace) -> None:
     lines = [f"Measurements at {args.site}: {len(rows)}"]
     for r in rows:
         units = f" [{r['units']}]" if r["units"] else ""
-        lines.append(f"- {r['measurement']}{units} ({r['data_source']}, {r['from']} → {r['to']})")
+        request_as = r["request_as"] or r["measurement"]
+        lines.append(
+            f"- {r['measurement']}{units} ({r['data_source']}, {r['from']} → {r['to']}; "
+            f"request as: {request_as})"
+        )
     emit(payload, args.json, lines)
 
 
 def cmd_latest(args: argparse.Namespace) -> None:
+    measurements_url = hilltop_url(args.base_url, "MeasurementList", Site=args.site)
+    measurement_rows = parse_measurement_list(fetch_root(measurements_url, args.base_url))
+    resolved_measurement = select_measurement_request(measurement_rows, args.measurement)
     url = hilltop_url(
         args.base_url,
         "GetData",
         Site=args.site,
-        Measurement=args.measurement,
+        Measurement=resolved_measurement,
         TimeInterval=f"PT{args.window_hours}H",
     )
     blocks = [b for b in parse_time_series(fetch_root(url, args.base_url)) if b["points"]]
@@ -322,6 +342,8 @@ def cmd_latest(args: argparse.Namespace) -> None:
         "source": source_name(args.base_url),
         "source_url": url,
         "site": block["site"],
+        "requested_measurement": args.measurement,
+        "resolved_measurement": resolved_measurement,
         "measurement": block["item_name"] or args.measurement,
         "units": block["units"],
         "window_hours": args.window_hours,
@@ -509,7 +531,7 @@ def main() -> None:
 
     s = sub.add_parser("latest", help="latest observation for one site and measurement")
     s.add_argument("--site", required=True, help="exact site name from the sites command")
-    s.add_argument("--measurement", required=True, help="measurement name, e.g. Stage, Flow, Rainfall")
+    s.add_argument("--measurement", required=True, help="display label or exact 'request as' value from measurements")
     s.add_argument("--window-hours", type=positive_int(720), default=72, help="lookback window in hours (default 72)")
     add_common(s)
     s.set_defaults(func=cmd_latest)

--- a/skills/gwrc-hilltop-nz/scripts/smoke_test.py
+++ b/skills/gwrc-hilltop-nz/scripts/smoke_test.py
@@ -62,6 +62,13 @@ def main() -> int:
             "to": "2026-07-23T14:15:00",
         }
         assert cli.select_measurement_request([rows[0], duplicate], "Stage") == "Stage [Gauging Results]"
+        assert cli.select_measurement_request([rows[0], duplicate], "Stage", exact=True) == "Stage"
+        try:
+            cli.select_measurement_request([rows[0], duplicate], "NotARequestAs", exact=True)
+        except SystemExit as exc:
+            assert exc.code == 2
+        else:
+            raise AssertionError("unknown exact RequestAs must fail before GetData")
         assert cli.select_measurement_request([rows[0], duplicate], "Stage [Gauging Results]") == "Stage [Gauging Results]"
 
         original = cli.fetch_root

--- a/skills/gwrc-hilltop-nz/scripts/smoke_test.py
+++ b/skills/gwrc-hilltop-nz/scripts/smoke_test.py
@@ -7,6 +7,9 @@ import json
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
+from contextlib import redirect_stdout
+from io import StringIO
+from types import SimpleNamespace
 from pathlib import Path
 
 CLI = Path(__file__).with_name("cli.py")
@@ -51,6 +54,26 @@ def main() -> int:
         assert rows[0]["units"] == "mm" and rows[0]["data_source"] == "Water Level"
         assert rows[1]["units"] == "m³/sec"
         assert rows[0]["from"] == "1979-03-16T12:15:00"
+
+        duplicate = {
+            **rows[0],
+            "data_source": "Gauging Results",
+            "request_as": "Stage [Gauging Results]",
+            "to": "2026-07-23T14:15:00",
+        }
+        assert cli.select_measurement_request([rows[0], duplicate], "Stage") == "Stage [Gauging Results]"
+        assert cli.select_measurement_request([rows[0], duplicate], "Stage [Gauging Results]") == "Stage [Gauging Results]"
+
+        original = cli.fetch_root
+        cli.fetch_root = lambda *_args, **_kwargs: root
+        output = StringIO()
+        try:
+            with redirect_stdout(output):
+                cli.cmd_measurements(SimpleNamespace(base_url=cli.DEFAULT_BASE, site="Synthetic River", json=False))
+        finally:
+            cli.fetch_root = original
+        assert "request as:" in output.getvalue().lower()
+        assert rows[0]["request_as"] in output.getvalue()
 
     def fixture_time_series():
         root = ET.parse(FIXTURES / "hilltop-get-data.xml").getroot()

--- a/skills/wcc-arcgis-nz/SKILL.md
+++ b/skills/wcc-arcgis-nz/SKILL.md
@@ -18,7 +18,7 @@ metadata:
   thecolab.skill_type: "public-api"
   thecolab.pack: "nz-public-data"
   thecolab.source_url: "https://data-wcc.opendata.arcgis.com/"
-  thecolab.allowed_domains: "data-wcc.opendata.arcgis.com,data-gwrc.opendata.arcgis.com,www.arcgis.com,hub.arcgis.com,services1.arcgis.com,services2.arcgis.com,gis.wcc.govt.nz,mapping.gw.govt.nz,gis-snowflake-opendata-public-wcc-arcgis-prod.s3.ap-southeast-2.amazonaws.com"
+  thecolab.allowed_domains: "data-wcc.opendata.arcgis.com,data-gwrc.opendata.arcgis.com,www.arcgis.com,hub.arcgis.com,services.arcgis.com,services1.arcgis.com,services2.arcgis.com,gis.wcc.govt.nz,giswebprd.gw.govt.nz,mapping.gw.govt.nz,maps.gw.govt.nz,gis-snowflake-opendata-public-wcc-arcgis-prod.s3.ap-southeast-2.amazonaws.com"
   thecolab.last_verified: "2026-07-22"
   thecolab.health: "healthy"
   thecolab.maintainer: "@adam91holt"
@@ -60,19 +60,23 @@ python3 skills/wcc-arcgis-nz/scripts/cli.py sensors-latest --limit 20 --json
 ```
 
 - `search KEYWORD [--portal wcc|gwrc] [--type TYPE] [--limit N] [--json]` — org-scoped catalogue search, newest first
-- `layers ITEM_OR_URL [--json]` — layers/tables of a Feature/Map service
-- `query LAYER [--layer-id N] [--where SQL] [--bbox minLon,minLat,maxLon,maxLat] [--fields F1,F2] [--limit N] [--json]` — GeoJSON features; LAYER is an item id, service URL, or layer URL
+- `layers ITEM_OR_URL [--json]` — layers/tables of a verified WCC/GWRC Feature/Map service
+- `query LAYER [--layer-id N] [--where SQL] [--bbox minLon,minLat,maxLon,maxLat] [--fields F1,F2] [--limit N] [--json]` — GeoJSON features; LAYER is a verified council item id, HTTPS service URL, or HTTPS layer URL
 - `sensors [--search TEXT] [--limit N] [--json]` — transport sensor countlines with coordinates and data spans
-- `sensors-latest [--month YYYY-MM] [--search TEXT] [--limit N] [--json]` — counts per countline and transport class for the newest published day, with a monthly daily average for baseline comparison
+- `sensors-latest [--month YYYY-MM] [--search TEXT] [--limit N] [--json]` — counts per countline and transport class for the newest published day, with a monthly daily average and explicit stale/missing observations
 
 ## Notes
 
 - Licence: CC BY 4.0 — attribute "Wellington City Council" (or GWRC for `--portal gwrc` data)
 - Searches are scoped to each council's ArcGIS organisation; hub-wide search APIs
   return a global catalogue and are deliberately not used
-- Layer queries only go to council/Esri hosts; other hosts are refused explicitly
+- Layer queries require HTTPS, exact declared hosts, and a verified WCC/GWRC ArcGIS
+  organisation id; unrelated global ArcGIS items and tenant paths are refused
 - `sensors-latest` downloads the month's count file (~12 MB) — WCC refreshes it at
   least monthly and in practice daily; expect the newest day to be about one day old
+- A missing countline/class row is not assumed to mean zero traffic:
+  `latest_date_count` is `null`, `stale` is true, and `latest_observed_date` plus the
+  metadata's `LATEST` date are returned for auditability
 - Query responses cap at the server's transfer limit (2000); a `truncated` flag says
   when to narrow with `--where`/`--bbox`
 

--- a/skills/wcc-arcgis-nz/references/source-notes.md
+++ b/skills/wcc-arcgis-nz/references/source-notes.md
@@ -3,8 +3,9 @@
 - Primary owner: Wellington City Council (GWRC via `--portal gwrc`)
 - Primary source: https://data-wcc.opendata.arcgis.com/
 - Declared outbound hosts: data-wcc.opendata.arcgis.com, data-gwrc.opendata.arcgis.com,
-  www.arcgis.com, hub.arcgis.com, services1.arcgis.com, services2.arcgis.com,
-  gis.wcc.govt.nz, mapping.gw.govt.nz,
+  www.arcgis.com, hub.arcgis.com, services.arcgis.com, services1.arcgis.com,
+  services2.arcgis.com, gis.wcc.govt.nz, giswebprd.gw.govt.nz,
+  mapping.gw.govt.nz, maps.gw.govt.nz,
   gis-snowflake-opendata-public-wcc-arcgis-prod.s3.ap-southeast-2.amazonaws.com
 - Access mode: public-api
 - Authentication: none
@@ -31,11 +32,16 @@ WCC `CPYspmTk3abe6d7i`, GWRC `RS7BXJAO6ksvblJm`. Item metadata resolves through
 
 Feature/Map service layers answer standard ArcGIS REST `query` requests with
 `f=geojson`, no key. Server page cap is 2000 records (`exceededTransferLimit`
-surfaces as `truncated`). Services live on `services1.arcgis.com` /
-`services2.arcgis.com` (Esri-hosted), `gis.wcc.govt.nz`, and
-`mapping.gw.govt.nz`; the CLI refuses any other host (exit 7). Note some
+surfaces as `truncated`). Services live on `services.arcgis.com` /
+`services1.arcgis.com` / `services2.arcgis.com` (Esri-hosted),
+`gis.wcc.govt.nz`, `giswebprd.gw.govt.nz`, `mapping.gw.govt.nz`, and
+`maps.gw.govt.nz`; the CLI refuses any other host (exit 7). Note some
 services do not start layer ids at 0 — the CLI reads the service's own layer
-list when no `--layer-id` is given.
+list when no `--layer-id` is given. Item ids must belong to the WCC or GWRC org
+ids above. Direct service/layer URLs must use HTTPS and either an exact council
+host or an Esri service path whose first segment is one of those org ids (plus
+GWRC's verified legacy tenant `XTtANUDT8Va4DLwI`). Every request pins redirects
+to its already-validated hostname.
 
 ## Pōneke Travel Insights transport sensors
 
@@ -57,6 +63,11 @@ the current-month file updated daily during verification (newest day = yesterday
 The bucket allows anonymous ListObjectsV2, but the CLI derives the newest month
 from the metadata's LATEST column and falls back one month on a missing file
 rather than listing the bucket.
+
+Mobility files omit rows when a countline/class did not report on a date. The CLI
+must not turn that absence into a measured zero: it emits `latest_date_count: null`,
+`stale: true`, `latest_observed_date`, and the metadata's `LATEST` date. A numeric
+zero is reserved for a row that was actually present and summed to zero.
 
 Upstream data source is VivaCity Labs sensors; WCC contact for the dataset is
 digitalinnovation@wcc.govt.nz.

--- a/skills/wcc-arcgis-nz/scripts/cli.py
+++ b/skills/wcc-arcgis-nz/scripts/cli.py
@@ -13,6 +13,7 @@ import argparse
 import csv
 import io
 import json
+import math
 import pathlib
 import sys
 import urllib.parse
@@ -320,9 +321,10 @@ def parse_sensor_meta(rows: list[dict[str, str]]) -> list[dict[str, Any]]:
 
 def parse_optional_float(raw: str | None) -> float | None:
     try:
-        return float(raw) if raw else None
+        value = float(raw) if raw else None
     except (TypeError, ValueError):
         return None
+    return value if value is not None and math.isfinite(value) else None
 
 
 def summarise_mobility(rows: list[dict[str, str]]) -> dict[str, Any]:

--- a/skills/wcc-arcgis-nz/scripts/cli.py
+++ b/skills/wcc-arcgis-nz/scripts/cli.py
@@ -41,8 +41,20 @@ PORTALS = {
         "site": "https://data-gwrc.opendata.arcgis.com/",
     },
 }
-# Layer queries may only leave for council/Esri infrastructure.
-ALLOWED_LAYER_SUFFIXES = (".arcgis.com", ".wcc.govt.nz", ".gw.govt.nz")
+# Layer queries may only leave for the councils' verified infrastructure. ArcGIS
+# Online service URLs also carry the owning organisation id as their first path
+# segment, so enforce that rather than trusting every tenant on *.arcgis.com.
+ARCGIS_SERVICE_HOSTS = {"services.arcgis.com", "services1.arcgis.com", "services2.arcgis.com"}
+COUNCIL_SERVICE_HOSTS = {
+    "gis.wcc.govt.nz",
+    "giswebprd.gw.govt.nz",
+    "mapping.gw.govt.nz",
+    "maps.gw.govt.nz",
+}
+COUNCIL_ORG_IDS = {portal["org_id"] for portal in PORTALS.values()}
+# ArcGIS Online normally uses the org id as the tenant path. GWRC retains one
+# verified legacy tenant id on services.arcgis.com.
+COUNCIL_TENANT_IDS = COUNCIL_ORG_IDS | {"XTtANUDT8Va4DLwI"}
 ATTRIBUTION = "CC BY 4.0 — attribute the owning council"
 
 
@@ -55,7 +67,8 @@ def fetch_json(url: str, params: dict[str, Any] | None = None) -> tuple[Any, str
     if params:
         url = url + "?" + urllib.parse.urlencode({k: v for k, v in params.items() if v is not None})
     try:
-        data = nzfetch.fetch_json(url, timeout=45)
+        host = urllib.parse.urlparse(url).hostname
+        data = nzfetch.fetch_json(url, timeout=45, allowed_hosts=[host] if host else None)
     except nzfetch.RateLimited as exc:
         die(f"network error: rate_limited: retry_after={exc.retry_after}: {exc}", 4)
     except nzfetch.Blocked as exc:
@@ -82,13 +95,28 @@ def normalise_item(item: dict[str, Any]) -> dict[str, Any]:
 
 
 def check_layer_host(url: str) -> None:
-    host = (urllib.parse.urlparse(url).hostname or "").lower()
-    if not host or not host.endswith(ALLOWED_LAYER_SUFFIXES):
+    parsed = urllib.parse.urlparse("")
+    try:
+        parsed = urllib.parse.urlparse(url)
+        host = (parsed.hostname or "").lower()
+        invalid_authority = parsed.port is not None or parsed.username is not None or parsed.password is not None
+    except ValueError:
+        host = ""
+        invalid_authority = True
+    allowed = parsed.scheme == "https" and not invalid_authority and host in (ARCGIS_SERVICE_HOSTS | COUNCIL_SERVICE_HOSTS)
+    if allowed and host in ARCGIS_SERVICE_HOSTS:
+        path_parts = [urllib.parse.unquote(part) for part in parsed.path.split("/") if part]
+        allowed = bool(path_parts and path_parts[0] in COUNCIL_TENANT_IDS)
+    if not allowed:
         die(
-            f"unsupported layer host {host!r}: only council/Esri hosts "
-            f"({', '.join('*' + s for s in ALLOWED_LAYER_SUFFIXES)}) are queried",
+            f"unsupported layer URL {url!r}: use HTTPS and a verified WCC/GWRC service host or ArcGIS organisation",
             7,
         )
+
+
+def validate_item_org(item: dict[str, Any], reference: str) -> None:
+    if item.get("orgId") not in COUNCIL_ORG_IDS:
+        die(f"ArcGIS item {reference!r} is not owned by the verified WCC/GWRC organisations", 7)
 
 
 def resolve_layer_url(reference: str, layer_id: int | None) -> str:
@@ -99,6 +127,7 @@ def resolve_layer_url(reference: str, layer_id: int | None) -> str:
         if not reference.replace("-", "").isalnum() or len(reference) < 8:
             die(f"invalid layer reference {reference!r}: pass an item id or a service/layer URL", 2)
         item, _ = fetch_json(SHARING_ITEM + urllib.parse.quote(reference), {"f": "json"})
+        validate_item_org(item, reference)
         url = (item.get("url") or "").rstrip("/")
         if not url:
             die(f"item {reference} has no service URL (type {item.get('type')!r}); pick a Feature/Map Service item", 2)
@@ -195,6 +224,7 @@ def cmd_layers(args: argparse.Namespace) -> None:
         service_url = reference.rstrip("/")
     else:
         item, _ = fetch_json(SHARING_ITEM + urllib.parse.quote(reference), {"f": "json"})
+        validate_item_org(item, reference)
         service_url = (item.get("url") or "").rstrip("/")
         if not service_url:
             die(f"item {reference} has no service URL (type {item.get('type')!r})", 2)
@@ -279,13 +309,20 @@ def parse_sensor_meta(rows: list[dict[str, str]]) -> list[dict[str, Any]]:
             {
                 "countline_id": row["COUNTLINE_ID"],
                 "name": row.get("NAME"),
-                "latitude": float(row["LATITUDE_START_LINE"]) if row.get("LATITUDE_START_LINE") else None,
-                "longitude": float(row["LONGITUDE_START_LINE"]) if row.get("LONGITUDE_START_LINE") else None,
+                "latitude": parse_optional_float(row.get("LATITUDE_START_LINE")),
+                "longitude": parse_optional_float(row.get("LONGITUDE_START_LINE")),
                 "earliest": row.get("EARLIEST"),
                 "latest": row.get("LATEST"),
             }
         )
     return out
+
+
+def parse_optional_float(raw: str | None) -> float | None:
+    try:
+        return float(raw) if raw else None
+    except (TypeError, ValueError):
+        return None
 
 
 def summarise_mobility(rows: list[dict[str, str]]) -> dict[str, Any]:
@@ -310,9 +347,16 @@ def summarise_mobility(rows: list[dict[str, str]]) -> dict[str, Any]:
     for (countline, klass, date), count in daily.items():
         entry = summary.setdefault(
             (countline, klass),
-            {"countline_id": countline, "transport_class": klass, "latest_date_count": 0, "day_totals": []},
+            {
+                "countline_id": countline,
+                "transport_class": klass,
+                "latest_date_count": None,
+                "latest_observed_date": date,
+                "day_totals": [],
+            },
         )
         entry["day_totals"].append(count)
+        entry["latest_observed_date"] = max(entry["latest_observed_date"], date)
         if date == latest_date:
             entry["latest_date_count"] = count
     rows_out = []
@@ -320,6 +364,7 @@ def summarise_mobility(rows: list[dict[str, str]]) -> dict[str, Any]:
         totals = entry.pop("day_totals")
         entry["daily_average"] = round(sum(totals) / len(totals), 1)
         entry["days_observed"] = len(totals)
+        entry["stale"] = entry["latest_observed_date"] != latest_date
         rows_out.append(entry)
     return {"latest_date": latest_date, "rows": rows_out}
 
@@ -387,10 +432,14 @@ def cmd_sensors_latest(args: argparse.Namespace) -> None:
         row["name"] = info.get("name")
         row["latitude"] = info.get("latitude")
         row["longitude"] = info.get("longitude")
+        row["metadata_latest_date"] = info.get("latest")
     if args.search:
         needle = args.search.casefold()
         out_rows = [r for r in out_rows if needle in (r.get("name") or "").casefold()]
-    out_rows.sort(key=lambda r: r["latest_date_count"], reverse=True)
+    out_rows.sort(
+        key=lambda r: (r["latest_date_count"] is not None, r["latest_date_count"] or 0),
+        reverse=True,
+    )
     total = len(out_rows)
     if args.limit:
         out_rows = out_rows[: args.limit]
@@ -401,7 +450,7 @@ def cmd_sensors_latest(args: argparse.Namespace) -> None:
         "licence": ATTRIBUTION,
         "month": f"{used[0]}-{used[1]}",
         "latest_date": summary["latest_date"],
-        "note": "counts refresh no less than monthly; latest_date is the newest day in the published file",
+        "note": "counts refresh no less than monthly; null latest_date_count means the countline/class did not report on latest_date",
         "total_rows": total,
         "counts": out_rows,
     }
@@ -410,9 +459,13 @@ def cmd_sensors_latest(args: argparse.Namespace) -> None:
         f"{len(out_rows)} shown of {total}, busiest first):"
     ]
     for r in out_rows:
+        if r["latest_date_count"] is None:
+            reading = f"no observation on {summary['latest_date']} (last observed {r['latest_observed_date']})"
+        else:
+            reading = str(r["latest_date_count"])
         lines.append(
-            f"- {r['name'] or r['countline_id']} [{r['transport_class']}]: {r['latest_date_count']} "
-            f"(daily avg {r['daily_average']} over {r['days_observed']} days)"
+            f"- {r['name'] or r['countline_id']} [{r['transport_class']}]: {reading} "
+            f"(daily avg {r['daily_average']} over {r['days_observed']} observed days)"
         )
     emit(payload, args.json, lines)
 

--- a/skills/wcc-arcgis-nz/scripts/smoke_test.py
+++ b/skills/wcc-arcgis-nz/scripts/smoke_test.py
@@ -77,6 +77,9 @@ def main() -> int:
         assert sensors[0]["countline_id"] == "90001" and sensors[0]["latitude"] == -41.3
         assert sensors[0]["latest"] == "2026-07-21"
         assert sensors[-1]["latitude"] is None and sensors[-1]["longitude"] == 174.8
+        assert cli.parse_optional_float("NaN") is None
+        assert cli.parse_optional_float("inf") is None
+        assert cli.parse_optional_float("-inf") is None
 
     def fixture_mobility():
         rows = list(csv.DictReader(io.StringIO((FIXTURES / "countline-mobility-sample.csv").read_text(encoding="utf-8"))))

--- a/skills/wcc-arcgis-nz/scripts/smoke_test.py
+++ b/skills/wcc-arcgis-nz/scripts/smoke_test.py
@@ -62,26 +62,95 @@ def main() -> int:
 
     def fixture_sensor_meta():
         rows = list(csv.DictReader(io.StringIO((FIXTURES / "countline-meta-sample.csv").read_text(encoding="utf-8"))))
+        rows.append(
+            {
+                "COUNTLINE_ID": "90003",
+                "NAME": "Synthetic malformed coordinate",
+                "LATITUDE_START_LINE": "N/A",
+                "LONGITUDE_START_LINE": "174.8",
+                "EARLIEST": "2026-07-01",
+                "LATEST": "2026-07-20",
+            }
+        )
         sensors = cli.parse_sensor_meta(rows)
-        assert len(sensors) == 2, "row without COUNTLINE_ID must be dropped"
+        assert len(sensors) == 3, "row without COUNTLINE_ID must be dropped"
         assert sensors[0]["countline_id"] == "90001" and sensors[0]["latitude"] == -41.3
         assert sensors[0]["latest"] == "2026-07-21"
+        assert sensors[-1]["latitude"] is None and sensors[-1]["longitude"] == 174.8
 
     def fixture_mobility():
         rows = list(csv.DictReader(io.StringIO((FIXTURES / "countline-mobility-sample.csv").read_text(encoding="utf-8"))))
+        rows.append(
+            {
+                "COUNTLINE_ID": "90003",
+                "COUNTLINE_DATE": "2026-07-20",
+                "COUNTLINE_HOUR": "8",
+                "DIRECTION_COUNT": "9",
+                "COUNTLINE_TRANSPORT_CLASS": "Car",
+                "DIRECTION": "N",
+            }
+        )
         summary = cli.summarise_mobility(rows)
         assert summary["latest_date"] == "2026-07-21"
         by_key = {(r["countline_id"], r["transport_class"]): r for r in summary["rows"]}
         walker = by_key[("90001", "Pedestrian")]
         assert walker["latest_date_count"] == 12, "hours and directions must sum; bad counts skipped"
+        assert walker["latest_observed_date"] == "2026-07-21" and walker["stale"] is False
         assert walker["days_observed"] == 2 and walker["daily_average"] == 18.0
         assert by_key[("90002", "Car")]["latest_date_count"] == 3
+        stale = by_key[("90003", "Car")]
+        assert stale["latest_date_count"] is None, "missing observations must not be fabricated as zero"
+        assert stale["latest_observed_date"] == "2026-07-20" and stale["stale"] is True
+
+    def fixture_council_scope():
+        allowed = "https://services1.arcgis.com/CPYspmTk3abe6d7i/arcgis/rest/services/example/FeatureServer"
+        allowed_gwrc_legacy = "https://services.arcgis.com/XTtANUDT8Va4DLwI/arcgis/rest/services/example/FeatureServer"
+        unrelated = "https://services1.arcgis.com/0MSEUqKaxRlEPj5g/arcgis/rest/services/example/FeatureServer"
+        for verified in (
+            allowed,
+            allowed_gwrc_legacy,
+            "https://maps.gw.govt.nz/portal/rest/services/example/MapServer",
+            "https://giswebprd.gw.govt.nz/arcgis/rest/services/example/MapServer",
+        ):
+            cli.check_layer_host(verified)
+        for rejected in (unrelated, allowed.replace("https://", "http://", 1)):
+            try:
+                cli.check_layer_host(rejected)
+            except SystemExit as exc:
+                assert exc.code == 7
+            else:
+                raise AssertionError(f"unverified ArcGIS route must be rejected: {rejected}")
+
+        calls = []
+
+        def fake_fetch(url, params=None):
+            calls.append(url)
+            return {
+                "id": "external-item",
+                "orgId": "UNRELATED_ORG",
+                "type": "Feature Service",
+                "url": unrelated,
+            }, url
+
+        original = cli.fetch_json
+        cli.fetch_json = fake_fetch
+        try:
+            try:
+                cli.resolve_layer_url("externalitem123", 0)
+            except SystemExit as exc:
+                assert exc.code == 7
+            else:
+                raise AssertionError("item outside WCC/GWRC must be rejected")
+        finally:
+            cli.fetch_json = original
+        assert len(calls) == 1, "unrelated service URL must fail before a second network request"
 
     results.append(check("fixture sharing-search item normalisation", fixture_search))
     results.append(check("fixture service layer/table parser", fixture_service))
     results.append(check("fixture bbox envelope parameters", fixture_bbox))
     results.append(check("fixture countline metadata parser", fixture_sensor_meta))
     results.append(check("fixture mobility count aggregation", fixture_mobility))
+    results.append(check("fixture council ArcGIS scope enforcement", fixture_council_scope))
 
     def live(name: str, args: list[str], assertion) -> None:
         completed = subprocess.run(


### PR DESCRIPTION
## Summary

Follow-up hardening for the Wellington public-data skills added in #206 and reviewed after #207.

- stop treating missing transport-sensor observations as measured zero traffic
- expose `latest_observed_date`, `metadata_latest_date`, and `stale` when countlines/classes did not report on the newest file date
- parse malformed sensor coordinates as `null` instead of crashing the entire command
- restrict ArcGIS items and direct URLs to verified WCC/GWRC organisations, tenant paths, exact hosts, and HTTPS
- pin every ArcGIS request and redirect to its validated hostname
- resolve duplicate Hilltop measurement labels to the freshest matching `RequestAs` value while preserving explicit qualified selection
- print copy-pastable Hilltop `request as` values and report requested/resolved names in JSON
- update source notes and generated catalogue metadata

## Live verification

- unrelated global ArcGIS item `c0b356e20b30490c8b8b4c7bb9554e7c` now fails closed with exit 7
- WCC Majoribanks sensors now return `latest_date_count: null`, `stale: true`, and their actual July 5–6 observation dates instead of fabricated July 21 zeroes
- `latest --site "Hutt River Below Kaitoke Intake" --measurement Stage` resolves to `Stage [Gauging Results]` and returns an honestly stale reading
- verified live GWRC item routing on `services.arcgis.com` and `maps.gw.govt.nz`

## Test plan

- [x] strict validation for both touched skills
- [x] both live smoke suites
- [x] 91/91 repository unit tests
- [x] 138/138 skill contract tests
- [x] repository policy validation
- [x] generated catalogue/README check
- [x] Python compilation and `git diff --check`
- [x] hostile/unrelated ArcGIS routing fixtures
- [x] missing-observation and malformed-coordinate fixtures
- [x] duplicate Hilltop measurement-resolution fixtures

## Risk

Read-only behavior changes. Some previously accepted unrelated ArcGIS URLs now fail closed by design. Missing mobility rows now use JSON `null` rather than the misleading numeric zero.