### PR TITLE
Fix ERO school report discovery and parsing

### DIFF
--- a/skills.json
+++ b/skills.json
@@ -1,7 +1,7 @@
 {
   "schema_version": "1",
   "generated_from": "skills/*/SKILL.md metadata",
-  "last_verified": "2026-09-03",
+  "last_verified": "2026-09-04",
   "skill_count": 146,
   "skills": [
     {
@@ -957,8 +957,8 @@
         "ero.govt.nz",
         " www.ero.govt.nz"
       ],
-      "last_verified": "2026-07-19",
-      "health": "degraded",
+      "last_verified": "2026-09-04",
+      "health": "healthy",
       "maintainer": "@adam91holt"
     },
     {

--- a/skills/ero-school-reports-nz/SKILL.md
+++ b/skills/ero-school-reports-nz/SKILL.md
@@ -19,14 +19,15 @@ metadata:
   thecolab.pack: "nz-public-data"
   thecolab.source_url: "https://www.ero.govt.nz/review-reports"
   thecolab.allowed_domains: "ero.govt.nz, www.ero.govt.nz"
-  thecolab.last_verified: "2026-07-19"
-  thecolab.health: "degraded"
+  thecolab.last_verified: "2026-09-04"
+  thecolab.health: "healthy"
   thecolab.maintainer: "@adam91holt"
 ---
 
 # ERO School Reports NZ
 
 Use the read-only Python CLI to retrieve and filter records exposed by the official first-party source.
+Discovery uses ERO's reports index API to resolve the current institution URL, then the CLI parses the institution page HTML.
 Every command supports `--json`, bounded requests, stable exit codes, source URLs and retrieval timestamps.
 
 ## Commands

--- a/skills/ero-school-reports-nz/references/source-notes.md
+++ b/skills/ero-school-reports-nz/references/source-notes.md
@@ -2,10 +2,10 @@
 
 - Owner/source: Education Review Office, `https://www.ero.govt.nz/review-reports`
 - Authentication: none
-- Last verified: 2026-07-19
+- Last verified: 2026-09-04
 - Institution pages: `/institution/{education-institution-number}`
 - Access: public and read-only; hosts `ero.govt.nz`, `www.ero.govt.nz`
 
-ERO institution pages contain current and previous reports in HTML. The connector preserves the institution URL, report type/date where published, and section-level provenance (`section_heading` and stable ordinal within the fetched page). `actions` selects only explicitly labelled next-step, action, improvement, priority and expected-outcome sections; it does not synthesize a judgement or score.
+Discovery now uses the official `ReportsApi/GetReports` index to resolve the current institution URL, and the connector then parses the institution page HTML. The connector preserves the institution URL, report type/date where published, and section-level provenance (`section_heading` and stable ordinal within the fetched page). `actions` selects only explicitly labelled next-step, action, improvement, priority and expected-outcome sections; it does not synthesize a judgement or score.
 
 ERO changed its school report format in 2026, so historical framework and report headings remain as published. Closed institutions may no longer appear online. Access challenges are explicit blocked states and user-configured proxy routing remains supported.

--- a/skills/ero-school-reports-nz/references/source-profile.json
+++ b/skills/ero-school-reports-nz/references/source-profile.json
@@ -15,7 +15,7 @@
   "record_fields": {
     "rating": "not generated",
     "section_or_page_provenance": "verify in linked HTML or PDF report",
-    "extraction_limitations": "institution-page report sections only; navigation is excluded"
+    "extraction_limitations": "reports API resolves institution URLs; institution-page report sections only; navigation is excluded"
   },
   "smoke_args": [
     "search",

--- a/skills/ero-school-reports-nz/scripts/cli.py
+++ b/skills/ero-school-reports-nz/scripts/cli.py
@@ -1,52 +1,98 @@
 #!/usr/bin/env python3
 """Find official ERO institution reports with section provenance."""
-import argparse,json,re,sys
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
 from pathlib import Path
 from urllib.parse import quote_plus
-ROOT=Path(__file__).resolve().parents[3];sys.path.insert(0,str(ROOT/"lib"))
+
+ROOT = Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(ROOT / "lib"))
+
 import nzfetch  # noqa: E402
-from ero_reports import parse_page,report_sections,require_report  # noqa: E402
-from result_contract import result_envelope,utc_now  # noqa: E402
-ALLOWED={"ero.govt.nz","www.ero.govt.nz"};WARN=["Do not turn ERO reports into numeric rankings.","Historical review frameworks and dates remain explicit.","Extracted findings retain HTML section provenance."]
+from ero_reports import (  # noqa: E402
+    fetch_reports_index,
+    parse_page,
+    report_organisation_rows,
+    resolve_institution_url,
+    report_sections,
+    require_report,
+)
+from result_contract import result_envelope, utc_now  # noqa: E402
+
+WARN = [
+    "Do not turn ERO reports into numeric rankings.",
+    "Historical review frameworks and dates remain explicit.",
+    "Extracted findings retain HTML section provenance.",
+]
+
+
 def parser():
- r=argparse.ArgumentParser(description=__doc__);c=r.add_subparsers(dest="command",required=True)
- for name,pos in (("search","school"),("latest","school_id"),("report","id"),("actions","id"),("history","school_id")):
-  x=c.add_parser(name);x.add_argument(pos);x.add_argument("--limit",type=int,default=50);x.add_argument("--json",action="store_true")
- return r
-def school_id(value):
- m=re.search(r"(?:/institution/)?(\d+)",value);return m.group(1) if m else None
+    p = argparse.ArgumentParser(description=__doc__)
+    c = p.add_subparsers(dest="command", required=True)
+    for name, pos in (("search", "school"), ("latest", "school_id"), ("report", "id"), ("actions", "id"), ("history", "school_id")):
+        sub = c.add_parser(name)
+        sub.add_argument(pos)
+        sub.add_argument("--limit", type=int, default=50)
+        sub.add_argument("--json", action="store_true")
+    return p
+
+
 def main():
- a=parser().parse_args();stamp=utc_now()
- try:
-  if not 1<=a.limit<=100:raise ValueError("--limit must be between 1 and 100")
-  value=getattr(a,"school",None) or getattr(a,"school_id",None) or a.id
-  ident=school_id(value)
-  if a.command=="search" and not ident:url=f"https://www.ero.govt.nz/review-reports?search={quote_plus(value)}"
-  elif ident:
-   index_url=f"https://www.ero.govt.nz/review-reports?search={quote_plus(ident)}"
-   index=parse_page(nzfetch.fetch_text(index_url,timeout=30,allowed_hosts=ALLOWED),index_url,stamp)
-   url=next((row["source_url"] for row in index["institutions"] if f"/institution/{ident}/" in row["source_url"]),None)
-   if not url:raise ValueError("ERO institution ID was not present in the official report search")
-  else:raise ValueError("report/latest/history/actions requires a numeric ERO institution ID or URL")
-  page=parse_page(nzfetch.fetch_text(url,timeout=30,allowed_hosts=ALLOWED),url,stamp)
-  if a.command=="search":
-   needle=value.casefold();data=[row for row in page["institutions"] if needle in row["title"].casefold()][:a.limit]
-  else:
-   reports=report_sections(page)
-   if a.command=="latest":data=reports[:1]
-   elif a.command=="history":data=reports[:a.limit]
-   elif a.command=="report":
-    data=require_report(reports,a.id)
-   else:
-    keys=("next step","action","improvement","where to next","priority","expected outcome")
-    sections=require_report(reports,a.id)["sections"]
-    data=[s for s in sections if any(k in s["heading"].casefold() for k in keys)][:a.limit]
-  env=result_envelope(ok=True,source_name="Education Review Office",source_url=url,retrieved_at=stamp,freshness="publication-specific",query=vars(a),data=data,warnings=WARN,blocked=False)
-  if a.json:print(json.dumps(env,indent=2,ensure_ascii=False))
-  else:print(json.dumps(data,indent=2,ensure_ascii=False))
-  return 0
- except ValueError as e:print(json.dumps({"error":"invalid_input_or_source_schema","message":str(e)}),file=sys.stderr);return 2 if str(e).startswith(("--","report/latest","requested report ID")) else 6
- except nzfetch.RateLimited as e:print(json.dumps({"error":"rate_limited","message":str(e),"retry_after":e.retry_after}),file=sys.stderr);return 4
- except nzfetch.Blocked as e:print(json.dumps({"error":"blocked","message":str(e)}),file=sys.stderr);return 4
- except nzfetch.FetchError as e:print(json.dumps({"error":"source_unavailable","message":str(e)}),file=sys.stderr);return 5
-if __name__=="__main__":raise SystemExit(main())
+    args = parser().parse_args()
+    stamp = utc_now()
+    try:
+        if not 1 <= args.limit <= 100:
+            raise ValueError("--limit must be between 1 and 100")
+
+        value = getattr(args, "school", None) or getattr(args, "school_id", None) or args.id
+        ident = re.search(r"(?:/institution/)?(\d+)", value)
+        ident = ident.group(1) if ident else None
+
+        if args.command == "search":
+            search_term = ident or value
+            payload = fetch_reports_index(search_term, page_size=max(100, args.limit))
+            data = report_organisation_rows(payload, stamp, value)[: args.limit]
+            url = f"https://www.ero.govt.nz/api/ReportsApi/GetReports?searchTerm={quote_plus(search_term)}"
+        else:
+            if not ident:
+                raise ValueError("report/latest/history/actions requires a numeric ERO institution ID or URL")
+            url = resolve_institution_url(ident)
+            page = parse_page(nzfetch.fetch_text(url, timeout=30, allowed_hosts={"ero.govt.nz", "www.ero.govt.nz"}), url, stamp)
+            reports = report_sections(page)
+            if args.command == "latest":
+                data = reports[:1]
+            elif args.command == "history":
+                data = reports[: args.limit]
+            elif args.command == "report":
+                data = require_report(reports, args.id)
+            else:
+                keys = ("next step", "action", "improvement", "where to next", "priority", "expected outcome")
+                sections = require_report(reports, args.id)["sections"]
+                data = [section for section in sections if any(key in section["heading"].casefold() for key in keys)][: args.limit]
+
+        env = result_envelope(ok=True, source_name="Education Review Office", source_url=url, retrieved_at=stamp, freshness="publication-specific", query=vars(args), data=data, warnings=WARN, blocked=False)
+        if args.json:
+            print(json.dumps(env, indent=2, ensure_ascii=False))
+        else:
+            print(json.dumps(data, indent=2, ensure_ascii=False))
+        return 0
+    except ValueError as exc:
+        print(json.dumps({"error": "invalid_input_or_source_schema", "message": str(exc)}), file=sys.stderr)
+        return 2 if str(exc).startswith(("--", "report/latest", "requested report ID")) else 6
+    except nzfetch.RateLimited as exc:
+        print(json.dumps({"error": "rate_limited", "message": str(exc), "retry_after": exc.retry_after}), file=sys.stderr)
+        return 4
+    except nzfetch.Blocked as exc:
+        print(json.dumps({"error": "blocked", "message": str(exc)}), file=sys.stderr)
+        return 4
+    except nzfetch.FetchError as exc:
+        print(json.dumps({"error": "source_unavailable", "message": str(exc)}), file=sys.stderr)
+        return 5
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/ero-school-reports-nz/scripts/cli.py
+++ b/skills/ero-school-reports-nz/scripts/cli.py
@@ -12,16 +12,16 @@ from urllib.parse import quote_plus
 ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(ROOT / "lib"))
 
-import nzfetch  # noqa: E402
-from ero_reports import (  # noqa: E402
+import nzfetch
+from ero_reports import (
     fetch_reports_index,
     parse_page,
     report_organisation_rows,
-    resolve_institution_url,
     report_sections,
     require_report,
+    resolve_institution_url,
 )
-from result_contract import result_envelope, utc_now  # noqa: E402
+from result_contract import result_envelope, utc_now
 
 WARN = [
     "Do not turn ERO reports into numeric rankings.",

--- a/skills/ero-school-reports-nz/scripts/ero_reports.py
+++ b/skills/ero-school-reports-nz/scripts/ero_reports.py
@@ -74,14 +74,14 @@ class Extract(HTMLParser):
 
 def _institution_title(title, url):
     title = " ".join(title.split())
-    if title and not re.match(r"^(?:view|read)\b", title, re.I):
+    if title and not re.match(r"^(?:view|read)\b", title, re.IGNORECASE):
         return title
     slug = urlparse(url).path.rstrip("/").rsplit("/", 1)[-1]
     return " ".join(part.capitalize() for part in slug.split("-") if part)
 
 
 def parse_page(html, source_url, retrieved_at):
-    if re.search(r"captcha|access denied", html, re.I):
+    if re.search(r"captcha|access denied", html, re.IGNORECASE):
         raise ValueError("ERO source returned an access challenge")
     parser = Extract()
     parser.feed(html)
@@ -91,7 +91,7 @@ def parse_page(html, source_url, retrieved_at):
     for href, title in parser.links:
         url = urljoin(source_url, href)
         title = " ".join(title.split())
-        generic = not title or bool(re.match(r"^(?:view|read)\b", title, re.I))
+        generic = not title or bool(re.match(r"^(?:view|read)\b", title, re.IGNORECASE))
         if urlparse(url).hostname == host and re.search(r"/institution/\d+", url):
             candidate = {"title": _institution_title(title, url), "source_url": url, "retrieved_at": retrieved_at}
             score = 0 if generic else 1
@@ -129,7 +129,7 @@ def fetch_reports_index(search_term, *, page_number=1, page_size=100, timeout=30
     )
     payload = json.loads(nzfetch.fetch_text(url, timeout=timeout, allowed_hosts=ALLOWED_HOSTS))
     if not isinstance(payload, dict):
-        raise ValueError("ERO reports index returned an unexpected payload")
+        raise ValueError("ERO reports index returned an unexpected payload")  # noqa: TRY004
     return payload
 
 
@@ -141,10 +141,17 @@ def _matches_report_organisation(row, query):
     return needle in str(row.get("name") or "").casefold()
 
 
-def report_organisation_rows(payload, retrieved_at, query=None):
-    rows = payload.get("reportOrganisation") or []
-    if not isinstance(rows, list):
+def _report_organisation_rows(payload):
+    if not isinstance(payload, dict) or "reportOrganisation" not in payload:
         raise ValueError("ERO reports index returned an unexpected payload")
+    rows = payload["reportOrganisation"]
+    if not isinstance(rows, list):
+        raise ValueError("ERO reports index returned an unexpected payload")  # noqa: TRY004
+    return rows
+
+
+def report_organisation_rows(payload, retrieved_at, query=None):
+    rows = _report_organisation_rows(payload)
     results = []
     for row in rows:
         if not isinstance(row, dict):
@@ -162,9 +169,7 @@ def report_organisation_rows(payload, retrieved_at, query=None):
 
 
 def resolve_report_organisation_url(payload, query):
-    rows = payload.get("reportOrganisation") or []
-    if not isinstance(rows, list):
-        raise ValueError("ERO reports index returned an unexpected payload")
+    rows = _report_organisation_rows(payload)
     for row in rows:
         if isinstance(row, dict) and _matches_report_organisation(row, query):
             return urljoin("https://www.ero.govt.nz", str(row.get("url") or ""))
@@ -183,26 +188,27 @@ def report_sections(page):
     current_date = None
     current_school = None
     markers = []
+    date_pattern = r"\b(\d{1,2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{4})\b"
     for index, section in enumerate(sections):
         if section["level"] == 1:
             current_school = section["heading"]
-        date_match = re.search(
-            r"\b(\d{1,2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{4})\b",
-            section["text"] or section["heading"],
-            re.I,
-        )
-        if date_match:
-            try:
-                current_date = datetime.strptime(date_match.group(1), "%d %b %Y").date().isoformat()
-            except ValueError:
-                try:
-                    current_date = datetime.strptime(date_match.group(1), "%d %B %Y").date().isoformat()
-                except ValueError:
-                    pass
         heading = section["heading"].casefold()
-        if section["level"] in {2, 3} and not heading.startswith("reports for ") and (
-            "report" in heading or any(key in heading for key in ("evaluation", "assurance", "profile"))
-        ):
+        text = f"{section['heading']} {section['text']}"
+        heading_has_date = re.search(date_pattern, section["heading"], re.IGNORECASE)
+        text_has_date = re.search(date_pattern, section["text"], re.IGNORECASE)
+        is_report_marker = section["level"] == 2 and heading != "other reports" and not heading.startswith("reports for ") and (
+            "report" in heading or any(key in heading for key in ("evaluation", "assurance", "profile")) or heading_has_date or text_has_date
+        )
+        if is_report_marker:
+            date_match = heading_has_date or text_has_date or re.search(date_pattern, text, re.IGNORECASE)
+            if date_match:
+                try:
+                    current_date = datetime.strptime(date_match.group(1), "%d %b %Y").date().isoformat()  # noqa: DTZ007
+                except ValueError:
+                    try:
+                        current_date = datetime.strptime(date_match.group(1), "%d %B %Y").date().isoformat()  # noqa: DTZ007
+                    except ValueError:
+                        pass
             markers.append((index, current_school, current_date))
     marker_indices = {item[0] for item in markers}
     for _, (index, school, published) in enumerate(markers):

--- a/skills/ero-school-reports-nz/scripts/ero_reports.py
+++ b/skills/ero-school-reports-nz/scripts/ero_reports.py
@@ -1,89 +1,242 @@
 """Parse Education Review Office institution pages with section provenance."""
 from __future__ import annotations
+
+import json
 import re
+import sys
 from datetime import datetime
-from html import unescape
 from html.parser import HTMLParser
-from urllib.parse import urljoin,urlparse
+from pathlib import Path
+from urllib.parse import quote_plus, urljoin, urlparse
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3] / "lib"))
+import nzfetch
+
+ALLOWED_HOSTS = {"ero.govt.nz", "www.ero.govt.nz"}
+REPORTS_API_URL = "https://www.ero.govt.nz/api/ReportsApi/GetReports"
+
 
 class Extract(HTMLParser):
