### PR TITLE
Add URL-only Grocer asset delivery

### DIFF
--- a/skills/grocer-nz/SKILL.md
+++ b/skills/grocer-nz/SKILL.md
@@ -53,6 +53,7 @@ The script bootstraps `duckdb` via `uv` when the active Python does not already 
 - Adam wants a store id for a known store, e.g. Papakura.
 - Adam wants price history for a known Grocer product id.
 - Adam wants current prices for one product across selected stores.
+- Adam wants the public DuckDB/parquet download URLs so another agent can download or analyse the raw files itself.
 - Adam wants to identify the same exact product in the Woolworths, New World, or PAK'nSAVE skills.
 - Adam has a UPC, EAN, or GTIN and needs the corresponding Grocer product id.
 
@@ -65,6 +66,35 @@ Set a helper variable:
 ```bash
 GROCER=skills/grocer-nz/scripts/cli.py
 ```
+
+### Get raw asset download URLs
+
+Use `assets` when the caller wants the source files rather than parsed rows. This
+command only constructs links from Grocer's fixed public asset layout. It makes
+no network request, starts no DuckDB process, and does not download or parse any
+file.
+
+```bash
+# Base catalogue DuckDB URL (also the default with no selectors)
+python3 $GROCER assets --base --json
+
+# Current-price parquet URLs for selected stores
+python3 $GROCER assets --store-id 230 --store-id 307 --json
+
+# Per-product history parquet URLs
+python3 $GROCER assets --product 5452 --product 5461 --json
+
+# Combine all three asset types
+python3 $GROCER assets --base --store-id 230 --product 5452 --json
+```
+
+The result contains `delivery: external_url` and a `resources` array. Each
+resource has a declared `format`, filename, and public `url`. Through The Colab
+MCP, supported resources are also emitted as native MCP `resource_link` content,
+so the client downloads directly from Grocer rather than through the MCP server.
+The URLs are deliberately not probed; a nonexistent store or product id can
+therefore produce a link that returns 403/404 when downloaded. At most 50 links
+may be requested in one call.
 
 ### List stores
 
@@ -206,6 +236,7 @@ Prices are stored in **NZ cents**. `$5.50` is represented as `550`.
 8. **Live smoke tests depend on upstream stock/history.** Product `5461` and Papakura stores were live-valid when added, but upstream catalogue changes can make the smoke fail without a code bug.
 9. **This is public read-only data.** Do not try to bypass sign-in or scrape private Grocer user/list/pro features.
 10. **Retailer barcode search has different shapes.** Search Foodstuffs with the compact barcode (leading zero padding removed). Woolworths returns its own `barcode`; normalise and verify that field because its text search may include unrelated rows.
+11. **`assets` constructs but does not validate links.** Use it for low-overhead handoff of raw public files. Use the parsed commands when the agent needs verified rows immediately.
 
 ## Verification Checklist
 
