### PR TITLE
legislation-nz: resolve schedules and schedule clauses in get-section

### DIFF
--- a/skills/legislation-nz/SKILL.md
+++ b/skills/legislation-nz/SKILL.md
@@ -50,6 +50,8 @@ Do not use this for:
 python3 skills/legislation-nz/scripts/cli.py search "Grocery Industry" --type act --json
 python3 skills/legislation-nz/scripts/cli.py get-act 2003/52 --json
 python3 skills/legislation-nz/scripts/cli.py get-section 2003/52 9C --json
+python3 skills/legislation-nz/scripts/cli.py get-section 1993/105 "Schedule 7" --json
+python3 skills/legislation-nz/scripts/cli.py get-section 1993/105 "Schedule 7 clause 1" --json
 python3 skills/legislation-nz/scripts/cli.py versions 2003/52 --json
 python3 skills/legislation-nz/scripts/cli.py updates --since 2026-07-01 --json
 python3 skills/legislation-nz/scripts/cli.py list-bills --json
@@ -67,6 +69,8 @@ Commands:
 - `sources` or `datasets` for source metadata and caveats
 
 `ACT_ID` can be a `year/number` pair such as `2003/52`, a work/version id such as `act_public_2003_52`, or a canonical legislation.govt.nz URL.
+
+`SECTION` accepts a body section label (`9C`), a schedule (`Schedule 7`, `sch 7`, `sched 7`), or a clause within a schedule (`Schedule 7 clause 1`, `sch 7 cl 1`). Schedules live in a separate XML tree from body sections, so they must be asked for by name. Bare numeric labels always resolve to the body section first — `get-section 1993/105 7` returns s7 "Control defined", not Schedule 7. Each result carries a `kind` field of `section`, `schedule`, or `schedule-clause`; schedule clauses also carry a `schedule` field. Check `kind` before quoting a result as a section.
 
 ## Source Behaviour
 