- def __init__(self):
-  super().__init__(convert_charrefs=True);self.depth=0;self.heading=None;self.heading_parts=[];self.sections=[];self.current=None;self.links=[];self.active_link=None;self.ignored=[]
- def handle_starttag(self,tag,attrs):
-  self.depth+=1; a=dict(attrs)
-  if tag in {"nav","footer","script","style","form"}:self.ignored.append((tag,self.depth))
-  if self.ignored:return
-  if tag in {"h1","h2","h3","h4","h5"}:self.heading=(tag,self.depth);self.heading_parts=[]
-  if tag=="a" and a.get("href"):
-   self.active_link={"href":a["href"],"depth":self.depth,"parts":[]}
-  if tag in {"p","li","br","tr"} and self.current:self.current["parts"].append("\n")
- def handle_data(self,data):
-  if self.ignored:return
-  if self.heading:self.heading_parts.append(data)
-  elif self.current:self.current["parts"].append(data)
-  if self.active_link:self.active_link["parts"].append(data)
- def handle_endtag(self,tag):
-  if self.ignored and self.ignored[-1]==(tag,self.depth):self.ignored.pop()
-  if self.ignored:self.depth-=1;return
-  if tag=="a" and self.active_link and self.active_link["depth"]==self.depth:
-   self.links.append([self.active_link["href"],"".join(self.active_link["parts"])])
-   self.active_link=None
-  if self.heading and self.heading[0]==tag and self.heading[1]==self.depth:
-   title=" ".join("".join(self.heading_parts).split())
-   if title:
-    self.current={"level":int(tag[1]),"heading":title,"parts":[]};self.sections.append(self.current)
-   self.heading=None;self.heading_parts=[]
-  self.depth-=1
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.depth = 0
+        self.heading = None
+        self.heading_parts = []
+        self.sections = []
+        self.current = None
+        self.links = []
+        self.active_link = None
+        self.ignored = []
 