@@ -213,6 +244,7 @@ Run these before relying on a fresh install:
 
 ```bash
 python3 $GROCER stores --query Papakura --json
+python3 $GROCER assets --base --store-id 230 --product 5452 --json
 python3 $GROCER search "milk" --store-query Papakura --limit 2
 python3 $GROCER prices 5461 --store-query Papakura --limit 10
 python3 $GROCER history 5461 --store-query Papakura --limit 5

--- a/skills/grocer-nz/scripts/cli.py
+++ b/skills/grocer-nz/scripts/cli.py
@@ -49,6 +49,7 @@ ALLOWED_HOSTS = {"assets-prod.grocer.nz", "grocer.nz", "meilisearch.grocer.nz"}
 CACHE = pathlib.Path(os.environ.get("GROCER_NZ_CACHE", "~/.cache/grocer-nz")).expanduser()
 HEADERS = {"Referer": "https://grocer.nz/"}
 MAX_LIMIT = 100
+MAX_ASSET_LINKS = 50
 
 
 def http_get(url: str, *, headers: dict[str, str] | None = None) -> bytes:
@@ -178,6 +179,90 @@ def print_result(data: Any, as_json: bool) -> None:
             print(" | ".join(f"{k}={v}" for k, v in item.items()))
     else:
         print(data)
+
+
+def positive_id(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("expected a positive integer id")
+    return parsed
+
+
+def asset_manifest(
+    *,
+    include_base: bool,
+    store_ids: list[int],
+    product_ids: list[int],
+) -> dict[str, Any]:
+    """Construct public asset URLs without fetching or parsing their bodies."""
+    stores = list(dict.fromkeys(store_ids))
+    products = list(dict.fromkeys(product_ids))
+    requested = int(include_base) + len(stores) + len(products)
+    if requested == 0:
+        include_base = True
+        requested = 1
+    if requested > MAX_ASSET_LINKS:
+        raise SystemExit(
+            f"assets: at most {MAX_ASSET_LINKS} download links may be requested"
+        )
+
+    resources: list[dict[str, Any]] = []
+    if include_base:
+        resources.append(
+            {
+                "kind": "base_catalogue",
+                "format": "duckdb",
+                "compression": "br",
+                "filename": "base_v3.duckdb.br",
+                "media_type": "application/octet-stream",
+                "url": f"{BASE}/base_v3.duckdb.br",
+            }
+        )
+    for store_id in stores:
+        filename = f"public_prices_{store_id}.parquet"
+        resources.append(
+            {
+                "kind": "current_prices",
+                "format": "parquet",
+                "store_id": store_id,
+                "filename": filename,
+                "media_type": "application/vnd.apache.parquet",
+                "url": f"{BASE}/prices_per_store_v3/{filename}",
+            }
+        )
+    for product_id in products:
+        filename = f"price_history_{product_id}.parquet"
+        resources.append(
+            {
+                "kind": "price_history",
+                "format": "parquet",
+                "product_id": product_id,
+                "filename": filename,
+                "media_type": "application/vnd.apache.parquet",
+                "url": f"{BASE}/price_history_v3/{filename}",
+            }
+        )
+    return {
+        "delivery": "external_url",
+        "resources": resources,
+        "network_requests_made": 0,
+        "warnings": [
+            "URLs are constructed from Grocer's public asset layout without probing them; a requested store or product asset may not exist."
+        ],
+    }
+
+
+def cmd_assets(args):
+    result = asset_manifest(
+        include_base=args.base,
+        store_ids=args.store_id or [],
+        product_ids=args.product or [],
+    )
+    if args.json:
+        print_result(result, True)
+        return
+    for resource in result["resources"]:
+        print(resource["url"])
 
 
 def cmd_stores(args):
@@ -595,6 +680,32 @@ def main(argv=None):
     p = argparse.ArgumentParser(description="Query public grocer.nz supermarket price/search/history data")
     p.add_argument("--refresh", action="store_true", help="refresh cached public files")
     sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser(
+        "assets",
+        help="return public DuckDB/parquet download URLs without downloading or parsing them",
+    )
+    sp.add_argument(
+        "--base",
+        action="store_true",
+        help="include the public base catalogue DuckDB URL (the default when no selectors are supplied)",
+    )
+    sp.add_argument(
+        "--store-id",
+        type=positive_id,
+        action="append",
+        default=[],
+        help="include the current-price parquet URL for this store id (repeatable)",
+    )
+    sp.add_argument(
+        "--product",
+        type=positive_id,
+        action="append",
+        default=[],
+        help="include the price-history parquet URL for this product id (repeatable)",
+    )
+    sp.add_argument("--json", action="store_true")
+    sp.set_defaults(func=cmd_assets)
 
     sp = sub.add_parser("stores", help="list stores")
     sp.add_argument("--query", "-q")

--- a/skills/grocer-nz/scripts/smoke_test.py
+++ b/skills/grocer-nz/scripts/smoke_test.py
@@ -49,7 +49,24 @@ def main() -> None:
     assert cli.normalize_gtin("94152210") == "00000094152210"
     assert cli.normalize_gtin("00 0000 9415 2210") == "00000094152210"
     assert cli.retailer_barcode("00000094152210") == "94152210"
-    print("[PASS] fixture query guard, bounds, and GTIN normalisation")
+    assets = json.loads(run(
+        "assets",
+        "--base",
+        "--store-id", "230",
+        "--store-id", "230",
+        "--product", "5452",
+        "--json",
+    ))
+    assert assets["network_requests_made"] == 0
+    assert [resource["kind"] for resource in assets["resources"]] == [
+        "base_catalogue",
+        "current_prices",
+        "price_history",
+    ]
+    assert assets["resources"][0]["url"].endswith("/base_v3.duckdb.br")
+    assert assets["resources"][1]["url"].endswith("/public_prices_230.parquet")
+    assert assets["resources"][2]["url"].endswith("/price_history_5452.parquet")
+    print("[PASS] fixture query guard, bounds, GTIN normalisation, and URL-only assets")
 
     try:
         stores = json.loads(run("stores", "--query", "Papakura", "--json"))

--- a/tests/test_grocer_assets.py
+++ b/tests/test_grocer_assets.py
@@ -1,0 +1,84 @@
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI_PATH = REPO_ROOT / "skills" / "grocer-nz" / "scripts" / "cli.py"
+
+
+def load_cli():
+    spec = importlib.util.spec_from_file_location("grocer_assets_cli", CLI_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class GrocerAssetTests(unittest.TestCase):
+    def test_manifest_constructs_deduplicated_urls_without_fetching(self):
+        cli = load_cli()
+        with (
+            mock.patch.object(
+                cli,
+                "ensure_dependencies",
+                side_effect=AssertionError("DuckDB must not start"),
+            ),
+            mock.patch.object(
+                cli,
+                "http_get",
+                side_effect=AssertionError("assets must not fetch"),
+            ),
+        ):
+            manifest = cli.asset_manifest(
+                include_base=True,
+                store_ids=[230, 230, 307],
+                product_ids=[5452, 5452],
+            )
+
+        self.assertEqual(manifest["delivery"], "external_url")
+        self.assertEqual(manifest["network_requests_made"], 0)
+        self.assertEqual(
+            [resource["kind"] for resource in manifest["resources"]],
+            [
+                "base_catalogue",
+                "current_prices",
+                "current_prices",
+                "price_history",
+            ],
+        )
+        self.assertEqual(
+            manifest["resources"][0]["url"],
+            "https://assets-prod.grocer.nz/public/base_v3.duckdb.br",
+        )
+        self.assertTrue(
+            manifest["resources"][1]["url"].endswith(
+                "/prices_per_store_v3/public_prices_230.parquet"
+            )
+        )
+        self.assertTrue(
+            manifest["resources"][3]["url"].endswith(
+                "/price_history_v3/price_history_5452.parquet"
+            )
+        )
+
+    def test_manifest_defaults_to_base_and_bounds_cardinality(self):
+        cli = load_cli()
+        manifest = cli.asset_manifest(
+            include_base=False,
+            store_ids=[],
+            product_ids=[],
+        )
+        self.assertEqual(len(manifest["resources"]), 1)
+        self.assertEqual(manifest["resources"][0]["kind"], "base_catalogue")
+        with self.assertRaisesRegex(SystemExit, "at most 50"):
+            cli.asset_manifest(
+                include_base=False,
+                store_ids=list(range(1, 52)),
+                product_ids=[],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- add a lightweight `grocer-nz assets` command for base DuckDB, per-store current-price Parquet, and per-product history Parquet URLs
- construct and deduplicate URLs without network requests, downloads, DuckDB startup, or parsing
- preserve all existing parsed Grocer commands unchanged
- validate positive IDs and cap each response at 50 links
- document the MCP `resource_link` handoff path

## Why

Agents that want to download or analyse the raw public datasets should not have to make the skill fetch and parse large files first.

## Verification

- `python3 -m unittest discover -s tests -p 'test_*.py'` — 93 passed
- `python3 scripts/security_check.py`
- `python3 scripts/validate_repo_policy.py skills/grocer-nz`
- `python3 skills/grocer-nz/scripts/test_contract.py`
- canonical `run_skill.py` URL-only execution and MCP resource-link integration verified locally