--- a/skills/legislation-nz/scripts/cli.py
+++ b/skills/legislation-nz/scripts/cli.py
@@ -347,31 +347,114 @@ def section_rows(root: ET.Element, *, limit: int | None = None) -> tuple[list[di
     return rows, total
 
 
-def find_section(root: ET.Element, section: str) -> ET.Element | None:
-    wanted = re.sub(r"\s+", "", section).lower()
-    for prov in root.findall(".//prov"):
-        label = child_text(prov, "label")
-        if label and re.sub(r"\s+", "", label).lower() == wanted:
-            return prov
+SCHEDULE_QUERY_RE = re.compile(
+    r"^(?:schedule|sched|sch)\.?\s*([0-9A-Za-z]+)"
+    r"(?:\s*(?:clause|cl|c)\.?\s*([0-9A-Za-z()]+))?$",
+    flags=re.I,
+)
+
+
+def _norm_label(value: str | None) -> str | None:
+    if not value:
+        return None
+    return re.sub(r"\s+", "", value).lower()
+
+
+def find_schedule(root: ET.Element, wanted: str) -> ET.Element | None:
+    for sched in root.iter("schedule"):
+        if _norm_label(child_text(sched, "label")) == wanted:
+            return sched
     return None
 
 
-def section_payload(prov: ET.Element, act: dict[str, Any]) -> dict[str, Any]:
+def find_section(root: ET.Element, section: str) -> ET.Element | None:
+    """Resolve a section, a schedule, or a clause within a schedule.
+
+    Schedules live in a separate <schedule> tree, not under <prov>, so a bare
+    ``.//prov`` walk silently misses them (e.g. Schedule 7 of the Companies
+    Act 1993). Explicit "Schedule N" queries resolve against schedules only;
+    bare labels prefer body sections, then fall back to schedules.
+    """
+    raw = section.strip()
+    wanted = _norm_label(raw)
+    if not wanted:
+        return None
+
+    sched_match = SCHEDULE_QUERY_RE.match(raw)
+    if sched_match:
+        sched = find_schedule(root, _norm_label(sched_match.group(1)))
+        if sched is None:
+            return None
+        clause = _norm_label(sched_match.group(2))
+        if not clause:
+            return sched
+        for prov in sched.iter("prov"):
+            if _norm_label(child_text(prov, "label")) == clause:
+                return prov
+        return None
+
+    # Body sections take precedence over identically-labelled schedule clauses.
+    schedule_provs = {id(prov) for sched in root.iter("schedule") for prov in sched.iter("prov")}
+    fallback = None
+    for prov in root.findall(".//prov"):
+        if _norm_label(child_text(prov, "label")) != wanted:
+            continue
+        if id(prov) not in schedule_provs:
+            return prov
+        fallback = fallback or prov
+    return fallback or find_schedule(root, wanted)
+
+
+def owning_schedule(root: ET.Element | None, prov: ET.Element) -> ET.Element | None:
+    """Return the <schedule> containing ``prov``, if any."""
+    if root is None or prov.tag == "schedule":
+        return None
+    for sched in root.iter("schedule"):
+        for child in sched.iter("prov"):
+            if child is prov:
+                return sched
+    return None
+
+
+def section_payload(
+    prov: ET.Element, act: dict[str, Any], root: ET.Element | None = None
+) -> dict[str, Any]:
     label = child_text(prov, "label")
     heading = child_text(prov, "heading")
-    body = prov.find("prov.body")
+    schedule_label = None
+    if prov.tag == "schedule":
+        body = prov.find("schedule.provisions")
+        kind = "schedule"
+        schedule_label = f"Schedule {label}" if label else "Schedule"
+        label = schedule_label
+    else:
+        body = prov.find("prov.body")
+        sched = owning_schedule(root, prov)
+        if sched is not None:
+            # A clause inside a schedule is NOT a body section; labelling it
+            # "section" is how duplicate labels end up misattributed.
+            kind = "schedule-clause"
+            sched_label = child_text(sched, "label")
+            schedule_label = f"Schedule {sched_label}" if sched_label else "Schedule"
+            label = f"{schedule_label} clause {label}" if label else schedule_label
+        else:
+            kind = "section"
     text = element_text(body if body is not None else prov)
     history = [element_text(note) for note in prov.findall(".//history-note")]
     xml_id = prov.attrib.get("id")
     source_url = act["source_url"] + (f"#{xml_id}" if xml_id else "")
-    return {
+    payload = {
         "label": label,
+        "kind": kind,
         "heading": heading,
         "xml_id": xml_id,
         "text": text,
         "history_notes": history,
         "source_url": source_url,
     }
+    if kind == "schedule-clause":
+        payload["schedule"] = schedule_label
+    return payload
 
 
 def parse_total(html_text: str) -> int | None:
@@ -717,7 +800,7 @@ def cmd_get_section(args: argparse.Namespace) -> None:
             "retrieved_at": now_iso(),
             "source": "legislation.govt.nz XML format",
             "act": act,
-            "section": section_payload(prov, act),
+            "section": section_payload(prov, act, root),
         },
         args.json,
     )


### PR DESCRIPTION
## Problem

`get-section` only walked `.//prov` nodes. In the official legislation.govt.nz XML, schedules live in a completely separate `<schedule>` tree, so they were invisible to the lookup:

```bash
$ python3 skills/legislation-nz/scripts/cli.py get-section 1993/105 "Schedule 7" --json
status: error / not_found
```

The Companies Act 1993 has 16 schedules the parser never looked at. Schedule 7 ("Preferential claims") is one of the most-cited parts of the Act, so this is a real gap for anyone doing insolvency work.

## Change

- `find_schedule()` plus a query parser for `Schedule N [clause M]`, with `schedule` / `sched` / `sch` and `clause` / `cl` / `c` aliases.
- Clause-level drill-down inside a schedule.
- Every result now carries a `kind` field: `section` | `schedule` | `schedule-clause`. Schedule clauses also carry a `schedule` field and a fully qualified label, so a clause can never be quoted back as if it were a body section.
- SKILL.md documents schedule lookups and the `kind` field.

Explicit `Schedule N` queries resolve against schedules only. Bare labels prefer body sections and fall back to schedules, so existing callers are unaffected.

## Verified against Companies Act 1993

```
[Schedule 7]           ok | schedule        | Schedule 7          | Preferential claims                          | 18136 chars | 28 history notes
[sch 7]                ok | schedule        | Schedule 7          | Preferential claims                          | 18136 chars | 28 history notes
[Schedule 7 clause 1]  ok | schedule-clause | Schedule 7 clause 1 | Priority of payments to preferential credi.. |  4979 chars | 11 history notes
[7]                    ok | section         | 7                   | Control defined                              |   932 chars |  0 history notes
[Schedule 99]          error / not_found
```

The `[7]` line is the regression that matters: a bare `7` still returns s7 "Control defined", not Schedule 7.

Also re-checked the pre-existing path — CCCFA 2003/52 s9C still returns 8,687 chars with amendment history unchanged.

## Tests

- `skills/legislation-nz/scripts/smoke_test.py` — 6 pass, 1 skip (upstream bot-challenge on `updates`, pre-existing and unrelated)
- `skills/legislation-nz/scripts/test_contract.py` — pass, 5 fixture assertions
- `scripts/security_check.py` — pass

## Known issue NOT fixed here

`get-act --all-sections` still conflates schedule clauses with body sections: 844 entries for the Companies Act, of which 146 are schedule clauses in disguise, producing 74 duplicate labels (label `7` appears eight times with unrelated text). That path is untouched by this PR — filed separately as #233.

Please do not merge this thinking schedules are fully solved. Single-section retrieval is fixed; the bulk index is not.

Note: raised from a fork because this account has read-only access to the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