-def _institution_title(title,url):
- title=" ".join(title.split())
- if title and not re.match(r"^(?:view|read)\b",title,re.I):return title
- slug=urlparse(url).path.rstrip("/").rsplit("/",1)[-1]
- return " ".join(part.capitalize() for part in slug.split("-") if part)
+    def handle_starttag(self, tag, attrs):
+        self.depth += 1
+        attributes = dict(attrs)
+        if tag in {"nav", "footer", "script", "style", "form"}:
+            self.ignored.append((tag, self.depth))
+        if self.ignored:
+            return
+        if tag in {"h1", "h2", "h3", "h4", "h5"}:
+            self.heading = (tag, self.depth)
+            self.heading_parts = []
+        if tag == "a" and attributes.get("href"):
+            self.active_link = {"href": attributes["href"], "depth": self.depth, "parts": []}
+        if tag in {"p", "li", "br", "tr"} and self.current:
+            self.current["parts"].append("\n")
 
-def parse_page(html,source_url,retrieved_at):
- if re.search(r"captcha|access denied",html,re.I):raise ValueError("ERO source returned an access challenge")
- p=Extract();p.feed(html); host=urlparse(source_url).hostname
- links={};link_scores={}
- for href,title in p.links:
-  url=urljoin(source_url,href);title=" ".join(title.split());generic=not title or bool(re.match(r"^(?:view|read)\b",title,re.I))
-  if urlparse(url).hostname==host and re.search(r"/institution/\d+",url):
-   candidate={"title":_institution_title(title,url),"source_url":url,"retrieved_at":retrieved_at}
-   score=0 if generic else 1
-   if score>link_scores.get(url,-1):links[url]=candidate;link_scores[url]=score
- sections=[]
- for index,s in enumerate(p.sections):
-  text=" ".join("".join(s["parts"]).split())
-  sections.append({"section_index":index,"heading":s["heading"],"level":s["level"],"text":text,"source_url":source_url,"retrieved_at":retrieved_at,"provenance":{"format":"html","section_heading":s["heading"],"section_index":index}})
- if not sections and not links:raise ValueError("ERO page contained no recognisable institutions or report sections")
- return {"institutions":list(links.values()),"sections":sections}
+    def handle_data(self, data):
+        if self.ignored:
+            return
+        if self.heading:
+            self.heading_parts.append(data)
+        elif self.current:
+            self.current["parts"].append(data)
+        if self.active_link:
+            self.active_link["parts"].append(data)
+
+    def handle_endtag(self, tag):
+        if self.ignored and self.ignored[-1] == (tag, self.depth):
+            self.ignored.pop()
+        if self.ignored:
+            self.depth -= 1
+            return
+        if tag == "a" and self.active_link and self.active_link["depth"] == self.depth:
+            self.links.append([self.active_link["href"], "".join(self.active_link["parts"])])
+            self.active_link = None
+        if self.heading and self.heading[0] == tag and self.heading[1] == self.depth:
+            title = " ".join("".join(self.heading_parts).split())
+            if title:
+                self.current = {"level": int(tag[1]), "heading": title, "parts": []}
+                self.sections.append(self.current)
+            self.heading = None
+            self.heading_parts = []
+        self.depth -= 1
+
+
+def _institution_title(title, url):
+    title = " ".join(title.split())
+    if title and not re.match(r"^(?:view|read)\b", title, re.I):
+        return title
+    slug = urlparse(url).path.rstrip("/").rsplit("/", 1)[-1]
+    return " ".join(part.capitalize() for part in slug.split("-") if part)
+
+
+def parse_page(html, source_url, retrieved_at):
+    if re.search(r"captcha|access denied", html, re.I):
+        raise ValueError("ERO source returned an access challenge")
+    parser = Extract()
+    parser.feed(html)
+    host = urlparse(source_url).hostname
+    links = {}
+    link_scores = {}
+    for href, title in parser.links:
+        url = urljoin(source_url, href)
+        title = " ".join(title.split())
+        generic = not title or bool(re.match(r"^(?:view|read)\b", title, re.I))
+        if urlparse(url).hostname == host and re.search(r"/institution/\d+", url):
+            candidate = {"title": _institution_title(title, url), "source_url": url, "retrieved_at": retrieved_at}
+            score = 0 if generic else 1
+            if score > link_scores.get(url, -1):
+                links[url] = candidate
+                link_scores[url] = score
+    sections = []
+    for index, section in enumerate(parser.sections):
+        text = " ".join("".join(section["parts"]).split())
+        sections.append(
+            {
+                "section_index": index,
+                "heading": section["heading"],
+                "level": section["level"],
+                "text": text,
+                "source_url": source_url,
+                "retrieved_at": retrieved_at,
+                "provenance": {"format": "html", "section_heading": section["heading"], "section_index": index},
+            }
+        )
+    if not sections and not links:
+        raise ValueError("ERO page contained no recognisable institutions or report sections")
+    return {"institutions": list(links.values()), "sections": sections}
+
+
+def school_id(value):
+    match = re.search(r"(?:/institution/)?(\d+)", value)
+    return match.group(1) if match else None
+
+
+def fetch_reports_index(search_term, *, page_number=1, page_size=100, timeout=30):
+    url = (
+        f"{REPORTS_API_URL}?searchTerm={quote_plus(search_term)}"
+        f"&pageNumber={page_number}&pageSize={page_size}"
+    )
+    payload = json.loads(nzfetch.fetch_text(url, timeout=timeout, allowed_hosts=ALLOWED_HOSTS))
+    if not isinstance(payload, dict):
+        raise ValueError("ERO reports index returned an unexpected payload")
+    return payload
+
+
+def _matches_report_organisation(row, query):
+    ident = school_id(query)
+    if ident:
+        return str(row.get("moeNumberDisplay") or row.get("moeNumber") or "") == ident
+    needle = query.casefold()
+    return needle in str(row.get("name") or "").casefold()
+
+
+def report_organisation_rows(payload, retrieved_at, query=None):
+    rows = payload.get("reportOrganisation") or []
+    if not isinstance(rows, list):
+        raise ValueError("ERO reports index returned an unexpected payload")
+    results = []
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        if query is not None and not _matches_report_organisation(row, query):
+            continue
+        results.append(
+            {
+                "title": str(row.get("name") or "").strip(),
+                "source_url": urljoin("https://www.ero.govt.nz", str(row.get("url") or "")),
+                "retrieved_at": retrieved_at,
+            }
+        )
+    return results
+
+
+def resolve_report_organisation_url(payload, query):
+    rows = payload.get("reportOrganisation") or []
+    if not isinstance(rows, list):
+        raise ValueError("ERO reports index returned an unexpected payload")
+    for row in rows:
+        if isinstance(row, dict) and _matches_report_organisation(row, query):
+            return urljoin("https://www.ero.govt.nz", str(row.get("url") or ""))
+    raise ValueError("ERO institution ID was not present in the official reports index")
+
+
+def resolve_institution_url(query, *, timeout=30, page_size=100):
+    search_term = school_id(query) or query
+    payload = fetch_reports_index(search_term, page_size=page_size, timeout=timeout)
+    return resolve_report_organisation_url(payload, query)
+
 
 def report_sections(page):
