### PR TITLE
fix: make airnz-flights and carjam-nz smoke tests outage-aware

### DIFF
--- a/skills/airnz-flights/scripts/cli.py
+++ b/skills/airnz-flights/scripts/cli.py
@@ -44,6 +44,51 @@ class BrowserUnavailableError(RuntimeError):
     """Raised when --browser is requested but CloakBrowser is not installed."""
 
 
+class TransientBrowserError(RuntimeError):
+    """A transient browser/navigation failure (anti-bot abort, timeout, connection
+    reset). Retryable via the public timetable fallback rather than a hard failure."""
+
+
+# Substrings that identify a transient Chromium/Playwright navigation failure —
+# the live booking host aborting an anti-bot-sensitive navigation, a timeout, or a
+# reset — as opposed to a real bug in our request/parse code.
+_TRANSIENT_BROWSER_MARKERS = (
+    "net::err_aborted",
+    "net::err_timed_out",
+    "net::err_connection",
+    "net::err_network_changed",
+    "net::err_name_not_resolved",
+    "net::err_empty_response",
+    "net::err_failed",
+    "err_aborted",
+    "timeout",
+    "timed out",
+    "navigation failed",
+)
+
+# Search-API HTTP statuses that signal an anti-bot block or upstream outage — worth
+# falling back to the public timetable feed rather than surfacing a raw error.
+_TRANSIENT_SEARCH_STATUSES = {403, 406, 408, 409, 429, 500, 502, 503, 504}
+
+
+def _is_transient_browser_error(exc: BaseException) -> bool:
+    text = str(exc).lower()
+    return any(marker in text for marker in _TRANSIENT_BROWSER_MARKERS)
+
+
+def _browser_goto(page: Any, url: str, *, timeout: int = 90000) -> None:
+    """Navigate *page* to *url*, converting transient nav failures into a
+    TransientBrowserError instead of leaking a raw Playwright traceback."""
+    try:
+        page.goto(url, wait_until="networkidle", timeout=timeout)
+    except BrowserUnavailableError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - classify, never leak a traceback
+        if _is_transient_browser_error(exc):
+            raise TransientBrowserError(str(exc)) from exc
+        raise
+
+
 def _request(
     opener: urllib.request.OpenerDirector,
     url: str,
@@ -372,6 +417,32 @@ def fetch_fares_with_cloakbrowser(origin: str, destination: str, depart_date: st
         ) from exc
 
     start_url = booking_url(origin, destination, depart_date)
+    try:
+        return _cloakbrowser_fare_search(launch, start_url, origin, destination, depart_date, adults, direct)
+    except TransientBrowserError as exc:
+        # The live booking host aborted/blocked the anonymous browser session
+        # (anti-bot navigation abort, timeout, or reset). Fall back to the public
+        # timetable feed — the same recovery the CAPTCHA branch already uses —
+        # rather than leaking a stack trace and hard-failing.
+        try:
+            return fetch_timetable_sync(origin, destination, depart_date, direct)
+        except Exception as fallback_exc:  # noqa: BLE001 - report cleanly, no traceback
+            raise RuntimeError(
+                "Air NZ browser fare search was blocked (network error: "
+                f"{exc}); the public timetable fallback was also unavailable "
+                f"(network error: {fallback_exc})"
+            ) from fallback_exc
+
+
+def _cloakbrowser_fare_search(
+    launch: Any,
+    start_url: str,
+    origin: str,
+    destination: str,
+    depart_date: str,
+    adults: int,
+    direct: bool,
+) -> dict[str, Any]:
     browser = None
     try:
         browser = launch(
@@ -381,7 +452,7 @@ def fetch_fares_with_cloakbrowser(origin: str, destination: str, depart_date: st
             locale="en-NZ",
         )
         page = browser.new_page()
-        page.goto(start_url, wait_until="networkidle", timeout=90000)
+        _browser_goto(page, start_url)
         payload = search_payload(origin, destination, depart_date, adults)
         search_result_raw = page.evaluate(
             """async ({url, payload}) => {
@@ -394,16 +465,18 @@ def fetch_fares_with_cloakbrowser(origin: str, destination: str, depart_date: st
             }""",
             {"url": SEARCH_API_PATH, "payload": payload},
         )
-        if int(search_result_raw.get("status") or 0) != 200:
-            raise RuntimeError(
-                f"Air NZ browser fare search returned HTTP {search_result_raw.get('status')}: "
-                f"{str(search_result_raw.get('text') or '')[:300]}"
-            )
+        status = int(search_result_raw.get("status") or 0)
+        if status != 200:
+            detail = str(search_result_raw.get("text") or "")[:300]
+            if status in _TRANSIENT_SEARCH_STATUSES:
+                # Anti-bot block / upstream outage — recover via the timetable feed.
+                raise TransientBrowserError(f"search API returned HTTP {status}: {detail}")
+            raise RuntimeError(f"Air NZ browser fare search returned HTTP {status}: {detail}")
         search_result = json.loads(str(search_result_raw.get("text") or "{}"))
         redirect_url = str(search_result.get("redirectUrl") or SELECT_ITINERARY_PATH)
         if "captcha" in redirect_url.lower():
             return fetch_timetable_sync(origin, destination, depart_date, direct)
-        page.goto(f"{BASE}{redirect_url}", wait_until="networkidle", timeout=90000)
+        _browser_goto(page, f"{BASE}{redirect_url}")
         select_html = page.content()
         return build_fare_result(
             extract_json_array(select_html, '"legOptions"'),

--- a/skills/airnz-flights/scripts/smoke_test.py
+++ b/skills/airnz-flights/scripts/smoke_test.py
@@ -24,6 +24,16 @@ assert fixture_rows == [{"id": "fixture"}]
 assert fixture_fare["price"] == 123 and fixture_fare["available"] is True
 print("[PASS] fixture fare array extraction and fare normalisation")
 
+# A transient Chromium navigation abort must be classified as retryable (so the
+# browser path falls back to the timetable feed instead of leaking a traceback),
+# while a genuine coding error must not be swallowed.
+assert fixture_cli._is_transient_browser_error(
+    RuntimeError('Page.goto: net::ERR_ABORTED at https://flightbookings.airnewzealand.co.nz/...')
+)
+assert fixture_cli._is_transient_browser_error(RuntimeError("Timeout 90000ms exceeded"))
+assert not fixture_cli._is_transient_browser_error(ValueError("unexpected key in payload"))
+print("[PASS] fixture transient browser-navigation error classification")
+
 DATE = (date.today() + timedelta(days=7)).isoformat()
 browser_required = os.getenv("COLAB_SMOKE_USE_BROWSER") == "1"
 use_browser = browser_required or find_spec("cloakbrowser") is not None

--- a/skills/carjam-nz/scripts/cli.py
+++ b/skills/carjam-nz/scripts/cli.py
@@ -23,6 +23,23 @@ BASE_URL = "https://www.carjam.co.nz"
 USER_AGENT = "Mozilla/5.0 (compatible; thecolab-carjam-nz-skill/1.0)"
 LOCKED_MARKERS = ("Get Report", "May be in Report", "Subscribe")
 
+# HTTP-200 anti-bot / interstitial bodies that some CDNs return in place of the
+# real page. These are transient (shared CI IPs, rate limits) rather than a real
+# "plate not found" or an HTML-structure change, so they should be retried and,
+# if still blocked, surfaced as an upstream outage — not a hard failure.
+BLOCK_MARKERS = (
+    "just a moment",
+    "attention required",
+    "access denied",
+    "access to this page has been denied",
+    "request unsuccessful",
+    "pardon our interruption",
+    "verify you are a human",
+    "are you a robot",
+    "enable javascript and cookies to continue",
+    "checking your browser before accessing",
+)
+
 LABELS = {
     "year_of_manufacture": "Year",
     "make": "Make",
@@ -88,6 +105,23 @@ _RETRY_STATUSES = {429, 502, 503, 504}
 _RETRY_DELAYS = (2, 5, 10)  # seconds between attempts 1→2, 2→3, 3→fail
 
 
+def looks_like_block(body: str) -> bool:
+    """True when *body* is an anti-bot/interstitial page rather than a CarJam page."""
+    low = body.lower()
+    return any(marker in low for marker in BLOCK_MARKERS)
+
+
+def has_carjam_shell(page: str) -> bool:
+    """True when *page* is a genuine CarJam vehicle response.
+
+    A real CarJam page — even for a plate with no free public fields — carries the
+    application shell (``data-key`` field spans and/or the CarJam-branded title).
+    A blocked/empty/proxy-error response carries none of these.
+    """
+    low = page.lower()
+    return "data-key=" in low or "carjam" in low
+
+
 def fetch(url: str) -> str:
     """Fetch *url* with up to 3 attempts and exponential backoff.
 
@@ -107,10 +141,10 @@ def fetch(url: str) -> str:
         try:
             with urllib.request.urlopen(req, timeout=30) as response:
                 body = response.read().decode("utf-8", "replace")
-                # Cloudflare challenge — treat as transient
+                # Cloudflare / anti-bot interstitial (HTTP 200) — treat as transient
                 cf_mitigated = response.headers.get("cf-mitigated", "")
-                if cf_mitigated or "Just a moment" in body:
-                    last_error = f"Cloudflare challenge on attempt {attempt}"
+                if cf_mitigated or looks_like_block(body):
+                    last_error = f"anti-bot challenge on attempt {attempt}"
                     should_retry = True
                 else:
                     return body
@@ -127,8 +161,8 @@ def fetch(url: str) -> str:
 
         if should_retry:
             if delay is None:
-                # All retries exhausted
-                die(f"all {attempt} attempts failed — last error: {last_error}")
+                # All retries exhausted — this is an upstream outage, not a bad plate.
+                die(f"all {attempt} attempts failed (temporary failure) — last error: {last_error}")
             time.sleep(delay)
 
     raise AssertionError("unreachable")
@@ -204,6 +238,14 @@ def parse_vehicle(page: str, *, source_url: str, identifier: str, lookup_type: s
     title = extract_title(page) or ""
     fields = extract_fields(page)
     if not any(fields.get(k) for k in ("year_of_manufacture", "make", "model", "plate", "vin", "chassis")):
+        if looks_like_block(page) or not has_carjam_shell(page):
+            # No CarJam application shell at all — a transient block/empty/proxy-error
+            # response (common on shared CI IPs), not a genuine result. Surface as an
+            # upstream outage so smoke reporting gates rather than hard-fails.
+            die(
+                f"no CarJam vehicle page returned for {lookup_type} {identifier!r} "
+                "(temporary failure — likely a transient block or rate-limit; retry later)"
+            )
         die(f"no public vehicle fields found for {lookup_type} {identifier!r}")
 
     summary = {key: fields.get(key) for key in SUMMARY_KEYS if key in fields}

--- a/skills/carjam-nz/scripts/smoke_test.py
+++ b/skills/carjam-nz/scripts/smoke_test.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
+import contextlib
 import importlib.util
+import io
 import json
 import subprocess
 import sys
@@ -57,6 +59,39 @@ def test_fixture_vehicle_parser() -> bool:
 
 
 results.append(test("fixture public vehicle HTML parser", test_fixture_vehicle_parser))
+
+
+def _die_message(page: str) -> str:
+    """Return the stderr message emitted when parse_vehicle rejects *page*."""
+    buffer = io.StringIO()
+    with contextlib.redirect_stderr(buffer):
+        try:
+            fixture_cli.parse_vehicle(
+                page, source_url="u", identifier="PSP532", lookup_type="plate"
+            )
+        except SystemExit:
+            pass
+    return buffer.getvalue()
+
+
+def test_fixture_block_detection() -> bool:
+    # An HTTP-200 anti-bot interstitial (no CarJam shell) must be classified as a
+    # transient outage — the message carries a network marker so smoke reporting
+    # gates rather than hard-fails.
+    block_page = "<html><body>Access to this page has been denied.</body></html>"
+    if not fixture_cli.looks_like_block(block_page):
+        return False
+    if fixture_cli.has_carjam_shell(block_page):
+        return False
+    if "temporary failure" not in _die_message(block_page):
+        return False
+    # A genuine CarJam page with the app shell but no free fields stays a hard
+    # failure (a real no-data / structure regression, not an outage).
+    shell_no_fields = "<title>PSP532 | CARJAM</title><div id='app'></div>"
+    return "temporary failure" not in _die_message(shell_no_fields)
+
+
+results.append(test("fixture anti-bot block classified as transient outage", test_fixture_block_detection))
 
 # Current public Trade Me vehicle listing 5805102051 exposed this plate in
 # listing details on 2026-05-24. Use a real listed vehicle rather than a


### PR DESCRIPTION
## Problem

Nightly Smoke Tests run [30038593852](https://github.com/thecolab-ai/.skills/actions/runs/30038593852) failed with 2 failures. Both are live-source scrapers, and both sources are healthy — the failures were **transient anti-bot events on the shared CI runner IP** that slipped through `run_smoke_tests.py`'s outage-aware gating (which downgrades a non-zero smoke exit to `gated` when the log carries a network marker and isn't a "deterministic" failure).

- **airnz-flights** — the `--browser`/CloakBrowser path let a raw Playwright `net::ERR_ABORTED` escape as a **traceback** (`main()` only catches `RuntimeError`/`BrowserUnavailableError`), which the framework's `TRACEBACK_MARKER` classified as a *deterministic* fail. Also violated the repo rule "fail with a clear human message — not a stack trace."
- **carjam-nz** — an HTTP-200 soft-block page (no `429`/"Just a moment", so `fetch()` didn't retry) produced `no public vehicle fields found` — a message with **no network marker** — so it was treated as a hard fail.

## Fix

- **airnz-flights**: added `_browser_goto()` + `TransientBrowserError`. Transient navigation aborts/timeouts (and 403/429/5xx from the search API) now fall back to the public timetable feed — the same recovery the CAPTCHA branch already uses — instead of leaking a traceback. If the fallback is also down, it raises a clean network-marker `RuntimeError` (no traceback).
- **carjam-nz**: added `looks_like_block()` / `has_carjam_shell()`. Anti-bot interstitials are retried; a response with no CarJam shell fails with a `temporary failure` message (→ gated). A genuine CarJam page missing fields (real no-data / HTML-structure regression) **still hard-fails**, so real breakage isn't masked.
- Added deterministic fixture assertions covering both classifications.

## Verification

Representative logs run through the framework's actual classification regexes:

| Scenario | Before | After |
|---|---|---|
| carjam soft-block | fail | **gated** |
| airnz browser abort (fallback ok) | fail | **pass** |
| airnz browser abort (both down) | fail | **gated** |

`run_smoke_tests.py airnz-flights carjam-nz` → `PASS: 2, GATED: 0, FAIL: 0`; both skills pass `validate_skill.py` and `test_contract.py`; airnz browser-fallback wiring unit-tested with a fake launcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)