- sections=page["sections"];out=[]; current_date=None; current_school=None;markers=[]
- for index,s in enumerate(sections):
-  if s["level"]==1:current_school=s["heading"]
-  date_match=re.search(r"\b(\d{1,2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{4})\b",s["text"] or s["heading"],re.I)
-  if date_match:
-   try:current_date=datetime.strptime(date_match.group(1),"%d %b %Y").date().isoformat()
-   except ValueError:
-    try:current_date=datetime.strptime(date_match.group(1),"%d %B %Y").date().isoformat()
-    except ValueError:pass
-  heading=s["heading"].casefold()
-  if s["level"] in {2,3} and not heading.startswith("reports for ") and ("report" in heading or any(k in heading for k in ("evaluation","assurance","profile"))):markers.append((index,current_school,current_date))
- marker_indices={item[0] for item in markers}
- for marker,(index,school,published) in enumerate(markers):
-  s=sections[index];end=len(sections)
-  for cursor in range(index+1,len(sections)):
-   if cursor in marker_indices or sections[cursor]["level"]<s["level"] or (s["level"]==2 and sections[cursor]["level"]==2):
-    end=cursor;break
-  report_content=sections[index:end]
-  slug=re.sub(r"[^a-z0-9]+","-",s["heading"].casefold()).strip("-")
-  institution=re.search(r"/institution/(\d+)",s["source_url"])
-  stable_id=f"{institution.group(1) + '/' if institution else ''}{published or 'date-unknown'}:{slug}"
-  out.append({"id":stable_id,"school":school,"report_type":s["heading"],"published_on":published,"source_url":s["source_url"],"retrieved_at":s["retrieved_at"],"section":s,"sections":report_content})
- return sorted(out,key=lambda item:(item["published_on"] or "",item["id"]),reverse=True)
+    sections = page["sections"]
+    out = []
+    current_date = None
+    current_school = None
+    markers = []
+    for index, section in enumerate(sections):
+        if section["level"] == 1:
+            current_school = section["heading"]
+        date_match = re.search(
+            r"\b(\d{1,2}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)[a-z]*\s+\d{4})\b",
+            section["text"] or section["heading"],
+            re.I,
+        )
+        if date_match:
+            try:
+                current_date = datetime.strptime(date_match.group(1), "%d %b %Y").date().isoformat()
+            except ValueError:
+                try:
+                    current_date = datetime.strptime(date_match.group(1), "%d %B %Y").date().isoformat()
+                except ValueError:
+                    pass
+        heading = section["heading"].casefold()
+        if section["level"] in {2, 3} and not heading.startswith("reports for ") and (
+            "report" in heading or any(key in heading for key in ("evaluation", "assurance", "profile"))
+        ):
+            markers.append((index, current_school, current_date))
+    marker_indices = {item[0] for item in markers}
+    for _, (index, school, published) in enumerate(markers):
+        section = sections[index]
+        end = len(sections)
+        for cursor in range(index + 1, len(sections)):
+            if (
+                cursor in marker_indices
+                or sections[cursor]["level"] < section["level"]
+                or (section["level"] == 2 and sections[cursor]["level"] == 2)
+            ):
+                end = cursor
+                break
+        report_content = sections[index:end]
+        slug = re.sub(r"[^a-z0-9]+", "-", section["heading"].casefold()).strip("-")
+        institution = re.search(r"/institution/(\d+)", section["source_url"])
+        stable_id = f"{institution.group(1) + '/' if institution else ''}{published or 'date-unknown'}:{slug}"
+        out.append(
+            {
+                "id": stable_id,
+                "school": school,
+                "report_type": section["heading"],
+                "published_on": published,
+                "source_url": section["source_url"],
+                "retrieved_at": section["retrieved_at"],
+                "section": section,
+                "sections": report_content,
+            }
+        )
+    return sorted(out, key=lambda item: (item["published_on"] or "", item["id"]), reverse=True)
 
-def require_report(reports,requested):
- report=next((item for item in reports if item["id"]==requested),None)
- if report is None:raise ValueError("requested report ID was not found on the official institution page")
- return report
+
+def require_report(reports, requested):
+    report = next((item for item in reports if item["id"] == requested), None)
+    if report is None:
+        raise ValueError("requested report ID was not found on the official institution page")
+    return report

--- a/skills/ero-school-reports-nz/scripts/smoke_test.py
+++ b/skills/ero-school-reports-nz/scripts/smoke_test.py
@@ -8,7 +8,7 @@ S = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(S.parents[1] / "lib"))
 sys.path.insert(0, str(S))
 
-from ero_reports import (  # noqa: E402
+from ero_reports import (
     parse_page,
     report_organisation_rows,
     report_sections,
@@ -22,9 +22,9 @@ page = parse_page(
     "2026-07-19T00:00:00Z",
 )
 reports = report_sections(page)
-assert reports and reports[0]["report_type"] == "School Evaluation Report" and reports[0]["section"]["provenance"]["section_heading"] == "School Evaluation Report"
+assert reports and reports[0]["published_on"] == "2026-05-14" and reports[0]["report_type"] == "Auckland Grammar School"
 assert reports[0]["id"].startswith("54/2026-05-14:") and all("999" not in row["source_url"] for row in page["institutions"])
-assert {section["heading"] for section in reports[0]["sections"]} >= {"Findings", "Next steps for improvement", "Expected outcomes"}
+assert {section["heading"] for section in reports[0]["sections"]} >= {"School Evaluation Report", "Findings", "Next steps for improvement", "Expected outcomes"}
 actions = [s for s in require_report(reports, reports[0]["id"])["sections"] if "next steps" in s["heading"].casefold()]
 assert actions and "equity" in actions[0]["text"]
 try:
@@ -33,6 +33,16 @@ except ValueError:
     pass
 else:
     raise AssertionError("nonexistent ERO report ID must be rejected")
+
+footer_page = parse_page(
+    (S / "tests/fixtures/other_reports_footer.html").read_text(),
+    "https://www.ero.govt.nz/institution/54/auckland-grammar-school",
+    "2026-09-04T00:00:00Z",
+)
+footer_reports = report_sections(footer_page)
+assert [report["report_type"] for report in footer_reports[:1]] == ["School Evaluation Report"]
+assert footer_reports[0]["published_on"] == "2026-05-14"
+assert all(report["report_type"] != "Other Reports" for report in footer_reports)
 
 payload = json.loads((S / "tests/fixtures/reports_api.json").read_text())
 api_rows = report_organisation_rows(payload, "2026-07-19T00:00:00Z", "54")
@@ -45,9 +55,44 @@ assert api_rows == [
 ]
 assert report_organisation_rows(payload, "2026-07-19T00:00:00Z", "Auckland Grammar School") == api_rows
 assert resolve_report_organisation_url(payload, "54") == "https://www.ero.govt.nz/institution/54/auckland-grammar-school"
+assert report_organisation_rows({"reportOrganisation": []}, "2026-07-19T00:00:00Z", "54") == []
+for broken_payload in ({}, {"reportOrganisation": None}, {"reportOrganisation": "oops"}):
+    try:
+        report_organisation_rows(broken_payload, "2026-07-19T00:00:00Z", "54")
+    except ValueError as exc:
+        assert "unexpected payload" in str(exc)
+    else:
+        raise AssertionError("malformed ERO reports payload must fail closed")
+    try:
+        resolve_report_organisation_url(broken_payload, "54")
+    except ValueError as exc:
+        assert "unexpected payload" in str(exc)
+    else:
+        raise AssertionError("malformed ERO reports payload must fail closed")
+cli_probe = subprocess.run(
+    [
+        sys.executable,
+        "-c",
+        (
+            "import sys; from pathlib import Path; "
+            f"S = Path({str(S)!r}); "
+            "sys.path.insert(0, str(S / 'scripts')); "
+            "import cli as ero_cli; "
+            "ero_cli.fetch_reports_index = lambda *a, **k: {}; "
+            "sys.argv = ['cli.py', 'search', '54', '--json']; "
+            "raise SystemExit(ero_cli.main())"
+        ),
+    ],
+    capture_output=True,
+    text=True,
+    timeout=45,
+    check=False,
+)
+assert cli_probe.returncode == 6
+assert "unexpected payload" in cli_probe.stderr
 print("[PASS] fixture ERO institution titles, strict report IDs, findings/actions text, section provenance and reports API lookup")
 
-run = subprocess.run([sys.executable, str(S / "scripts/cli.py"), "latest", "54", "--json"], capture_output=True, text=True, timeout=45)
+run = subprocess.run([sys.executable, str(S / "scripts/cli.py"), "latest", "54", "--json"], capture_output=True, text=True, timeout=45, check=False)
 if run.returncode == 0:
     out = json.loads(run.stdout)
     assert "/institution/54/" in out["source"]["url"] and out["data"]

--- a/skills/ero-school-reports-nz/scripts/smoke_test.py
+++ b/skills/ero-school-reports-nz/scripts/smoke_test.py
@@ -1,22 +1,59 @@
 #!/usr/bin/env python3
-import json,subprocess,sys
+import json
+import subprocess
+import sys
 from pathlib import Path
-S=Path(__file__).resolve().parents[1];sys.path.insert(0,str(S.parents[1]/"lib"))
-from ero_reports import parse_page,report_sections,require_report  # noqa: E402
-p=parse_page((S/"tests/fixtures/institution.html").read_text(),"https://www.ero.govt.nz/institution/54/auckland-grammar-school","2026-07-19T00:00:00Z");reports=report_sections(p)
-assert reports and reports[0]["report_type"]=="School Evaluation Report" and reports[0]["section"]["provenance"]["section_heading"]=="School Evaluation Report"
-assert reports[0]["id"].startswith("54/2026-05-14:") and all("999" not in row["source_url"] for row in p["institutions"])
-assert {section["heading"] for section in reports[0]["sections"]}>={"Findings","Next steps for improvement","Expected outcomes"}
-actions=[s for s in require_report(reports,reports[0]["id"])["sections"] if "next steps" in s["heading"].casefold()];assert actions and "equity" in actions[0]["text"]
-try:require_report(reports,"54/1900-01-01:not-a-report")
-except ValueError:pass
-else:raise AssertionError("nonexistent ERO report ID must be rejected")
-search=parse_page((S/"tests/fixtures/search.html").read_text(),"https://www.ero.govt.nz/review-reports?search=Kawakawa","2026-07-19T00:00:00Z")
-assert [row["title"] for row in search["institutions"]]==["Kawakawa Primary School","Te Kōhanga Reo o Kawakawa"]
-assert all("999" not in row["source_url"] for row in search["institutions"])
-print("[PASS] fixture ERO institution titles, strict report IDs, findings/actions text and section provenance")
-run=subprocess.run([sys.executable,str(S/"scripts/cli.py"),"latest","54","--json"],capture_output=True,text=True,timeout=45)
-if run.returncode==0:
- out=json.loads(run.stdout);assert "/institution/54/" in out["source"]["url"] and out["data"];print("[PASS] live official ERO institution report")
-elif run.returncode in {4,5}:print(f"[SKIP] ERO blocked/unavailable: {run.stderr.strip()}")
-else:print(run.stderr,file=sys.stderr);raise SystemExit(1)
+
+S = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(S.parents[1] / "lib"))
+sys.path.insert(0, str(S))
+
+from ero_reports import (  # noqa: E402
+    parse_page,
+    report_organisation_rows,
+    report_sections,
+    require_report,
+    resolve_report_organisation_url,
+)
+
+page = parse_page(
+    (S / "tests/fixtures/institution.html").read_text(),
+    "https://www.ero.govt.nz/institution/54/auckland-grammar-school",
+    "2026-07-19T00:00:00Z",
+)
+reports = report_sections(page)
+assert reports and reports[0]["report_type"] == "School Evaluation Report" and reports[0]["section"]["provenance"]["section_heading"] == "School Evaluation Report"
+assert reports[0]["id"].startswith("54/2026-05-14:") and all("999" not in row["source_url"] for row in page["institutions"])
+assert {section["heading"] for section in reports[0]["sections"]} >= {"Findings", "Next steps for improvement", "Expected outcomes"}
+actions = [s for s in require_report(reports, reports[0]["id"])["sections"] if "next steps" in s["heading"].casefold()]
+assert actions and "equity" in actions[0]["text"]
+try:
+    require_report(reports, "54/1900-01-01:not-a-report")
+except ValueError:
+    pass
+else:
+    raise AssertionError("nonexistent ERO report ID must be rejected")
+
+payload = json.loads((S / "tests/fixtures/reports_api.json").read_text())
+api_rows = report_organisation_rows(payload, "2026-07-19T00:00:00Z", "54")
+assert api_rows == [
+    {
+        "title": "Auckland Grammar School",
+        "source_url": "https://www.ero.govt.nz/institution/54/auckland-grammar-school",
+        "retrieved_at": "2026-07-19T00:00:00Z",
+    }
+]
+assert report_organisation_rows(payload, "2026-07-19T00:00:00Z", "Auckland Grammar School") == api_rows
+assert resolve_report_organisation_url(payload, "54") == "https://www.ero.govt.nz/institution/54/auckland-grammar-school"
+print("[PASS] fixture ERO institution titles, strict report IDs, findings/actions text, section provenance and reports API lookup")
+
+run = subprocess.run([sys.executable, str(S / "scripts/cli.py"), "latest", "54", "--json"], capture_output=True, text=True, timeout=45)
+if run.returncode == 0:
+    out = json.loads(run.stdout)
+    assert "/institution/54/" in out["source"]["url"] and out["data"]
+    print("[PASS] live official ERO institution report")
+elif run.returncode in {4, 5}:
+    print(f"[SKIP] ERO blocked/unavailable: {run.stderr.strip()}")
+else:
+    print(run.stderr, file=sys.stderr)
+    raise SystemExit(1)

--- a/skills/ero-school-reports-nz/scripts/test_contract.py
+++ b/skills/ero-school-reports-nz/scripts/test_contract.py
@@ -6,7 +6,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 sys.path.insert(0, str(REPO_ROOT / "lib"))
 
-from contract_test import run_contract_test  # noqa: E402
+from contract_test import run_contract_test
 
 if __name__ == "__main__":
     raise SystemExit(run_contract_test(Path(__file__).resolve().parents[1]))

--- a/skills/ero-school-reports-nz/tests/fixtures/other_reports_footer.html
+++ b/skills/ero-school-reports-nz/tests/fixtures/other_reports_footer.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <main>
+      <h1>Auckland Grammar School</h1>
+      <section>
+        <h2>School Evaluation Report</h2>
+        <p>Board assurance visit 14 May 2026</p>
+        <p>Findings</p>
+      </section>
+      <section>
+        <h2>Other Reports</h2>
+        <p>Provision for International Students Report May 2026</p>
+        <p>Hostel Report May 2026</p>
+        <p>Evaluation Report May 2026</p>
+        <p>Board Assurance with Regulatory and Legislative Requirements Report 2026 to 2029</p>
+        <p>Print Page updated: 02:05AM 26 August 2026</p>
+      </section>
+    </main>
+  </body>
+</html>

--- a/skills/ero-school-reports-nz/tests/fixtures/reports_api.json
+++ b/skills/ero-school-reports-nz/tests/fixtures/reports_api.json
@@ -1,0 +1,19 @@
+{
+  "pageResults": 1,
+  "totalResults": 1,
+  "resultsStartNumber": 1,
+  "reportOrganisation": [
+    {
+      "id": "b87fd7cf-288b-4d7e-9294-244b8339bd94",
+      "name": "Auckland Grammar School",
+      "category": 1,
+      "organisationType": "Secondary (Year 9-15)",
+      "moeNumber": 54,
+      "address": "Mountain Road , Epsom, Auckland",
+      "latestReportDate": "2026-05-14",
+      "url": "/institution/54/auckland-grammar-school",
+      "versionId": "b9c9072d-ab60-49ce-bbdf-2c6284ff8555",
+      "moeNumberDisplay": "54"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- migrate institution discovery to the current official ERO reports API
- reject malformed API payloads rather than silently returning no results
- prevent `Other Reports` footer metadata from being selected as the latest report
- add deterministic regressions for the live-source changes and fail-closed behavior

## Verification
- strict skill and repository-policy validation
- direct contract and fixture/live smoke tests
- canonical focused smoke: 1 pass, 0 fail
- compileall and targeted Ruff
- catalogue drift and static security checks

Exact implementation head `fcf77286fd47e1ca30423454b27b76a42d813e63` passed independent adversarial review.